### PR TITLE
[#877] improvement(web): optimize clean task of build.gradle.kts for web to delete node_modules folder

### DIFF
--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -52,7 +52,10 @@ tasks {
   }
 
   clean {
+    delete(".node")
     delete("build")
     delete("dist")
+    delete("node_modules")
+    delete("yarn-error.log")
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Optimize clean task of `build.gradle.kts` for web to delete `node_modules` folder which reduces space after gradle clean.

### Why are the changes needed?

The `node_modules` folder contains libraries downloaded from npm that takes up a lot of space.

Fix: #877

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Test with gradle clean.