### PR TITLE
[#792] improvement(core): Optimize the deletion process of entities that have large sub-entities

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/storage/kv/KvEntityStore.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/kv/KvEntityStore.java
@@ -302,7 +302,9 @@ public class KvEntityStore implements EntityStore {
                   // 1/2/schema1 ---> 3
                   // Then the prefix of the name to id mapping for sub-entities of this one is
                   // '1/2/3/'
+                  // identNameToIdKey in this example is '1/2/schema1'
                   String identNameToIdKey = generateKeyForMapping(ident);
+                  // id in this example is 3, ids in this example is ['1', '2', 'schema1']
                   long id = nameMappingService.getIdByName(identNameToIdKey);
                   String[] ids = identNameToIdKey.split(NAMESPACE_SEPARATOR);
                   String[] realIds = ArrayUtils.remove(ids, ids.length - 1);

--- a/core/src/main/java/com/datastrato/gravitino/storage/kv/KvEntityStore.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/kv/KvEntityStore.java
@@ -294,6 +294,14 @@ public class KvEntityStore implements EntityStore {
                     return false;
                   }
                   // Get the prefix of the name to id mapping for sub-entities of this one
+                  // According to KvNameMappingService, if the entity is
+                  // 'mataleke1.catalog1.schema1',
+                  // and the name to id mapping is as following:
+                  // metalake1   ---> 1
+                  // 1/catalog1  ---> 2
+                  // 1/2/schema1 ---> 3
+                  // Then the prefix of the name to id mapping for sub-entities of this one is
+                  // '1/2/3/'
                   String identNameToIdKey = generateKeyForMapping(ident);
                   long id = nameMappingService.getIdByName(identNameToIdKey);
                   String[] ids = identNameToIdKey.split(NAMESPACE_SEPARATOR);

--- a/core/src/main/java/com/datastrato/gravitino/storage/kv/KvNameMappingService.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/kv/KvNameMappingService.java
@@ -30,12 +30,12 @@ public class KvNameMappingService implements NameMappingService {
   // name prefix of name in name to id mapping,
   // e.g., name_metalake1 -> 1
   //       name_metalake2 -> 2
-  private static final byte[] NAME_PREFIX = "name_".getBytes(StandardCharsets.UTF_8);
+  static final byte[] NAME_PREFIX = "name_".getBytes(StandardCharsets.UTF_8);
 
   // id prefix of id in name to id mapping,
   // e.g., id_1 -> metalake1
   //       id_2 -> metalake2
-  private static final byte[] ID_PREFIX = "id_".getBytes(StandardCharsets.UTF_8);
+  static final byte[] ID_PREFIX = "id_".getBytes(StandardCharsets.UTF_8);
 
   @VisibleForTesting final TransactionalKvBackend transactionalKvBackend;
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

When removing an entity, we will delete the name-id mapping instead of the entity itself. 

### Why are the changes needed?

Deleting an entity with many sub-entities is time-consuming. By removing the name-id mapping, we can delete an entity more efficiently. 

Fix: #792 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Existing UT `testEntityDelete` can cover this change. 
