### PR TITLE
[#554] improvement(CI): improve Hadoop access permission

### DIFF
--- a/dev/docker/README.md
+++ b/dev/docker/README.md
@@ -79,6 +79,10 @@ docker run --rm -d -p 9000:9000 -p 9083:9083 -p 10000:10000 -p 10002:10002 -p 50
   - `22` SSH
   - `8088` YARN Service
 
+### 0.1.7
+- Download Mysql JDBC driver before building the Docker image
+- Set `hdfs` as HDFS superuser group
+
 ## Gravitino CI Trino
 
 ### Container startup commands

--- a/dev/docker/build-docker.sh
+++ b/dev/docker/build-docker.sh
@@ -64,7 +64,7 @@ fi
 
 if [[ "${component_type}" == "hive" ]]; then
   . ${script_dir}/hive/hive-dependency.sh
-  build_args="--build-arg HADOOP_PACKAGE_NAME=${HADOOP_PACKAGE_NAME} --build-arg HIVE_PACKAGE_NAME=${HIVE_PACKAGE_NAME}"
+  build_args="--build-arg HADOOP_PACKAGE_NAME=${HADOOP_PACKAGE_NAME} --build-arg HIVE_PACKAGE_NAME=${HIVE_PACKAGE_NAME} --build-arg JDBC_DIVER_PACKAGE_NAME=${JDBC_DIVER_PACKAGE_NAME}"
 elif [ "${component_type}" == "trino" ]; then
   true # Placeholder, do nothing
 elif [ "${component_type}" == "gravitino" ]; then

--- a/dev/docker/hive/Dockerfile
+++ b/dev/docker/hive/Dockerfile
@@ -8,6 +8,7 @@ LABEL maintainer="support@datastrato.com"
 
 ARG HADOOP_PACKAGE_NAME
 ARG HIVE_PACKAGE_NAME
+ARG JDBC_DIVER_PACKAGE_NAME
 
 WORKDIR /
 
@@ -129,10 +130,7 @@ RUN sed -i "s/.*bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/mysql.conf.d/
 
 ################################################################################
 # add mysql jdbc driver
-RUN wget https://downloads.mysql.com/archives/get/p/3/file/mysql-connector-java-8.0.15.tar.gz
-RUN tar -xzf mysql-connector-java-8.0.15.tar.gz
-RUN cp mysql-connector-java-8.0.15/mysql-connector-java-8.0.15.jar ${HIVE_HOME}/lib
-RUN rm -rf mysql-connector-java-8.0.15 mysql-connector-java-8.0.15.tar.gz
+RUN tar -xz -C ${HIVE_HOME}/lib --strip-components 1 -f /tmp/packages/${JDBC_DIVER_PACKAGE_NAME}
 
 ################################################################################
 # add users and groups

--- a/dev/docker/hive/hdfs-site.xml
+++ b/dev/docker/hive/hdfs-site.xml
@@ -13,4 +13,9 @@
     <name>dfs.datanode.address</name>
     <value>0.0.0.0:50010</value>
   </property>
+
+  <property>
+    <name>dfs.permissions.superusergroup</name>
+    <value>hdfs</value>
+  </property>
 </configuration>

--- a/dev/docker/hive/hive-dependency.sh
+++ b/dev/docker/hive/hive-dependency.sh
@@ -10,12 +10,16 @@ hive_dir="$(cd "${hive_dir}">/dev/null; pwd)"
 # Environment variables definition
 HADOOP_VERSION="2.7.3"
 HIVE_VERSION="2.3.9"
+MYSQL_JDBC_DRIVER_VERSION="8.0.15"
 
 HADOOP_PACKAGE_NAME="hadoop-${HADOOP_VERSION}.tar.gz" # Must export this variable for Dockerfile
 HADOOP_DOWNLOAD_URL="http://archive.apache.org/dist/hadoop/core/hadoop-${HADOOP_VERSION}/${HADOOP_PACKAGE_NAME}"
 
 HIVE_PACKAGE_NAME="apache-hive-${HIVE_VERSION}-bin.tar.gz" # Must export this variable for Dockerfile
 HIVE_DOWNLOAD_URL="https://archive.apache.org/dist/hive/hive-${HIVE_VERSION}/${HIVE_PACKAGE_NAME}"
+
+JDBC_DIVER_PACKAGE_NAME="mysql-connector-java-${MYSQL_JDBC_DRIVER_VERSION}.tar.gz" # Must export this variable for Dockerfile
+JDBC_DIVER_DOWNLOAD_URL="https://downloads.mysql.com/archives/get/p/3/file/${JDBC_DIVER_PACKAGE_NAME}"
 
 # Prepare download packages
 if [[ ! -d "${hive_dir}/packages" ]]; then
@@ -28,4 +32,8 @@ fi
 
 if [ ! -f "${hive_dir}/packages/${HIVE_PACKAGE_NAME}" ]; then
   curl -s -o "${hive_dir}/packages/${HIVE_PACKAGE_NAME}" ${HIVE_DOWNLOAD_URL}
+fi
+
+if [ ! -f "${hive_dir}/packages/${JDBC_DIVER_PACKAGE_NAME}" ]; then
+  curl -L -s -o "${hive_dir}/packages/${JDBC_DIVER_PACKAGE_NAME}" ${JDBC_DIVER_DOWNLOAD_URL}
 fi

--- a/dev/docker/hive/start.sh
+++ b/dev/docker/hive/start.sh
@@ -12,16 +12,6 @@ ssh-keyscan 0.0.0.0 >> /root/.ssh/known_hosts
 # start hdfs
 ${HADOOP_HOME}/sbin/start-dfs.sh
 
-${HADOOP_HOME}/bin/hdfs dfs -mkdir /tmp
-${HADOOP_HOME}/bin/hdfs dfs -chmod 1777 /tmp
-${HADOOP_HOME}/bin/hdfs dfs -mkdir -p /user/hive/warehouse
-${HADOOP_HOME}/bin/hdfs dfs -chown -R hive:hive /user/hive
-${HADOOP_HOME}/bin/hdfs dfs -chmod -R 775 /user/hive
-${HADOOP_HOME}/bin/hdfs dfs -mkdir -p /user/datastrato
-${HADOOP_HOME}/bin/hdfs dfs -chown -R datastrato:hdfs /user/datastrato
-${HADOOP_HOME}/bin/hdfs dfs -chmod 755 /user/datastrato
-${HADOOP_HOME}/bin/hdfs dfs -chmod -R 777 /user/hive/tmp
-
 # start mysql and create databases/users for hive
 chown -R mysql:mysql /var/lib/mysql
 usermod -d /var/lib/mysql/ mysql

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -259,14 +259,13 @@ tasks.test {
 
       // Default use MiniGravitino to run integration tests
       environment("GRAVITINO_ROOT_DIR", rootDir.path)
-      // TODO: use hive user instead after we fix the permission issue #554
-      environment("HADOOP_USER_NAME", "root")
+      environment("HADOOP_USER_NAME", "datastrato")
       environment("HADOOP_HOME", "/tmp")
       environment("PROJECT_VERSION", version)
       environment("TRINO_CONF_DIR", buildDir.path + "/trino-conf")
 
       // Gravitino CI Docker image
-      environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "datastrato/gravitino-ci-hive:0.1.6")
+      environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "datastrato/gravitino-ci-hive:0.1.7")
       environment("GRAVITINO_CI_TRINO_DOCKER_IMAGE", "datastrato/gravitino-ci-trino:0.1.0")
 
       val testMode = project.properties["testMode"] as? String ?: "embedded"


### PR DESCRIPTION
### What changes were proposed in this pull request?
 - set `hdfs` as HDFS superuser group in container
 - use `datastrato` as the Integration Test user instead of `root`

### Why are the changes needed?
we should not use the `root` user directly to access HDFS

Fix: #554 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
existing ITs
