### PR TITLE
[#1047] improvement(core): Fix the issue of StringIdentifier in metalake property

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/StringIdentifier.java
+++ b/core/src/main/java/com/datastrato/gravitino/StringIdentifier.java
@@ -7,6 +7,7 @@ package com.datastrato.gravitino;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -106,6 +107,27 @@ public class StringIdentifier {
         .putAll(properties)
         .put(ID_KEY, stringId.toString())
         .build();
+  }
+
+  /**
+   * Remove StringIdentifier from properties.
+   *
+   * @param properties the properties to remove the string identifier from.
+   * @return the properties with the string identifier removed.
+   */
+  public static Map<String, String> removeFromProperties(Map<String, String> properties) {
+    if (properties == null) {
+      return null;
+    }
+
+    if (!properties.containsKey(ID_KEY)) {
+      return properties;
+    }
+
+    Map<String, String> copy = Maps.newHashMap(properties);
+    copy.remove(ID_KEY);
+
+    return ImmutableMap.copyOf(copy);
   }
 
   public static StringIdentifier fromProperties(Map<String, String> properties) {

--- a/core/src/main/java/com/datastrato/gravitino/storage/kv/KvGarbageCollector.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/kv/KvGarbageCollector.java
@@ -44,7 +44,7 @@ public final class KvGarbageCollector implements Closeable {
       new ScheduledThreadPoolExecutor(
           2,
           r -> {
-            Thread t = new Thread(r, "KvEntityStore-Garbage-Collector-%d");
+            Thread t = new Thread(r, "KvEntityStore-Garbage-Collector");
             t.setDaemon(true);
             return t;
           },
@@ -188,6 +188,7 @@ public final class KvGarbageCollector implements Closeable {
 
       // All keys in this transaction have been deleted, we can remove the commit mark.
       if (keysDeletedCount == keysInTheTransaction.size()) {
+        LOG.info("Physically delete commit mark: {}", Bytes.wrap(kv.getKey()));
         kvBackend.delete(kv.getKey());
       }
     }

--- a/core/src/test/java/com/datastrato/gravitino/meta/TestMetalakeManager.java
+++ b/core/src/test/java/com/datastrato/gravitino/meta/TestMetalakeManager.java
@@ -173,8 +173,6 @@ public class TestMetalakeManager {
           Assertions.assertEquals(v, testProps.get(k));
         });
 
-    Assertions.assertTrue(testProps.containsKey(StringIdentifier.ID_KEY));
-    StringIdentifier StringId = StringIdentifier.fromString(testProps.get(StringIdentifier.ID_KEY));
-    Assertions.assertEquals(StringId.toString(), testProps.get(StringIdentifier.ID_KEY));
+    Assertions.assertFalse(testProps.containsKey(StringIdentifier.ID_KEY));
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove the `stringId` from metalake property map. 

### Why are the changes needed?

`gravitino.identifier` is generated internally and should not be visible to users.  

Fix: #1047 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Existing UTs can cover it. 
