### PR TITLE
[#1052] fix(common): position name should support upper-case when add a column

### DIFF
--- a/common/src/main/java/com/datastrato/gravitino/json/JsonUtils.java
+++ b/common/src/main/java/com/datastrato/gravitino/json/JsonUtils.java
@@ -704,9 +704,9 @@ public class JsonUtils {
           node != null && !node.isNull(),
           "Cannot parse column position from invalid JSON: %s",
           node);
-      if (node.isTextual() && node.asText().equals(POSITION_FIRST)) {
+      if (node.isTextual() && node.asText().equalsIgnoreCase(POSITION_FIRST)) {
         return TableChange.ColumnPosition.first();
-      } else if (node.isTextual() && node.asText().equals(POSITION_DEFAULT)) {
+      } else if (node.isTextual() && node.asText().equalsIgnoreCase(POSITION_DEFAULT)) {
         return TableChange.ColumnPosition.defaultPos();
       } else if (node.isObject()) {
         String afterColumn = getString(POSITION_AFTER, node);

--- a/common/src/main/java/com/datastrato/gravitino/json/JsonUtils.java
+++ b/common/src/main/java/com/datastrato/gravitino/json/JsonUtils.java
@@ -704,9 +704,13 @@ public class JsonUtils {
           node != null && !node.isNull(),
           "Cannot parse column position from invalid JSON: %s",
           node);
-      if (node.isTextual() && node.asText().equalsIgnoreCase(POSITION_FIRST)) {
+      if (node.isTextual()
+          && (node.asText().equals(POSITION_FIRST)
+              || node.asText().equals(POSITION_FIRST.toUpperCase()))) {
         return TableChange.ColumnPosition.first();
-      } else if (node.isTextual() && node.asText().equalsIgnoreCase(POSITION_DEFAULT)) {
+      } else if (node.isTextual()
+          && (node.asText().equalsIgnoreCase(POSITION_DEFAULT)
+              || node.asText().equalsIgnoreCase(POSITION_DEFAULT.toUpperCase()))) {
         return TableChange.ColumnPosition.defaultPos();
       } else if (node.isObject()) {
         String afterColumn = getString(POSITION_AFTER, node);

--- a/common/src/test/java/com/datastrato/gravitino/dto/requests/TestTableUpdatesRequest.java
+++ b/common/src/test/java/com/datastrato/gravitino/dto/requests/TestTableUpdatesRequest.java
@@ -151,6 +151,13 @@ public class TestTableUpdatesRequest {
             + "}";
     Assertions.assertEquals(
         JsonUtils.objectMapper().readTree(expected), JsonUtils.objectMapper().readTree(jsonString));
+    Assertions.assertTrue(
+        JsonUtils.objectMapper()
+                .readValue(
+                    jsonString.replace("first", "FIRST"),
+                    TableUpdateRequest.AddTableColumnRequest.class)
+                .getPosition()
+            instanceof TableChange.First);
 
     // test default position
     addTableColumnRequest =
@@ -170,5 +177,12 @@ public class TestTableUpdatesRequest {
             + "}";
     Assertions.assertEquals(
         JsonUtils.objectMapper().readTree(expected), JsonUtils.objectMapper().readTree(jsonString));
+    Assertions.assertTrue(
+        JsonUtils.objectMapper()
+                .readValue(
+                    jsonString.replace("default", "DEFAULT"),
+                    TableUpdateRequest.AddTableColumnRequest.class)
+                .getPosition()
+            instanceof TableChange.Default);
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Position name supports upper-case when add a column for `FIRST` and `DEFAULT`.

### Why are the changes needed?

Position name should support upper-case when add a column. For example, the correct value of position is first NOT FIRST currently.
```
curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" -H "Content-Type: application/json" -d '{
  "updates": [
    {
      "@type": "removeProperty",
      "property": "key2"
    }, {
      "@type": "setProperty",
      "property": "key3",
      "value": "value3"
    },
    {
    "@type": "addColumn",
    "fieldName": [
      "position"
      ],
    "type": "varchar(20)",
    "comment": "Position of user",
    "position": "FIRST"
    } 
  ]
}' http://localhost:8090/api/metalakes/metalake/catalogs/catalog/schemas/schema/tables/table
```

```
Unknown json column position: "FIRST" (through reference chain: com.datastrato.gravitino.dto.requests.TableUpdatesRequest["updates"]->java.util.ArrayList[2])%
```

Fix: #1052 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`TestTableUpdatesRequest#testAddTableColumnRequest`