### PR TITLE
[#1047] improvement(core): Fix the issue of StringIdentifier in metalake property

### DIFF
--- a/common/src/main/java/com/datastrato/gravitino/dto/MetalakeDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/MetalakeDTO.java
@@ -7,14 +7,13 @@ package com.datastrato.gravitino.dto;
 import com.datastrato.gravitino.Audit;
 import com.datastrato.gravitino.Metalake;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import java.util.Map;
 import javax.annotation.Nullable;
-import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 /** Represents a Metalake Data Transfer Object (DTO) that implements the Metalake interface. */
-@EqualsAndHashCode
 @ToString
 public class MetalakeDTO implements Metalake {
 
@@ -131,5 +130,41 @@ public class MetalakeDTO implements Metalake {
       Preconditions.checkArgument(audit != null, "audit cannot be null");
       return new MetalakeDTO(name, comment, properties, audit);
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MetalakeDTO that = (MetalakeDTO) o;
+    return Objects.equal(name, that.name)
+        && Objects.equal(comment, that.comment)
+        && propertyEqual(properties, that.properties)
+        && Objects.equal(audit, that.audit);
+  }
+
+  private boolean propertyEqual(Map<String, String> p1, Map<String, String> p2) {
+    if (p1 == null && p2 == null) {
+      return true;
+    }
+
+    if (p1 != null && p1.isEmpty() && p2 == null) {
+      return true;
+    }
+
+    if (p2 != null && p2.isEmpty() && p1 == null) {
+      return true;
+    }
+
+    return java.util.Objects.equals(p1, p2);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(name, comment, audit);
   }
 }

--- a/core/src/main/java/com/datastrato/gravitino/StringIdentifier.java
+++ b/core/src/main/java/com/datastrato/gravitino/StringIdentifier.java
@@ -127,7 +127,7 @@ public class StringIdentifier {
     Map<String, String> copy = Maps.newHashMap(properties);
     copy.remove(ID_KEY);
 
-    return ImmutableMap.copyOf(copy);
+    return ImmutableMap.<String, String>builder().putAll(copy).build();
   }
 
   public static StringIdentifier fromProperties(Map<String, String> properties) {

--- a/core/src/main/java/com/datastrato/gravitino/StringIdentifier.java
+++ b/core/src/main/java/com/datastrato/gravitino/StringIdentifier.java
@@ -7,6 +7,7 @@ package com.datastrato.gravitino;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -106,6 +107,27 @@ public class StringIdentifier {
         .putAll(properties)
         .put(ID_KEY, stringId.toString())
         .build();
+  }
+
+  /**
+   * Remove StringIdentifier from properties.
+   *
+   * @param properties the properties to remove the string identifier from.
+   * @return the properties with the string identifier removed.
+   */
+  public static Map<String, String> removeFromProperties(Map<String, String> properties) {
+    if (properties == null) {
+      return null;
+    }
+
+    if (!properties.containsKey(ID_KEY)) {
+      return properties;
+    }
+
+    Map<String, String> copy = Maps.newHashMap(properties);
+    copy.remove(ID_KEY);
+
+    return ImmutableMap.copyOf(copy);
   }
 
   public static StringIdentifier fromProperties(Map<String, String> properties) {

--- a/core/src/main/java/com/datastrato/gravitino/StringIdentifier.java
+++ b/core/src/main/java/com/datastrato/gravitino/StringIdentifier.java
@@ -115,7 +115,7 @@ public class StringIdentifier {
    * @param properties the properties to remove the string identifier from.
    * @return the properties with the string identifier removed.
    */
-  public static Map<String, String> removeFromProperties(Map<String, String> properties) {
+  public static Map<String, String> removeIdFromProperties(Map<String, String> properties) {
     if (properties == null) {
       return null;
     }

--- a/core/src/main/java/com/datastrato/gravitino/meta/BaseMetalake.java
+++ b/core/src/main/java/com/datastrato/gravitino/meta/BaseMetalake.java
@@ -127,7 +127,7 @@ public class BaseMetalake implements Metalake, Entity, Auditable, HasIdentifier 
    */
   @Override
   public Map<String, String> properties() {
-    return StringIdentifier.removeFromProperties(properties);
+    return StringIdentifier.removeIdFromProperties(properties);
   }
 
   /** Builder class for creating instances of {@link BaseMetalake}. */

--- a/core/src/main/java/com/datastrato/gravitino/meta/BaseMetalake.java
+++ b/core/src/main/java/com/datastrato/gravitino/meta/BaseMetalake.java
@@ -10,6 +10,7 @@ import com.datastrato.gravitino.Entity;
 import com.datastrato.gravitino.Field;
 import com.datastrato.gravitino.HasIdentifier;
 import com.datastrato.gravitino.Metalake;
+import com.datastrato.gravitino.StringIdentifier;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -126,7 +127,7 @@ public class BaseMetalake implements Metalake, Entity, Auditable, HasIdentifier 
    */
   @Override
   public Map<String, String> properties() {
-    return properties;
+    return StringIdentifier.removeFromProperties(properties);
   }
 
   /** Builder class for creating instances of {@link BaseMetalake}. */

--- a/core/src/main/java/com/datastrato/gravitino/meta/MetalakeManager.java
+++ b/core/src/main/java/com/datastrato/gravitino/meta/MetalakeManager.java
@@ -53,7 +53,6 @@ public class MetalakeManager implements SupportsMetalakes {
   public BaseMetalake[] listMetalakes() {
     try {
       return store.list(Namespace.empty(), BaseMetalake.class, EntityType.METALAKE).stream()
-          .map(this::removeIdFromProperties)
           .toArray(BaseMetalake[]::new);
     } catch (IOException ioe) {
       LOG.error("Listing Metalakes failed due to storage issues.", ioe);
@@ -72,8 +71,7 @@ public class MetalakeManager implements SupportsMetalakes {
   @Override
   public BaseMetalake loadMetalake(NameIdentifier ident) throws NoSuchMetalakeException {
     try {
-      BaseMetalake baseMetalake = store.get(ident, EntityType.METALAKE, BaseMetalake.class);
-      return removeIdFromProperties(baseMetalake);
+      return store.get(ident, EntityType.METALAKE, BaseMetalake.class);
     } catch (NoSuchEntityException e) {
       LOG.warn("Metalake {} does not exist", ident, e);
       throw new NoSuchMetalakeException("Metalake " + ident + " does not exist");
@@ -116,7 +114,8 @@ public class MetalakeManager implements SupportsMetalakes {
 
     try {
       store.put(metalake, false /* overwritten */);
-      return removeIdFromProperties(metalake);
+      return metalake;
+      //      return removeIdFromProperties(metalake);
     } catch (EntityAlreadyExistsException e) {
       LOG.warn("Metalake {} already exists", ident, e);
       throw new MetalakeAlreadyExistsException("Metalake " + ident + " already exists");
@@ -173,7 +172,7 @@ public class MetalakeManager implements SupportsMetalakes {
                 return builder.build();
               });
 
-      return removeIdFromProperties(baseMetalake);
+      return baseMetalake;
 
     } catch (NoSuchEntityException ne) {
       LOG.warn("Metalake {} does not exist", ident, ne);
@@ -241,16 +240,5 @@ public class MetalakeManager implements SupportsMetalakes {
     }
 
     return builder.withProperties(newProps);
-  }
-
-  private BaseMetalake removeIdFromProperties(BaseMetalake metalake) {
-    return new BaseMetalake.Builder()
-        .withId(metalake.id())
-        .withName(metalake.name())
-        .withComment(metalake.comment())
-        .withProperties(StringIdentifier.removeFromProperties(metalake.properties()))
-        .withVersion(metalake.version)
-        .withAuditInfo((AuditInfo) metalake.auditInfo())
-        .build();
   }
 }

--- a/core/src/main/java/com/datastrato/gravitino/meta/MetalakeManager.java
+++ b/core/src/main/java/com/datastrato/gravitino/meta/MetalakeManager.java
@@ -115,7 +115,6 @@ public class MetalakeManager implements SupportsMetalakes {
     try {
       store.put(metalake, false /* overwritten */);
       return metalake;
-      //      return removeIdFromProperties(metalake);
     } catch (EntityAlreadyExistsException e) {
       LOG.warn("Metalake {} already exists", ident, e);
       throw new MetalakeAlreadyExistsException("Metalake " + ident + " already exists");
@@ -139,40 +138,37 @@ public class MetalakeManager implements SupportsMetalakes {
   public BaseMetalake alterMetalake(NameIdentifier ident, MetalakeChange... changes)
       throws NoSuchMetalakeException, IllegalArgumentException {
     try {
-      BaseMetalake baseMetalake =
-          store.update(
-              ident,
-              BaseMetalake.class,
-              EntityType.METALAKE,
-              metalake -> {
-                BaseMetalake.Builder builder =
-                    new BaseMetalake.Builder()
-                        .withId(metalake.id())
-                        .withName(metalake.name())
-                        .withComment(metalake.comment())
-                        .withProperties(metalake.properties())
-                        .withVersion(metalake.getVersion());
+      return store.update(
+          ident,
+          BaseMetalake.class,
+          EntityType.METALAKE,
+          metalake -> {
+            BaseMetalake.Builder builder =
+                new BaseMetalake.Builder()
+                    .withId(metalake.id())
+                    .withName(metalake.name())
+                    .withComment(metalake.comment())
+                    .withProperties(metalake.properties())
+                    .withVersion(metalake.getVersion());
 
-                AuditInfo newInfo =
-                    new AuditInfo.Builder()
-                        .withCreator(metalake.auditInfo().creator())
-                        .withCreateTime(metalake.auditInfo().createTime())
-                        .withLastModifier(
-                            metalake.auditInfo().creator()) /*TODO: Use real user later on.  */
-                        .withLastModifiedTime(Instant.now())
-                        .build();
-                builder.withAuditInfo(newInfo);
+            AuditInfo newInfo =
+                new AuditInfo.Builder()
+                    .withCreator(metalake.auditInfo().creator())
+                    .withCreateTime(metalake.auditInfo().createTime())
+                    .withLastModifier(
+                        metalake.auditInfo().creator()) /*TODO: Use real user later on.  */
+                    .withLastModifiedTime(Instant.now())
+                    .build();
+            builder.withAuditInfo(newInfo);
 
-                Map<String, String> newProps =
-                    metalake.properties() == null
-                        ? Maps.newHashMap()
-                        : Maps.newHashMap(metalake.properties());
-                builder = updateEntity(builder, newProps, changes);
+            Map<String, String> newProps =
+                metalake.properties() == null
+                    ? Maps.newHashMap()
+                    : Maps.newHashMap(metalake.properties());
+            builder = updateEntity(builder, newProps, changes);
 
-                return builder.build();
-              });
-
-      return baseMetalake;
+            return builder.build();
+          });
 
     } catch (NoSuchEntityException ne) {
       LOG.warn("Metalake {} does not exist", ident, ne);

--- a/core/src/main/java/com/datastrato/gravitino/storage/kv/KvGarbageCollector.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/kv/KvGarbageCollector.java
@@ -44,7 +44,7 @@ public final class KvGarbageCollector implements Closeable {
       new ScheduledThreadPoolExecutor(
           2,
           r -> {
-            Thread t = new Thread(r, "KvEntityStore-Garbage-Collector-%d");
+            Thread t = new Thread(r, "KvEntityStore-Garbage-Collector");
             t.setDaemon(true);
             return t;
           },
@@ -188,6 +188,7 @@ public final class KvGarbageCollector implements Closeable {
 
       // All keys in this transaction have been deleted, we can remove the commit mark.
       if (keysDeletedCount == keysInTheTransaction.size()) {
+        LOG.info("Physically delete commit mark: {}", Bytes.wrap(kv.getKey()));
         kvBackend.delete(kv.getKey());
       }
     }

--- a/core/src/main/java/com/datastrato/gravitino/storage/kv/KvGarbageCollector.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/kv/KvGarbageCollector.java
@@ -188,7 +188,6 @@ public final class KvGarbageCollector implements Closeable {
 
       // All keys in this transaction have been deleted, we can remove the commit mark.
       if (keysDeletedCount == keysInTheTransaction.size()) {
-        LOG.info("Physically delete commit mark: {}", Bytes.wrap(kv.getKey()));
         kvBackend.delete(kv.getKey());
       }
     }

--- a/core/src/test/java/com/datastrato/gravitino/meta/TestMetalakeManager.java
+++ b/core/src/test/java/com/datastrato/gravitino/meta/TestMetalakeManager.java
@@ -173,8 +173,6 @@ public class TestMetalakeManager {
           Assertions.assertEquals(v, testProps.get(k));
         });
 
-    Assertions.assertTrue(testProps.containsKey(StringIdentifier.ID_KEY));
-    StringIdentifier StringId = StringIdentifier.fromString(testProps.get(StringIdentifier.ID_KEY));
-    Assertions.assertEquals(StringId.toString(), testProps.get(StringIdentifier.ID_KEY));
+    Assertions.assertFalse(testProps.containsKey(StringIdentifier.ID_KEY));
   }
 }

--- a/trino-connector/build.gradle.kts
+++ b/trino-connector/build.gradle.kts
@@ -13,8 +13,7 @@ repositories {
 }
 
 dependencies {
-//  implementation(project(":clients:client-java-runtime", configuration = "shadow"))
-  implementation(files("/Users/yuqi/Downloads/gravitino-client-java-runtime-0.3.0-SNAPSHOT.jar"))
+  implementation(project(":clients:client-java-runtime", configuration = "shadow"))
   implementation(libs.jackson.databind)
   implementation(libs.jackson.annotations)
   implementation(libs.guava)

--- a/trino-connector/build.gradle.kts
+++ b/trino-connector/build.gradle.kts
@@ -13,7 +13,8 @@ repositories {
 }
 
 dependencies {
-  implementation(project(":clients:client-java-runtime", configuration = "shadow"))
+//  implementation(project(":clients:client-java-runtime", configuration = "shadow"))
+  implementation(files("/Users/yuqi/Downloads/gravitino-client-java-runtime-0.3.0-SNAPSHOT.jar"))
   implementation(libs.jackson.databind)
   implementation(libs.jackson.annotations)
   implementation(libs.guava)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove the `stringId` from metalake property map. 

### Why are the changes needed?

`gravitino.identifier` is generated internally and should not be visible to users.  

Fix: #1047 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Existing UTs can cover it. 
