### PR TITLE
[#1136] improvement(docs): Add the `md` suffix for every link in the markdown

### DIFF
--- a/docs/apache-hive-catalog.md
+++ b/docs/apache-hive-catalog.md
@@ -36,7 +36,7 @@ The Hive catalog supports to create, update, and delete databases and tables in 
 
 ### Catalog operations
 
-see [Manage Metadata Using Gravitino](./manage-metadata-using-gravitino#catalogs-operations).
+see [Manage Metadata Using Gravitino](./manage-metadata-using-gravitino.md#catalogs-operations).
 
 ## Schema
 
@@ -55,7 +55,7 @@ The following table lists predefined schema properties for the Hive database. Ad
 
 ### Schema operations
 
-see [Manage Metadata Using Gravitino](./manage-metadata-using-gravitino#schemas-operations).
+see [Manage Metadata Using Gravitino](./manage-metadata-using-gravitino.md#schemas-operations).
 
 ## Table
 
@@ -138,7 +138,7 @@ Hive automatically adds and manages some reserved properties. Users aren't allow
 
 #### Alter operations
 
-Gravitino has already defined a unified set of [metadata operation interfaces](./manage-metadata-using-gravitino#alter-a-table), and almost all [Hive Alter operations](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-AlterTable/Partition/Column) have corresponding table update request which enable you to change the struct of an existing table.
+Gravitino has already defined a unified set of [metadata operation interfaces](./manage-metadata-using-gravitino.md#alter-a-table), and almost all [Hive Alter operations](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-AlterTable/Partition/Column) have corresponding table update request which enable you to change the struct of an existing table.
 The following table lists the mapping relationship between Hive Alter operations and Gravitino table update request.
 
 ##### Alter table

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -62,10 +62,10 @@ To begin using Gravitino on AWS, follow these steps:
 5. Install Gravitino on the instance:
 
    You can install Gravitino from the binary release package or Docker image, please follow the
-   [how-to-install](./how-to-install) to install Gravitino.
+   [how-to-install](./how-to-install.md) to install Gravitino.
 
    Or, you can install Gravitino from scratch, please follow the documentation of
-   [how-to-build](./how-to-build) and [how-to-install](./how-to-install) to install Gravitino.
+   [how-to-build](./how-to-build.md) and [how-to-install](./how-to-install.md) to install Gravitino.
 
 6. Start Gravitino using the gravitino.sh script:
 
@@ -109,10 +109,10 @@ To begin using Gravitino on GCP, follow these steps:
 5. Install Gravitino on the instance:
 
    You can install Gravitino from the binary release package or Docker image, please follow the
-   [how-to-install](./how-to-install) to install Gravitino.
+   [how-to-install](./how-to-install.md) to install Gravitino.
 
    Or, you can install Gravitino from scratch, please follow the documentation of
-   [how-to-build](./how-to-build) and [how-to-install](./how-to-install) to install Gravitino.
+   [how-to-build](./how-to-build.md) and [how-to-install](./how-to-install.md) to install Gravitino.
 
 6. Start Gravitino using the gravitino.sh script:
 
@@ -136,10 +136,10 @@ To use Gravitino locally on macOS or Linux, follow similar steps:
 2. Install Gravitino:
 
    You can install Gravitino from the binary release package or Docker image, please follow the
-   [how-to-install](./how-to-install) to install Gravitino.
+   [how-to-install](./how-to-install.md) to install Gravitino.
 
    Or, you can install Gravitino from scratch, please follow the documentation of
-   [how-to-build](./how-to-build) and [how-to-install](./how-to-install) to install Gravitino.
+   [how-to-build](./how-to-build.md) and [how-to-install](./how-to-install.md) to install Gravitino.
 
 3. Start Gravitino using the gravitino.sh script:
 
@@ -191,7 +191,7 @@ newgrp docker
 
 You can install and run all the programs as Docker containers by using the
 [gravitino-playground](https://github.com/datastrato/gravitino-playground). For the details of
-how to run the playground, please see [how-to-use-the-playground](./how-to-use-the-playground)
+how to run the playground, please see [how-to-use-the-playground](./how-to-use-the-playground.md)
 
 ## Installing Gravitino playground locally
 

--- a/docs/gravitino-server-config.md
+++ b/docs/gravitino-server-config.md
@@ -64,11 +64,11 @@ It's highly recommend that you change the default value of `gravitino.entity.sto
 |-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|---------------|---------------|
 | `gravitino.auxService.names ` | The auxiliary service name of the Gravitino Iceberg REST server, use **`iceberg-rest`** for the Gravitino Iceberg REST server. | (none)        | 0.2.0         |
 
-Please refer to [Iceberg REST catalog service](iceberg-rest-service) for Iceberg REST catalog service configurations.
+Please refer to [Iceberg REST catalog service](iceberg-rest-service.md) for Iceberg REST catalog service configurations.
 
 ### Security configuration
 
-Please refer to [security](security) for HTTPS and Authentication configurations.
+Please refer to [security](security.md) for HTTPS and Authentication configurations.
 
 ## Gravitino catalog properties configuration
 
@@ -88,12 +88,12 @@ Explicit specifications take precedence over the formal configurations.
 These rules only apply on the catalog properties, doesn't affect on the schema or table properties.
 :::
 
-| catalog provider    | catalog properties                                                                   | catalog properties configuration file path               |
-|---------------------|--------------------------------------------------------------------------------------|----------------------------------------------------------|
-| `hive`              | [Hive catalog properties](apache-hive-catalog#catalog-properties)                    | `catalogs/hive/conf/hive.conf`                           |
-| `lakehouse-iceberg` | [Lakehouse Iceberg catalog properties](lakehouse-iceberg-catalog#catalog-properties) | `catalogs/lakehouse-iceberg/conf/lakehouse-iceberg.conf` |
-| `jdbc-mysql`        | [MySQL catalog properties](jdbc-mysql-catalog#catalog-properties)                    | `catalogs/jdbc-mysql/conf/jdbc-mysql.conf`               |
-| `jdbc-postgresql`   | [PostgreSQL catalog properties](jdbc-postgresql-catalog#catalog-properties)          | `catalogs/jdbc-postgresql/conf/jdbc-postgresql.conf`     |
+| catalog provider    | catalog properties                                                                      | catalog properties configuration file path               |
+|---------------------|-----------------------------------------------------------------------------------------|----------------------------------------------------------|
+| `hive`              | [Hive catalog properties](apache-hive-catalog.md#catalog-properties)                    | `catalogs/hive/conf/hive.conf`                           |
+| `lakehouse-iceberg` | [Lakehouse Iceberg catalog properties](lakehouse-iceberg-catalog.md#catalog-properties) | `catalogs/lakehouse-iceberg/conf/lakehouse-iceberg.conf` |
+| `jdbc-mysql`        | [MySQL catalog properties](jdbc-mysql-catalog.md#catalog-properties)                    | `catalogs/jdbc-mysql/conf/jdbc-mysql.conf`               |
+| `jdbc-postgresql`   | [PostgreSQL catalog properties](jdbc-postgresql-catalog.md#catalog-properties)          | `catalogs/jdbc-postgresql/conf/jdbc-postgresql.conf`     |
 
 :::info
 Gravitino server automatically add catalog properties configuration dir to classpath.

--- a/docs/how-to-install.md
+++ b/docs/how-to-install.md
@@ -16,7 +16,7 @@ configured correctly. To confirm the Java version, you can simply run `${JAVA_HO
 
 Before installing Gravitino, make sure you have Gravitino binary distribution package. You can
 download the latest Gravitino binary distribution Package from [GitHub](https://github.com/datastrato/gravitino/releases),
-or you can build it yourself by following the instructions in [How to Build Gravitino](./how-to-build).
+or you can build it yourself by following the instructions in [How to Build Gravitino](./how-to-build.md).
 
 If you build Gravitino yourself by `./gradlew compileDistribution` command, you can find the
 Gravitino binary distribution package in `distribution/package` directory.
@@ -49,7 +49,7 @@ The Gravitino binary distribution package contains the following files:
 
 The Gravitino server configuration file is `conf/gravitino.conf`. You can configure the Gravitino
 server by modifying this file. Basic configurations are already added to this file, all the
-configurations list in [Gravitino Server Configurations](./gravitino-server-config).
+configurations list in [Gravitino Server Configurations](./gravitino-server-config.md).
 
 #### Configure Gravitino server log
 
@@ -142,4 +142,4 @@ compose file.
 
 For the details, you can review the
 [Gravitino playground repository](https://github.com/datastrato/gravitino-playground) and
-[playground example](./how-to-use-the-playground).
+[playground example](./how-to-use-the-playground.md).

--- a/docs/how-to-test.md
+++ b/docs/how-to-test.md
@@ -12,7 +12,7 @@ are end-to-end tests that covers the whole system.
 :::note before test
 * If you want to run the complete integration test suites, you need to install Docker in your
   environment.
-* Please refer to [How to build Gravitino](./how-to-build) for more details to make sure you have
+* Please refer to [How to build Gravitino](./how-to-build.md) for more details to make sure you have
   a build environment ready.
 * [OrbStack](https://orbstack.dev/) is highly recommended to replace Docker Desktop for
   macOS. OrbStack automatically configures the network between Docker containers.

--- a/docs/iceberg-rest-service.md
+++ b/docs/iceberg-rest-service.md
@@ -16,7 +16,7 @@ The Gravitino Iceberg REST Server follows the [Apache Iceberg REST API specifica
 - Supports the Apache Iceberg REST API defined in Iceberg 1.3.1, supports all namespace and table interfaces. `Token`, `ReportMetrics`, and `Config` interfaces aren't supported yet.
 - Works as a catalog proxy, supporting `HiveCatalog` and `JDBCCatalog`.
 - When writing to HDFS, the Gravitino Iceberg REST catalog service can only operate as the specified HDFS user and
-  doesn't support proxying to other HDFS users. See [How to access Apache Hadoop](gravitino-server-config) for more details.
+  doesn't support proxying to other HDFS users. See [How to access Apache Hadoop](gravitino-server-config.md) for more details.
 
 :::info
 Builds with Apache Iceberg `1.3.1`. The Apache Iceberg table format version is `1` by default.
@@ -28,7 +28,7 @@ Builds with Hadoop 2.10.x, there may compatibility issue when accessing Hadoop 3
 
 ## How to start the Gravitino Iceberg REST catalog service
 
-Deploy the Gravitino server to the `GRAVITINO_HOME` directory. You can find the configuration options in [`$GRAVITINO_HOME/conf/gravitino.conf`](gravitino-server-config).
+Deploy the Gravitino server to the `GRAVITINO_HOME` directory. You can find the configuration options in [`$GRAVITINO_HOME/conf/gravitino.conf`](gravitino-server-config.md).
 
 ### Gravitino Iceberg REST catalog service configuration
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,37 +11,37 @@ Gravitino is a high-performance, geo-distributed, and federated metadata lake. I
 metadata directly in different sources, types, and regions. It also provides users with unified
 metadata access for data and AI assets.
 
-[Learn more](./overview)&rarr;
+[Learn more](./overview.md)&rarr;
 
 ## Downloading
 
 You can get Graviton from the [GitHub release page](https://github.com/datastrato/gravitino/releases),
-or you can build Gravitino from source, please see [How to build Gravitino](./how-to-build).
+or you can build Gravitino from source, please see [How to build Gravitino](./how-to-build.md).
 
 Gravitino runs on both Linux and macOS, and requires Java 8. Gravitino trino-connector runs with
 Trino, and requires Java 17. This should include JVMs on x86_64 and
 ARM64. It's easy to run locally on one machine --- all you need is to have `java` installed on
 your system `PATH`, or the `JAVA_HOME` environment variable pointing to a Java installation.
 
-See [How to install Gravitino](./how-to-install) to learn how to install Gravitino server.
+See [How to install Gravitino](./how-to-install.md) to learn how to install Gravitino server.
 
 Gravitino provides Docker image on [Docker Hub](https://hub.docker.com/u/datastrato).
 Please pull the image and run it. For the details of Gravitino Docker image, please see
-[Dock image details](./docker-image-details).
+[Dock image details](./docker-image-details.md).
 
 Gravitino also provides a playground to experience the whole Gravitino system with other components.
 Please see the [Gravitino playground repository](https://github.com/datastrato/gravitino-playground)
-and [How to use the playground](./how-to-use-the-playground).
+and [How to use the playground](./how-to-use-the-playground.md).
 
 ## Getting started
 
-To get started with Gravitino, please see [Getting started](./getting-started) for the details.
+To get started with Gravitino, please see [Getting started](./getting-started.md) for the details.
 
-* [Getting started locally](./getting-started#getting-started-locally): a quick guide to start
+* [Getting started locally](./getting-started.md#getting-started-locally): a quick guide to start
   and use Gravitino locally.
-* [Running on Amazon Web Services](./getting-started#getting-started-on-amazon-web-services): a
+* [Running on Amazon Web Services](./getting-started.md#getting-started-on-amazon-web-services): a
   quick guide to start and use Gravitino on AWS.
-* [Running on Google Cloud Platform](./getting-started#getting-started-on-google-cloud-platform):
+* [Running on Google Cloud Platform](./getting-started.md#getting-started-on-google-cloud-platform):
   a quick guide to start and use Gravitino on GCP.
 
 ## Gravitino playground
@@ -49,21 +49,21 @@ To get started with Gravitino, please see [Getting started](./getting-started) f
 To experience Gravitino with other components simply, Gravitino provides a playground to run. It
 integrates Apache Hadoop, Apache Hive, Trino, MySQL, PostgreSQL, and Gravitino together as a
 complete environment. To experience the whole features, please also see
-[Getting started](./getting-started) and [How to use the Gravitino playground](./how-to-use-the-playground)
+[Getting started](./getting-started.md) and [How to use the Gravitino playground](./how-to-use-the-playground.md)
 to learn how to use the playground.
 
-* [Install Gravitino playground on AWS or GCP](./getting-started#installing-gravitino-playground-on-aws-or-google-cloud-platform):
+* [Install Gravitino playground on AWS or GCP](./getting-started.md#installing-gravitino-playground-on-aws-or-google-cloud-platform):
   a quick guide to start and use Gravitino playground on AWS or GCP.
-* [Install Gravitino playground locally](./getting-started#installing-gravitino-playground-locally):
+* [Install Gravitino playground locally](./getting-started.md#installing-gravitino-playground-locally):
   a quick guide to start and use Gravitino playground locally.
-* [How to use the Gravitino playground](./how-to-use-the-playground): provides an example of how
+* [How to use the Gravitino playground](./how-to-use-the-playground.md): provides an example of how
   to use Gravitino and other components together.
 
 ## Where to go from here
 
 ### Programming guides
 
-* [Manage metadata using Gravitino](./manage-metadata-using-gravitino): provides the complete
+* [Manage metadata using Gravitino](./manage-metadata-using-gravitino.md): provides the complete
   functionalities of Gravitino metadata management. Including metalake, catalog, schema and
   table management.
 * [Gravitino Open API](pathname:///docs/0.3.0/api/rest/index.html): provides the complete Open API definition of
@@ -74,24 +74,24 @@ to learn how to use the playground.
 
 Gravitino provides several ways to configure and manage the Gravitino server. Please see:
 
-* [How to customize Gravitino server configurations](./gravitino-server-config): provides the
+* [How to customize Gravitino server configurations](./gravitino-server-config.md): provides the
   complete Gravitino server configurations.
-* [Security](./security): provides the security configurations for Gravitino, including HTTPS
+* [Security](./security.md): provides the security configurations for Gravitino, including HTTPS
   and OAuth2 configurations.
-* [Gravitino metrics](./metrics): provides the metrics configurations and detailed metrics list
+* [Gravitino metrics](./metrics.md): provides the metrics configurations and detailed metrics list
   of Gravitino server.
 
 ### Catalog details
 
 Gravitino supports different catalogs to manage the metadata in different sources. Please see:
 
-* [Lakehouse Iceberg catalog](./lakehouse-iceberg-catalog): a complete guide to use Gravitino
+* [Lakehouse Iceberg catalog](./lakehouse-iceberg-catalog.md): a complete guide to use Gravitino
   manage Apache Iceberg data.
-* [How to set up Gravitino Apache Iceberg REST catalog service](./iceberg-rest-service): a
+* [How to set up Gravitino Apache Iceberg REST catalog service](./iceberg-rest-service.md): a
   complete guide to use Gravitino as Apache Iceberg REST catalog service.
-* [Apache Hive catalog](./apache-hive-catalog): a complete guide to use Gravitino manage Apache Hive data.
-* [JDBC MySQL catalog](./jdbc-mysql-catalog): a complete guide to use Gravitino manage MySQL data.
-* [JDBC PostgreSQL catalog](./jdbc-postgresql-catalog): a complete guide to use Gravitino manage PostgreSQL data.
+* [Apache Hive catalog](./apache-hive-catalog.md): a complete guide to use Gravitino manage Apache Hive data.
+* [JDBC MySQL catalog](./jdbc-mysql-catalog.md): a complete guide to use Gravitino manage MySQL data.
+* [JDBC PostgreSQL catalog](./jdbc-postgresql-catalog.md): a complete guide to use Gravitino manage PostgreSQL data.
 
 ### Trino connector
 
@@ -103,11 +103,11 @@ way. to use the Trino connector, please see:
 
 ### Development guides
 
-* [How to build Gravitino](./how-to-build): a complete guide to build Gravitino from
+* [How to build Gravitino](./how-to-build.md): a complete guide to build Gravitino from
   source.
-* [How to test Gravitino](./how-to-test): a complete guide to run Gravitino unit tests and
+* [How to test Gravitino](./how-to-test.md): a complete guide to run Gravitino unit tests and
   integration tests.
-* [How to sign and verify a Gravitino releases](./how-to-sign-releases): a guide to sign and verify
+* [How to sign and verify a Gravitino releases](./how-to-sign-releases.md): a guide to sign and verify
   a Gravitino release.
-* [Publish Docker images](./publish-docker-images): a guide to publish Gravitino Docker images,
+* [Publish Docker images](./publish-docker-images.md): a guide to publish Gravitino Docker images,
   also list the change logs of Gravitino CI Docker images and release images.

--- a/docs/jdbc-mysql-catalog.md
+++ b/docs/jdbc-mysql-catalog.md
@@ -44,7 +44,7 @@ You must download the corresponding JDBC driver to the `catalogs/jdbc-mysql/libs
 
 ### Catalog operations
 
-see [Manage metadata using Gravitino](./manage-metadata-using-gravitino#catalogs-operations).
+see [Manage metadata using Gravitino](./manage-metadata-using-gravitino.md#catalogs-operations).
 
 ## Schema
 
@@ -61,7 +61,7 @@ see [Manage metadata using Gravitino](./manage-metadata-using-gravitino#catalogs
 
 ### Schema operations
 
-see [Manage metadata using Gravitino](./manage-metadata-using-gravitino#schemas-operations).
+see [Manage metadata using Gravitino](./manage-metadata-using-gravitino.md#schemas-operations).
 
 ## Table
 

--- a/docs/jdbc-postgresql-catalog.md
+++ b/docs/jdbc-postgresql-catalog.md
@@ -50,7 +50,7 @@ In PostgreSQL, the database corresponds to the Gravitino catalog, and the schema
 
 ### Catalog operations
 
-see [Manage metadata using Gravitino](./manage-metadata-using-gravitino#catalogs-operations).
+see [Manage metadata using Gravitino](./manage-metadata-using-gravitino.md#catalogs-operations).
 
 ## Schema
 
@@ -65,7 +65,7 @@ see [Manage metadata using Gravitino](./manage-metadata-using-gravitino#catalogs
 - Doesn't are schema property settings.
 
 ### Schema operations
-see [Manage metadata using Gravitino](./manage-metadata-using-gravitino#schemas-operations).
+see [Manage metadata using Gravitino](./manage-metadata-using-gravitino.md#schemas-operations).
 
 ## Table
 ### Table capabilities

--- a/docs/lakehouse-iceberg-catalog.md
+++ b/docs/lakehouse-iceberg-catalog.md
@@ -196,5 +196,5 @@ If you update a nullability column to non nullability, there may be compatibilit
 You can place `core-site.xml` and `hdfs-site.xml` in the `catalogs/lakehouse-iceberg/conf` directory to automatically load as the default HDFS configuration.
 
 :::caution
-When writing to HDFS, the Gravitino Iceberg REST server can only operate as the specified HDFS user and doesn't support proxying to other HDFS users. See [How to access Apache Hadoop](gravitino-server-config) for more details.
+When writing to HDFS, the Gravitino Iceberg REST server can only operate as the specified HDFS user and doesn't support proxying to other HDFS users. See [How to access Apache Hadoop](gravitino-server-config.md) for more details.
 :::

--- a/docs/manage-metadata-using-gravitino.md
+++ b/docs/manage-metadata-using-gravitino.md
@@ -15,10 +15,10 @@ like metalakes, catalogs, schemas, and tables. This page includes the following 
 In this document, Gravitino uses Apache Hive catalog as an example to show how to manage metadata by Gravitino. Other catalogs are similar to Hive catalog,
 but they may have some differences, especially in catalog property, table property and column type. For more details, please refer to the related doc.
 
-- [**Apache Hive**](./apache-hive-catalog)
-- [**MySQL**](./jdbc-postgresql-catalog)
-- [**PostgreSQL**](./jdbc-mysql-catalog)
-- [**Apache Iceberg**](./lakehouse-iceberg-catalog)
+- [**Apache Hive**](./apache-hive-catalog.md)
+- [**MySQL**](./jdbc-postgresql-catalog.md)
+- [**PostgreSQL**](./jdbc-mysql-catalog.md)
+- [**Apache Iceberg**](./lakehouse-iceberg-catalog.md)
 
 
 Assuming Gravitino has just started, and the host and port is `http://localhost:8090`.
@@ -244,12 +244,12 @@ Catalog catalog = gravitinoMetaLake.createCatalog(
 
 Currently, Gravitino supports the following catalog providers:
 
-| Catalog provider    | Catalog property                                                            |
-|---------------------|-----------------------------------------------------------------------------|
-| `hive`              | [Hive catalog property](./apache-hive-catalog#catalog-properties)           |
-| `lakehouse-iceberg` | [Iceberg catalog property](./lakehouse-iceberg-catalog#catalog-properties)  |
-| `jdbc-mysql`        | [MySQL catalog property](./jdbc-mysql-catalog#catalog-properties)           |
-| `jdbc-postgresql`   | [PostgreSQL catalog property](./jdbc-postgresql-catalog#catalog-properties) |
+| Catalog provider    | Catalog property                                                               |
+|---------------------|--------------------------------------------------------------------------------|
+| `hive`              | [Hive catalog property](./apache-hive-catalog.md#catalog-properties)           |
+| `lakehouse-iceberg` | [Iceberg catalog property](./lakehouse-iceberg-catalog.md#catalog-properties)  |
+| `jdbc-mysql`        | [MySQL catalog property](./jdbc-mysql-catalog.md#catalog-properties)           |
+| `jdbc-postgresql`   | [PostgreSQL catalog property](./jdbc-postgresql-catalog.md#catalog-properties) |
 
 ### Load a catalog
 
@@ -448,12 +448,12 @@ Schema schema = supportsSchemas.createSchema(
 
 Currently, Gravitino supports the following schema property:
 
-| Catalog provider    | Schema property                                                           |
-|---------------------|---------------------------------------------------------------------------|
-| `hive`              | [Hive schema property](./apache-hive-catalog#schema-properties)           |
-| `lakehouse-iceberg` | [Iceberg scheme property](./lakehouse-iceberg-catalog#schema-properties)  |
-| `jdbc-mysql`        | [MySQL schema property](./jdbc-mysql-catalog#schema-properties)           |
-| `jdbc-postgresql`   | [PostgreSQL schema property](./jdbc-postgresql-catalog#schema-properties) |
+| Catalog provider    | Schema property                                                              |
+|---------------------|------------------------------------------------------------------------------|
+| `hive`              | [Hive schema property](./apache-hive-catalog.md#schema-properties)           |
+| `lakehouse-iceberg` | [Iceberg scheme property](./lakehouse-iceberg-catalog.md#schema-properties)  |
+| `jdbc-mysql`        | [MySQL schema property](./jdbc-mysql-catalog.md#schema-properties)           |
+| `jdbc-postgresql`   | [PostgreSQL schema property](./jdbc-postgresql-catalog.md#schema-properties) |
 
 ### Load a schema
 
@@ -717,12 +717,12 @@ The related java doc is [here](pathname:///docs/0.3.0/api/java/com/datastrato/gr
 
 The following is the table property that Gravitino supports:
 
-| Catalog provider    | Table property                                                          | Type mapping                                                            |
-|---------------------|-------------------------------------------------------------------------|-------------------------------------------------------------------------|
-| `hive`              | [Hive table property](./apache-hive-catalog#table-properties)           | [Hive type mapping](./apache-hive-catalog#table-column-types)           |
-| `lakehouse-iceberg` | [Iceberg table property](./lakehouse-iceberg-catalog#table-properties)  | [Iceberg type mapping](./lakehouse-iceberg-catalog#table-column-types)  |
-| `jdbc-mysql`        | [MySQL table property](./jdbc-mysql-catalog#table-properties)           | [MySQL type mapping](./jdbc-mysql-catalog#table-column-types)           |
-| `jdbc-postgresql`   | [PostgreSQL table property](./jdbc-postgresql-catalog#table-properties) | [PostgreSQL type mapping](./jdbc-postgresql-catalog#table-column-types) |
+| Catalog provider    | Table property                                                             | Type mapping                                                               |
+|---------------------|----------------------------------------------------------------------------|----------------------------------------------------------------------------|
+| `hive`              | [Hive table property](./apache-hive-catalog.md#table-properties)           | [Hive type mapping](./apache-hive-catalog.md#table-column-types)           |
+| `lakehouse-iceberg` | [Iceberg table property](./lakehouse-iceberg-catalog.md#table-properties)  | [Iceberg type mapping](./lakehouse-iceberg-catalog.md#table-column-types)  |
+| `jdbc-mysql`        | [MySQL table property](./jdbc-mysql-catalog.md#table-properties)           | [MySQL type mapping](./jdbc-mysql-catalog.md#table-column-types)           |
+| `jdbc-postgresql`   | [PostgreSQL table property](./jdbc-postgresql-catalog.md#table-properties) | [PostgreSQL type mapping](./jdbc-postgresql-catalog.md#table-column-types) |
 
 
 In addition to the basic settings, Gravitino supports the following features:

--- a/docs/publish-docker-images.md
+++ b/docs/publish-docker-images.md
@@ -33,4 +33,4 @@ You can use GitHub actions to publish Docker images to the Docker Hub repository
 
 ## More details of Gravitino Docker images
 
-+ [Gravitino Docker images](docker-image-details)
++ [Gravitino Docker images](docker-image-details.md)

--- a/docs/security.md
+++ b/docs/security.md
@@ -110,7 +110,7 @@ You can follow the steps to set up an OAuth mode Gravitino server.
 
 5. Copy the public key and remove the character `\n` and you can get the default signing key of Gravitino server.
 
-6. You can refer to the [Configurations](gravitino-server-config) and append the configurations to the conf/gravitino.conf.
+6. You can refer to the [Configurations](gravitino-server-config.md) and append the configurations to the conf/gravitino.conf.
 
 ```text
 gravitino.authenticator oauth
@@ -220,7 +220,7 @@ bin/keytool -export -alias localhost -keystore localhost.jks -file  localhost.cr
 bin/keytool -import -alias localhost -keystore jre/lib/security/cacerts -file localhost.crt -storepass changeit -noprompt
 ```
 
-5. You can refer to the [Configurations](gravitino-server-config) and append the configurations to the conf/gravitino.conf.
+5. You can refer to the [Configurations](gravitino-server-config.md) and append the configurations to the conf/gravitino.conf.
 Configuration doesn't support to resolve environment variable, so you should replace `${JAVA_HOME}` with the actual value.
 Then, You can start the Gravitino server.
 

--- a/docs/trino-connector/catalog-hive.md
+++ b/docs/trino-connector/catalog-hive.md
@@ -99,7 +99,7 @@ CREATE TABLE "metalake.catalog".dbname.tabname
 First, you need to create a metalake and catalog in Gravitino.
 For example, create a new metalake named `test` and create a new catalog named `hive_test` using the `hive` provider.
 And configure the Metalake `test` into the `Graviton connector`.
-For More information about the Hive catalog, please refer to [Hive catalog](../apache-hive-catalog).
+For More information about the Hive catalog, please refer to [Hive catalog](../apache-hive-catalog.md).
 
 ```bash
 curl -X POST -H "Content-Type: application/json" \

--- a/docs/trino-connector/catalog-iceberg.md
+++ b/docs/trino-connector/catalog-iceberg.md
@@ -51,7 +51,7 @@ Iceberg's tables and schemas do not support properties.
 First, you need to create a metalake and catalog in Gravitino.
 For example, create a new metalake named `test` and create a new catalog named `iceberg_test` using the `lakehouse-iceberg` provider.
 And configure the Metalake `test` into the `Graviton connector`.
-For More information about the Iceberg catalog, please refer to [Iceberg catalog](../lakehouse-iceberg-catalog).
+For More information about the Iceberg catalog, please refer to [Iceberg catalog](../lakehouse-iceberg-catalog.md).
 
 ```bash
 curl -X POST -H "Content-Type: application/json" \

--- a/docs/trino-connector/catalog-mysql.md
+++ b/docs/trino-connector/catalog-mysql.md
@@ -45,7 +45,7 @@ MySQL's tables and schemas cannot support properties.
 First, you need to create a metalake and catalog in Gravitino.
 For example, create a new metalake named `test` and create a new catalog named `mysql_test` using the `jdbc-mysql` provider.
 And configure the Metalake `test` into the `Graviton connector`.
-For More information about the MySQL catalog, please refer to [MySql catalog](../jdbc-mysql-catalog.md).
+For More information about the MySQL catalog, please refer to [MySQL catalog](../jdbc-mysql-catalog.md).
 
 ```bash
 curl -X POST -H "Content-Type: application/json" \

--- a/docs/trino-connector/catalog-mysql.md
+++ b/docs/trino-connector/catalog-mysql.md
@@ -45,7 +45,7 @@ MySQL's tables and schemas cannot support properties.
 First, you need to create a metalake and catalog in Gravitino.
 For example, create a new metalake named `test` and create a new catalog named `mysql_test` using the `jdbc-mysql` provider.
 And configure the Metalake `test` into the `Graviton connector`.
-For More information about the MySQL catalog, please refer to [MySql catalog](../docs/jdbc-mysql-catalog).
+For More information about the MySQL catalog, please refer to [MySql catalog](../jdbc-mysql-catalog.md).
 
 ```bash
 curl -X POST -H "Content-Type: application/json" \

--- a/docs/trino-connector/catalog-postgresql.md
+++ b/docs/trino-connector/catalog-postgresql.md
@@ -46,7 +46,7 @@ PostgreSQL's tables and schemas cannot support properties.
 First, you need to create a metalake and catalog in Gravitino.
 For example, create a new metalake named `test` and create a new catalog named `postgresql_test` using the `jdbc-postgresql` provider.
 And configure the Metalake `test` into the `Graviton connector`.
-For More information about the PostgreSQL catalog, please refer to [PostgreSQL catalog](../docs/jdbc-postgressql-catalog).
+For More information about the PostgreSQL catalog, please refer to [PostgreSQL catalog](../jdbc-postgresql-catalog.md).
 
 ```bash
 curl -X POST -H "Content-Type: application/json" \

--- a/docs/trino-connector/index.md
+++ b/docs/trino-connector/index.md
@@ -8,13 +8,13 @@ This software is licensed under the Apache License version 2."
 
 Gravitino connector index:
 
-- [Trino Support](trino-connector)
-  - [Requirements](requirements)
-  - [Installation](installation)
-  - [Configuration](configuration)
-  - [Supported catalogs](supported-catalog)
-    - [Hive](catalog-hive)
-    - [Iceberg](catalog-iceberg)
-    - [MySQL](catalog-mysql)
-    - [PostgreSQL](catalog-postgresql)
-  - [Supported SQL](sql-support)
+- [Trino Support](trino-connector.md)
+  - [Requirements](requirements.md)
+  - [Installation](installation.md)
+  - [Configuration](configuration.md)
+  - [Supported catalogs](supported-catalog.md)
+    - [Hive](catalog-hive.md)
+    - [Iceberg](catalog-iceberg.md)
+    - [MySQL](catalog-mysql.md)
+    - [PostgreSQL](catalog-postgresql.md)
+  - [Supported SQL](sql-support.md)

--- a/docs/trino-connector/installation.md
+++ b/docs/trino-connector/installation.md
@@ -20,7 +20,7 @@ Please refer to the [Deploying Trino documentation](https://trino.io/docs/curren
 Alternatively,
 you can build the Gravitino connector package from the sources
 and obtain the `gravitino-trino-connector-<version>.tar.gz` file in the `$PROJECT/distribution` directory.
-Please refer to the [Gravitino Development documentation](../how-to-build)
+Please refer to the [Gravitino Development documentation](../how-to-build.md)
 
 ## Example
 
@@ -68,7 +68,7 @@ Now you can see the Gravitino connector directory in the plugin directory.
 ### Configuring the Gravitino connector
 
 Assuming you have now started the Gravitino server on the host `gravitino-server-host` and can access it properly. 
-And you have created a metalake named `test`. If not, please refer to the [Gravitino Getting-started](../getting-started)
+And you have created a metalake named `test`. If not, please refer to the [Gravitino Getting-started](../getting-started.md)
 
 Add catalog configuration to the Trino configuration file `/etc/trino/catalog/gravitino.properties`.
 
@@ -116,7 +116,7 @@ system
 You can see the `gravitino` catalog in the result. This signifies the successful installation of the Gravitino connector.
 
 Assuming you have created a catalog named `test.jdbc-mysql` in the Gravitino server.
-If you don't have it, please refer to [Create a Catalog](../manage-metadata-using-gravitino#create-a-catalog)
+If you don't have it, please refer to [Create a Catalog](../manage-metadata-using-gravitino.md#create-a-catalog)
 
 Then you can use the Trino CLI to connect to the Trino container and run a query.
 

--- a/docs/trino-connector/supported-catalog.md
+++ b/docs/trino-connector/supported-catalog.md
@@ -8,16 +8,16 @@ This software is licensed under the Apache License version 2."
 
 The catalogs currently supported by the Gravitino connector are as follows:
 
-- [Hive](catalog-hive)
-- [Iceberg](catalog-iceberg)
-- [MySQL](catalog-mysql)
-- [PostgreSQL](catalog-postgresql)
+- [Hive](catalog-hive.md)
+- [Iceberg](catalog-iceberg.md)
+- [MySQL](catalog-mysql.md)
+- [PostgreSQL](catalog-postgresql.md)
 
 ## Create catalog
 
 Trino currently does not support creating Gravitino managed catalogs. 
 If you need to create a catalog, please refer to:
-- [Create a Catalog](../manage-metadata-using-gravitino#create-a-catalog)
+- [Create a Catalog](../manage-metadata-using-gravitino.md#create-a-catalog)
 
 ## Data type mapping
 

--- a/docs/trino-connector/trino-connector.md
+++ b/docs/trino-connector/trino-connector.md
@@ -20,7 +20,7 @@ The loading of Gravitino's catalogs into Trino follows the naming convention:
 ```
 
 Regarding `metalake` and `catalog`, 
-you can refer to [Create a Metalake](../manage-metadata-using-gravitino#create-a-metalake), [Create a Catalog](../manage-metadata-using-gravitino#create-a-catalog).
+you can refer to [Create a Metalake](../manage-metadata-using-gravitino.md#create-a-metalake), [Create a Catalog](../manage-metadata-using-gravitino.md#create-a-catalog).
 
 Usage in queries is as follows:
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
 Add the `md` suffix for every link in the markdown

### Why are the changes needed?

Fix: #1136

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Tested in Docunausars and markdown locally.