### PR TITLE
[#1065] Improvement(jdbc): Cancel the configuration of multiple databases.

### DIFF
--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogPropertiesMetadata.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogPropertiesMetadata.java
@@ -21,7 +21,6 @@ public class JdbcCatalogPropertiesMetadata extends BaseCatalogPropertiesMetadata
   private static final List<String> JDBC_PROPERTIES =
       ImmutableList.of(
           JdbcConfig.JDBC_URL.getKey(),
-          JdbcConfig.JDBC_DATABASE.getKey(),
           JdbcConfig.JDBC_DRIVER.getKey(),
           JdbcConfig.USERNAME.getKey(),
           JdbcConfig.PASSWORD.getKey(),
@@ -35,13 +34,6 @@ public class JdbcCatalogPropertiesMetadata extends BaseCatalogPropertiesMetadata
                 JdbcConfig.JDBC_URL.getKey(),
                 JdbcConfig.JDBC_URL.getDoc(),
                 true,
-                null,
-                false,
-                false),
-            stringImmutablePropertyEntry(
-                JdbcConfig.JDBC_DATABASE.getKey(),
-                JdbcConfig.JDBC_DATABASE.getDoc(),
-                false,
                 null,
                 false,
                 false),

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlSchemaOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlSchemaOperations.java
@@ -34,7 +34,7 @@ public class PostgreSqlSchemaOperations extends JdbcDatabaseOperations {
     database =
         new JdbcConfig(conf)
             .getJdbcDatabaseOrElseThrow(
-                "The `jdbc-database` configuration item is mandatory in PostgreSQL.");
+                "The `database` name must be configured in the PostgreSQL `jdbc-url`.");
   }
 
   @Override

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlTableOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlTableOperations.java
@@ -73,7 +73,7 @@ public class PostgreSqlTableOperations extends JdbcTableOperations {
     database =
         new JdbcConfig(conf)
             .getJdbcDatabaseOrElseThrow(
-                "The `jdbc-database` configuration item is mandatory in PostgreSQL.");
+                "The `database` name must be configured in the PostgreSQL `jdbc-url`.");
   }
 
   @Override

--- a/catalogs/catalog-jdbc-postgresql/src/main/resources/jdbc-postgresql.conf
+++ b/catalogs/catalog-jdbc-postgresql/src/main/resources/jdbc-postgresql.conf
@@ -5,5 +5,4 @@
 # jdbc-url: jdbc:postgresql://localhost:5432/your_database
 # jdbc-user: strato
 # jdbc-password: strato
-# jdbc-database: your_database
 # jdbc-driver: org.postgresql.Driver

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/TestMultipleJdbcLoad.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/TestMultipleJdbcLoad.java
@@ -23,7 +23,6 @@ import com.datastrato.gravitino.integration.test.util.ITUtils;
 import com.datastrato.gravitino.rel.types.Types;
 import com.google.common.collect.Maps;
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -82,9 +81,7 @@ public class TestMultipleJdbcLoad extends AbstractIT {
 
     Map<String, String> pgConf = Maps.newHashMap();
     String jdbcUrl = postgreSQLContainer.getJdbcUrl();
-    String database = new URI(jdbcUrl.substring(jdbcUrl.lastIndexOf("/") + 1)).getPath();
     pgConf.put(JdbcConfig.JDBC_URL.getKey(), jdbcUrl);
-    pgConf.put(JdbcConfig.JDBC_DATABASE.getKey(), database);
     pgConf.put(JdbcConfig.JDBC_DRIVER.getKey(), postgreSQLContainer.getDriverClassName());
     pgConf.put(JdbcConfig.USERNAME.getKey(), postgreSQLContainer.getUsername());
     pgConf.put(JdbcConfig.PASSWORD.getKey(), postgreSQLContainer.getPassword());

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
@@ -31,8 +31,6 @@ import com.datastrato.gravitino.rel.types.Types;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -140,16 +138,10 @@ public class CatalogPostgreSqlIT extends AbstractIT {
   private static void createCatalog() {
     Map<String, String> catalogProperties = Maps.newHashMap();
 
-    try {
-      String jdbcUrl = POSTGRESQL_CONTAINER.getJdbcUrl();
-      String database = new URI(jdbcUrl.substring(jdbcUrl.lastIndexOf("/") + 1)).getPath();
-      catalogProperties.put(JdbcConfig.JDBC_URL.getKey(), jdbcUrl);
-      catalogProperties.put(JdbcConfig.JDBC_DATABASE.getKey(), database);
-      catalogProperties.put(JdbcConfig.USERNAME.getKey(), POSTGRESQL_CONTAINER.getUsername());
-      catalogProperties.put(JdbcConfig.PASSWORD.getKey(), POSTGRESQL_CONTAINER.getPassword());
-    } catch (URISyntaxException e) {
-      throw new RuntimeException(e);
-    }
+    String jdbcUrl = POSTGRESQL_CONTAINER.getJdbcUrl();
+    catalogProperties.put(JdbcConfig.JDBC_URL.getKey(), jdbcUrl);
+    catalogProperties.put(JdbcConfig.USERNAME.getKey(), POSTGRESQL_CONTAINER.getUsername());
+    catalogProperties.put(JdbcConfig.PASSWORD.getKey(), POSTGRESQL_CONTAINER.getPassword());
 
     Catalog createdCatalog =
         metalake.createCatalog(

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/TestPostgreSqlAbstractIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/TestPostgreSqlAbstractIT.java
@@ -10,8 +10,6 @@ import com.datastrato.gravitino.catalog.postgresql.converter.PostgreSqlTypeConve
 import com.datastrato.gravitino.catalog.postgresql.operation.PostgreSqlSchemaOperations;
 import com.datastrato.gravitino.catalog.postgresql.operation.PostgreSqlTableOperations;
 import com.datastrato.gravitino.integration.test.catalog.jdbc.TestJdbcAbstractIT;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeAll;
@@ -30,23 +28,16 @@ public class TestPostgreSqlAbstractIT extends TestJdbcAbstractIT {
     JDBC_EXCEPTION_CONVERTER = new PostgreSqlExceptionConverter();
     TestJdbcAbstractIT.startup();
     String jdbcUrl = CONTAINER.getJdbcUrl();
-    try {
-      String database =
-          new URI(CONTAINER.getJdbcUrl().substring(jdbcUrl.lastIndexOf("/") + 1, jdbcUrl.length()))
-              .getPath();
-      Map<String, String> config =
-          new HashMap<String, String>() {
-            {
-              put(JdbcConfig.JDBC_DATABASE.getKey(), database);
-            }
-          };
-      TABLE_OPERATIONS = new PostgreSqlTableOperations();
-      DATABASE_OPERATIONS.initialize(DATA_SOURCE, JDBC_EXCEPTION_CONVERTER, config);
-      TABLE_OPERATIONS.initialize(
-          DATA_SOURCE, JDBC_EXCEPTION_CONVERTER, new PostgreSqlTypeConverter(), config);
-      DATABASE_OPERATIONS.create(TEST_DB_NAME, null, null);
-    } catch (URISyntaxException e) {
-      throw new RuntimeException(e);
-    }
+    Map<String, String> config =
+        new HashMap<String, String>() {
+          {
+            put(JdbcConfig.JDBC_URL.getKey(), jdbcUrl);
+          }
+        };
+    TABLE_OPERATIONS = new PostgreSqlTableOperations();
+    DATABASE_OPERATIONS.initialize(DATA_SOURCE, JDBC_EXCEPTION_CONVERTER, config);
+    TABLE_OPERATIONS.initialize(
+        DATA_SOURCE, JDBC_EXCEPTION_CONVERTER, new PostgreSqlTypeConverter(), config);
+    DATABASE_OPERATIONS.create(TEST_DB_NAME, null, null);
   }
 }

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/TestPostgreSqlSchemaOperations.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/TestPostgreSqlSchemaOperations.java
@@ -57,13 +57,7 @@ public class TestPostgreSqlSchemaOperations extends TestPostgreSqlAbstractIT {
     properties.put(JdbcConfig.PASSWORD.getKey(), CONTAINER.getPassword());
     DataSource dataSource = DataSourceUtils.createDataSource(properties);
     PostgreSqlSchemaOperations postgreSqlSchemaOperations = new PostgreSqlSchemaOperations();
-    Map<String, String> config =
-        new HashMap<String, String>() {
-          {
-            put(JdbcConfig.JDBC_DATABASE.getKey(), testDbName);
-          }
-        };
-    postgreSqlSchemaOperations.initialize(dataSource, JDBC_EXCEPTION_CONVERTER, config);
+    postgreSqlSchemaOperations.initialize(dataSource, JDBC_EXCEPTION_CONVERTER, properties);
 
     String schema_1 = "schema_multiple_1";
     DATABASE_OPERATIONS.create(schema_1, null, null);

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/TestPostgreSqlTableOperations.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/TestPostgreSqlTableOperations.java
@@ -317,19 +317,13 @@ public class TestPostgreSqlTableOperations extends TestPostgreSqlAbstractIT {
     properties.put(JdbcConfig.PASSWORD.getKey(), CONTAINER.getPassword());
     DataSource dataSource = DataSourceUtils.createDataSource(properties);
     PostgreSqlSchemaOperations postgreSqlSchemaOperations = new PostgreSqlSchemaOperations();
-    Map<String, String> config =
-        new HashMap<String, String>() {
-          {
-            put(JdbcConfig.JDBC_DATABASE.getKey(), testDbName);
-          }
-        };
-    postgreSqlSchemaOperations.initialize(dataSource, JDBC_EXCEPTION_CONVERTER, config);
+    postgreSqlSchemaOperations.initialize(dataSource, JDBC_EXCEPTION_CONVERTER, properties);
     postgreSqlSchemaOperations.create(TEST_DB_NAME, null, null);
 
     PostgreSqlTableOperations postgreSqlTableOperations = new PostgreSqlTableOperations();
 
     postgreSqlTableOperations.initialize(
-        dataSource, JDBC_EXCEPTION_CONVERTER, new PostgreSqlTypeConverter(), config);
+        dataSource, JDBC_EXCEPTION_CONVERTER, new PostgreSqlTypeConverter(), properties);
 
     String table_1 = "table_multiple_1";
     postgreSqlTableOperations.create(

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/TestPostgresqlConfigCheck.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/TestPostgresqlConfigCheck.java
@@ -1,0 +1,41 @@
+package com.datastrato.gravitino.integration.test.catalog.jdbc.postgresql;
+
+import com.datastrato.gravitino.catalog.jdbc.config.JdbcConfig;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestPostgresqlConfigCheck {
+
+  @Test
+  public void checkDatabase() {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(
+        JdbcConfig.JDBC_URL.getKey(), "jdbc:postgresql://localhost:60440/test_db_9728?123");
+    String database =
+        Assertions.assertDoesNotThrow(
+            () -> new JdbcConfig(properties).getJdbcDatabaseOrElseThrow("have database"));
+    Assertions.assertEquals("test_db_9728", database);
+
+    properties.put(JdbcConfig.JDBC_URL.getKey(), "jdbc:postgresql://localhost:60440/test_db_9728");
+    database =
+        Assertions.assertDoesNotThrow(
+            () -> new JdbcConfig(properties).getJdbcDatabaseOrElseThrow("have database"));
+    Assertions.assertEquals("test_db_9728", database);
+
+    properties.put(JdbcConfig.JDBC_URL.getKey(), "jdbc:postgresql://localhost:60440");
+    IllegalArgumentException illegalArgumentException =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new JdbcConfig(properties).getJdbcDatabaseOrElseThrow("no database"));
+    Assertions.assertEquals("no database", illegalArgumentException.getMessage());
+
+    properties.put(JdbcConfig.JDBC_URL.getKey(), "jdbc:postgresql://localhost:60440/");
+    illegalArgumentException =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new JdbcConfig(properties).getJdbcDatabaseOrElseThrow("no database"));
+    Assertions.assertEquals("no database", illegalArgumentException.getMessage());
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Cancel the configuration of multiple databases.


### Why are the changes needed?

Fix: #1065

### Does this PR introduce _any_ user-facing change?
Removed the configuration of `jdbc-database`, users only configure the database through `jdbc-url`

### How was this patch tested?
UT