### PR TITLE
[MINOR] fix(docs): fix ./gradlew spotlessApply of Coding standards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ When adding new code or fixing a bug be sure to add unit tests to provide covera
 Spotless checks code formatting. If your code isn't correctly formatted, the build fails. To correctly format your code please use Spotless.
 
 ```bash
-./grawdlew spotlessApply
+./gradlew spotlessApply
 ```
 
 All files must have a license header and the build fails if any files are missing license headers. If you are adding third-party code be sure to understand how to add the third-party license to Gravitino LICENSE and NOTICE files.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update `./gradlew spotlessApply` of Coding standards in `Contributing.md`.

### Why are the changes needed?

There is no `grawdlew` file in project, which cause that developer could not follow coding standards.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.