### PR TITLE
[#1166] fix(docs): Fix typos `graviton` and syntax problems in docs

### DIFF
--- a/docs/how-to-test.md
+++ b/docs/how-to-test.md
@@ -7,7 +7,7 @@ This software is licensed under the Apache License version 2."
 
 Gravitino has two types of tests: unit tests and integration tests. Unit tests are mainly
 focused on the functionalities of the specific class, module, or component. Integration tests
-are end-to-end tests that covers the whole system.
+are end-to-end tests that cover the whole system.
 
 :::note before test
 * If you want to run the complete integration test suites, you need to install Docker in your
@@ -31,15 +31,15 @@ To run the unit test, you can simply run the following command:
 ./gradlew test -PskipITs
 ```
 
-This command runs all the unit tests and skip the integration tests.
+This command runs all the unit tests and skips the integration tests.
 
 ## Run the integration tests
 
-Gravitino has two modes to run the integration tests, the `embedded` and `deploy` modes.
+Gravitino has two modes to run the integration tests, the `embedded`(default) and `deploy` modes.
 
 * With the `embedded` mode, the integration test starts an embedded `MiniGravitino` server
   within the same process of the integration test to run the integration tests.
-* With the `deploy` mode, the user has to deploy a Gravitino binary package beforehand, the
+* With the `deploy` mode, the user has to build(`./gradlew compileDistribution`) a Gravitino binary package beforehand, the
   integration test launches and connects to the local Gravitino server to run the integration
   tests.
 
@@ -153,7 +153,7 @@ server code, follow these steps:
 
 If a test fails, you can retrieve valuable information from the logs and test report. Test reports are in the `./build/reports` directory. The integration test logs are in the `./integrate-test/build` directory. In deploy mode, Gravitino server logs are in the `./distribution/package/logs/` directory. In the event of a test failure within the GitHub workflow, the system generates archived logs and test reports. To obtain the archive, follow these steps:
 
-1. Click the `detail` link associated with the failed integrate test in the pull request. This redirects you to the job page.
+1. Click the `detail` link associated with the failed integrated test in the pull request. This redirects you to the job page.
 
    ![pr page Image](assets/test-fail-pr.png)
 

--- a/docs/how-to-test.md
+++ b/docs/how-to-test.md
@@ -35,11 +35,11 @@ This command runs all the unit tests and skips the integration tests.
 
 ## Run the integration tests
 
-Gravitino has two modes to run the integration tests, the `embedded`(default) and `deploy` modes.
+Gravitino has two modes to run the integration tests, the default `embedded` mode and `deploy` mode.
 
 * With the `embedded` mode, the integration test starts an embedded `MiniGravitino` server
   within the same process of the integration test to run the integration tests.
-* With the `deploy` mode, the user has to build(`./gradlew compileDistribution`) a Gravitino binary package beforehand, the
+* With the `deploy` mode, the user has to build (`./gradlew compileDistribution`) a Gravitino binary package beforehand, the
   integration test launches and connects to the local Gravitino server to run the integration
   tests.
 
@@ -153,7 +153,7 @@ server code, follow these steps:
 
 If a test fails, you can retrieve valuable information from the logs and test report. Test reports are in the `./build/reports` directory. The integration test logs are in the `./integrate-test/build` directory. In deploy mode, Gravitino server logs are in the `./distribution/package/logs/` directory. In the event of a test failure within the GitHub workflow, the system generates archived logs and test reports. To obtain the archive, follow these steps:
 
-1. Click the `detail` link associated with the failed integrated test in the pull request. This redirects you to the job page.
+1. Click the `detail` link associated with the failed integration test in the pull request. This redirects you to the job page.
 
    ![pr page Image](assets/test-fail-pr.png)
 

--- a/docs/iceberg-rest-service.md
+++ b/docs/iceberg-rest-service.md
@@ -61,7 +61,7 @@ The Gravitino Iceberg REST catalog service using memory catalog for default. You
 | `gravitino.auxService.iceberg-rest.uri`             | The Hive metadata address, such as `thrift://127.0.0.1:9083`.                                               | (none)        | Yes        | 0.2.0         |
 | `gravitino.auxService.iceberg-rest.warehouse `      | The warehouse directory of the Hive catalog, such as `/user/hive/warehouse-hive/`.                          | (none)        | Yes        | 0.2.0         |
 
-#### JDBC catalog configuration
+#### Iceberg JDBC backend configuration
 
 | Configuration item                                  | Description                                                                                                                        | Default value | Required | Since Version |
 |-----------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|---------------|----------|---------------|

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,8 +18,8 @@ metadata access for data and AI assets.
 You can get Gravitino from the [GitHub release page](https://github.com/datastrato/gravitino/releases),
 or you can build Gravitino from source code, please see [How to build Gravitino](./how-to-build.md).
 
-Gravitino runs on both Linux and macOS, and requires at least Java 8. Gravitino trino-connector runs with
-Trino, and requires at least Java 17. This should include JVMs on x86_64 and
+Gravitino runs on both Linux and macOS, and requires Java 8. Gravitino trino-connector runs with
+Trino, and requires Java 17. This should include JVMs on x86_64 and
 ARM64. It's easy to run locally on one machine --- all you need is to have `java` installed on
 your system `PATH`, or the `JAVA_HOME` environment variable pointing to a Java installation.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,11 +15,11 @@ metadata access for data and AI assets.
 
 ## Downloading
 
-You can get Graviton from the [GitHub release page](https://github.com/datastrato/gravitino/releases),
-or you can build Gravitino from source, please see [How to build Gravitino](./how-to-build.md).
+You can get Gravitino from the [GitHub release page](https://github.com/datastrato/gravitino/releases),
+or you can build Gravitino from source code, please see [How to build Gravitino](./how-to-build.md).
 
-Gravitino runs on both Linux and macOS, and requires Java 8. Gravitino trino-connector runs with
-Trino, and requires Java 17. This should include JVMs on x86_64 and
+Gravitino runs on both Linux and macOS, and requires at least Java 8. Gravitino trino-connector runs with
+Trino, and requires at least Java 17. This should include JVMs on x86_64 and
 ARM64. It's easy to run locally on one machine --- all you need is to have `java` installed on
 your system `PATH`, or the `JAVA_HOME` environment variable pointing to a Java installation.
 
@@ -46,7 +46,7 @@ To get started with Gravitino, please see [Getting started](./getting-started.md
 
 ## Gravitino playground
 
-To experience Gravitino with other components simply, Gravitino provides a playground to run. It
+To experience Gravitino with other components easily, Gravitino provides a playground to run. It
 integrates Apache Hadoop, Apache Hive, Trino, MySQL, PostgreSQL, and Gravitino together as a
 complete environment. To experience the whole features, please also see
 [Getting started](./getting-started.md) and [How to use the Gravitino playground](./how-to-use-the-playground.md)
@@ -98,7 +98,7 @@ Gravitino supports different catalogs to manage the metadata in different source
 Gravitino provides a Trino connector to connect to Gravitino to manage the metadata in a unified
 way. to use the Trino connector, please see:
 
-* [How to use Gravitino Trino connector](./trino-connector/index): a complete guide to use Gravitino
+* [How to use Gravitino Trino connector](./trino-connector/index.md): a complete guide to use Gravitino
   Trino connector.
 
 ### Development guides


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Fix typo `Graviton` in `index.md` 
- Fix link mistakes in `index.md` and other sentence problems

### Why are the changes needed?

To Improve the professionalism and rigor of documents 

Fixed #1166 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

N/A.
