### PR TITLE
[#995] improvement(test): Remove annotation Order to alleviate test sequence dependency

### DIFF
--- a/core/src/test/java/com/datastrato/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/com/datastrato/gravitino/catalog/TestCatalogManager.java
@@ -34,13 +34,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 import org.mockito.Mockito;
 
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class TestCatalogManager {
 
   private static CatalogManager catalogManager;
@@ -136,7 +132,6 @@ public class TestCatalogManager {
   }
 
   @Test
-  @Order(1)
   void testLoadTable() throws IOException {
     NameIdentifier ident = NameIdentifier.of("metalake", "test444");
     // key1 is required;
@@ -161,7 +156,6 @@ public class TestCatalogManager {
   }
 
   @Test
-  @Order(2)
   void testPropertyValidationInAlter() throws IOException {
     // key1 is required and immutable and do not have default value, is not hidden and not reserved
     // key2 is required and mutable and do not have default value, is not hidden and not reserved
@@ -228,7 +222,6 @@ public class TestCatalogManager {
   }
 
   @Test
-  @Order(3)
   void testPropertyValidationInCreate() throws IOException {
     // key1 is required and immutable and do not have default value, is not hidden and not reserved
     // key2 is required and mutable and do not have default value, is not hidden and not reserved

--- a/core/src/test/java/com/datastrato/gravitino/storage/kv/TestEntityKeyEncoding.java
+++ b/core/src/test/java/com/datastrato/gravitino/storage/kv/TestEntityKeyEncoding.java
@@ -29,16 +29,12 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.ClassOrderer.OrderAnnotation;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestClassOrder;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.mockito.Mockito;
 
 @TestInstance(Lifecycle.PER_CLASS)
-@TestClassOrder(OrderAnnotation.class)
 public class TestEntityKeyEncoding {
   private Config getConfig() throws IOException {
     File baseDir = new File(System.getProperty("java.io.tmpdir"));
@@ -75,7 +71,6 @@ public class TestEntityKeyEncoding {
   }
 
   @Test
-  @Order(1)
   public void testIdentifierEncoding()
       throws IOException, IllegalAccessException, NoSuchFieldException {
     Config config = getConfig();
@@ -192,7 +187,6 @@ public class TestEntityKeyEncoding {
   }
 
   @Test
-  @Order(10)
   public void testNamespaceEncoding()
       throws IOException, IllegalAccessException, NoSuchFieldException {
     Config config = getConfig();

--- a/core/src/test/java/com/datastrato/gravitino/storage/kv/TestKvNameMappingService.java
+++ b/core/src/test/java/com/datastrato/gravitino/storage/kv/TestKvNameMappingService.java
@@ -23,13 +23,9 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.ClassOrderer.OrderAnnotation;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestClassOrder;
 import org.mockito.Mockito;
 
-@TestClassOrder(OrderAnnotation.class)
 public class TestKvNameMappingService {
   private Config getConfig() throws IOException {
     File baseDir = new File(System.getProperty("java.io.tmpdir"));
@@ -63,7 +59,6 @@ public class TestKvNameMappingService {
   }
 
   @Test
-  @Order(1)
   public void testGetIdByName() throws Exception {
     try (KvEntityStore kvEntityStore = getKvEntityStore(getConfig())) {
       NameMappingService nameMappingService = kvEntityStore.nameMappingService;
@@ -85,7 +80,6 @@ public class TestKvNameMappingService {
   }
 
   @Test
-  @Order(2)
   public void testUpdateName() throws Exception {
     try (KvEntityStore kvEntityStore = getKvEntityStore(getConfig())) {
       NameMappingService nameMappingService = kvEntityStore.nameMappingService;
@@ -111,7 +105,6 @@ public class TestKvNameMappingService {
   }
 
   @Test
-  @Order(3)
   public void testBindAndUnBind() throws Exception {
     try (KvEntityStore kvEntityStore = getKvEntityStore(getConfig())) {
       KvNameMappingService nameMappingService =

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/CatalogMysqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/CatalogMysqlIT.java
@@ -48,14 +48,11 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 import org.testcontainers.containers.MySQLContainer;
 
 @Tag("gravitino-docker-it")
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class CatalogMysqlIT extends AbstractIT {
   public static String metalakeName = GravitinoITUtils.genRandomName("mysql_it_metalake");
   public static String catalogName = GravitinoITUtils.genRandomName("mysql_it_catalog");

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
@@ -44,14 +44,11 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 @Tag("gravitino-docker-it")
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class CatalogPostgreSqlIT extends AbstractIT {
   public static String metalakeName = GravitinoITUtils.genRandomName("postgresql_it_metalake");
   public static String catalogName = GravitinoITUtils.genRandomName("postgresql_it_catalog");

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/lakehouse/iceberg/CatalogIcebergIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/lakehouse/iceberg/CatalogIcebergIT.java
@@ -67,13 +67,10 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 
 @Tag("gravitino-docker-it")
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class CatalogIcebergIT extends AbstractIT {
   public static String metalakeName = GravitinoITUtils.genRandomName("iceberg_it_metalake");
   public static String catalogName = GravitinoITUtils.genRandomName("iceberg_it_catalog");

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/TrinoContainer.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/TrinoContainer.java
@@ -32,10 +32,6 @@ public class TrinoContainer extends BaseContainer {
 
   static Connection trinoJdbcConnection = null;
 
-  public static final String TRINO_CONF_GRAVITINO_URI = "gravitino.uri";
-  public static final String TRINO_CONF_GRAVITINO_METALAKE = "gravitino.metalake";
-  public static final String TRINO_CONF_HIVE_METASTORE_URI = "hive.metastore.uri";
-  public static final String TRINO_CONTAINER_CONF_DIR = "/etc/trino";
   public static final String TRINO_CONTAINER_PLUGIN_GRAVITINO_DIR =
       "/usr/lib/trino/plugin/gravitino";
 
@@ -50,11 +46,7 @@ public class TrinoContainer extends BaseContainer {
       Map<String, String> extraHosts,
       Map<String, String> filesToMount,
       Map<String, String> envVars,
-      Optional<Network> network,
-      String trinoConfDir,
-      InetSocketAddress gravitinoServerAddress,
-      String metalakeName,
-      String hiveContainerIP) {
+      Optional<Network> network) {
     super(image, hostName, ports, extraHosts, filesToMount, envVars, network);
   }
 
@@ -229,17 +221,7 @@ public class TrinoContainer extends BaseContainer {
     @Override
     public TrinoContainer build() {
       return new TrinoContainer(
-          image,
-          hostName,
-          exposePorts,
-          extraHosts,
-          filesToMount,
-          envVars,
-          network,
-          trinoConfDir,
-          gravitinoServerAddress,
-          metalakeName,
-          hiveContainerIP);
+          image, hostName, exposePorts, extraHosts, filesToMount, envVars, network);
     }
   }
 }

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoConnectorIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoConnectorIT.java
@@ -36,16 +36,12 @@ import org.apache.thrift.TException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Tag("gravitino-docker-it")
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class TrinoConnectorIT extends AbstractIT {
   public static final Logger LOG = LoggerFactory.getLogger(TrinoConnectorIT.class);
 
@@ -142,7 +138,6 @@ public class TrinoConnectorIT extends AbstractIT {
   }
 
   @Test
-  @Order(1)
   public void testShowSchemas() {
     String sql =
         String.format(
@@ -153,7 +148,6 @@ public class TrinoConnectorIT extends AbstractIT {
   }
 
   @Test
-  @Order(2)
   public void testCreateTable() throws TException, InterruptedException {
     String sql3 =
         String.format(
@@ -178,11 +172,11 @@ public class TrinoConnectorIT extends AbstractIT {
         hiveClientPool.run(client -> client.getTable(databaseName, tab1Name));
     Assertions.assertEquals(databaseName, hiveTab1.getDbName());
     Assertions.assertEquals(tab1Name, hiveTab1.getTableName());
+
+    testShowTable();
   }
 
-  @Order(3)
-  @Test
-  public void testShowTable() {
+  void testShowTable() {
     String sql =
         String.format(
             "SHOW TABLES FROM \"%s.%s\".%s LIKE '%s'",
@@ -192,8 +186,6 @@ public class TrinoConnectorIT extends AbstractIT {
     Assertions.assertEquals(queryData.get(0).get(0), tab1Name);
   }
 
-  @Test
-  @Order(4)
   public void testScenarioTable1() throws TException, InterruptedException {
     String sql3 =
         String.format(
@@ -260,8 +252,6 @@ public class TrinoConnectorIT extends AbstractIT {
     Assertions.assertEquals(table1Data, table1QueryData);
   }
 
-  @Test
-  @Order(5)
   public void testScenarioTable2() throws TException, InterruptedException {
     String sql4 =
         String.format(
@@ -326,8 +316,10 @@ public class TrinoConnectorIT extends AbstractIT {
   }
 
   @Test
-  @Order(6)
-  public void testScenarioJoinTwoTable() {
+  public void testScenarioJoinTwoTable() throws TException, InterruptedException {
+    testScenarioTable1();
+    testScenarioTable2();
+
     String sql9 =
         String.format(
             "SELECT * FROM (SELECT t1.user_name as user_name, gender, age, phone, consumer, recharge, event_time FROM \"%1$s.%2$s\".%3$s.%4$s AS t1\n"
@@ -355,7 +347,6 @@ public class TrinoConnectorIT extends AbstractIT {
   }
 
   @Test
-  @Order(7)
   void testHiveSchemaCreatedByTrino() {
     String schemaName = GravitinoITUtils.genRandomName("schema").toLowerCase();
 
@@ -373,7 +364,6 @@ public class TrinoConnectorIT extends AbstractIT {
   }
 
   @Test
-  @Order(8)
   void testHiveTableCreatedByTrino() {
     String schemaName = GravitinoITUtils.genRandomName("schema").toLowerCase();
     String tableName = GravitinoITUtils.genRandomName("table").toLowerCase();
@@ -400,7 +390,6 @@ public class TrinoConnectorIT extends AbstractIT {
   }
 
   @Test
-  @Order(9)
   void testHiveSchemaCreatedByGravitino() throws InterruptedException {
     String catalogName = GravitinoITUtils.genRandomName("catalog").toLowerCase();
     String schemaName = GravitinoITUtils.genRandomName("schema").toLowerCase();
@@ -551,7 +540,6 @@ public class TrinoConnectorIT extends AbstractIT {
   }
 
   @Test
-  @Order(10)
   void testHiveTableCreatedByGravitino() throws InterruptedException {
     String catalogName = GravitinoITUtils.genRandomName("catalog").toLowerCase();
     String schemaName = GravitinoITUtils.genRandomName("schema").toLowerCase();
@@ -624,7 +612,6 @@ public class TrinoConnectorIT extends AbstractIT {
   }
 
   @Test
-  @Order(11)
   void testHiveCatalogCreatedByGravitino() throws InterruptedException {
     String catalogName = GravitinoITUtils.genRandomName("catalog").toLowerCase();
     GravitinoMetaLake createdMetalake = client.loadMetalake(NameIdentifier.of(metalakeName));
@@ -663,7 +650,6 @@ public class TrinoConnectorIT extends AbstractIT {
   }
 
   @Test
-  @Order(12)
   void testWrongHiveCatalogProperty() throws InterruptedException {
     String catalogName = GravitinoITUtils.genRandomName("catalog").toLowerCase();
     GravitinoMetaLake createdMetalake = client.loadMetalake(NameIdentifier.of(metalakeName));
@@ -697,7 +683,6 @@ public class TrinoConnectorIT extends AbstractIT {
     Assertions.assertTrue(containerSuite.getTrinoContainer().executeQuerySQL(sql).isEmpty());
   }
 
-  @Order(13)
   @Test
   void testIcebergTableAndSchemaCreatedByGravitino() throws InterruptedException {
     String catalogName = GravitinoITUtils.genRandomName("catalog").toLowerCase();
@@ -767,7 +752,6 @@ public class TrinoConnectorIT extends AbstractIT {
   }
 
   @Test
-  @Order(14)
   void testIcebergTableAndSchemaCreatedByTrino() {
     String schemaName = GravitinoITUtils.genRandomName("schema").toLowerCase();
     String tableName = GravitinoITUtils.genRandomName("table").toLowerCase();
@@ -790,7 +774,6 @@ public class TrinoConnectorIT extends AbstractIT {
   }
 
   @Test
-  @Order(15)
   void testIcebergCatalogCreatedByGravitino() throws InterruptedException {
     String catalogName = GravitinoITUtils.genRandomName("iceberg_catalog").toLowerCase();
     GravitinoMetaLake createdMetalake = client.loadMetalake(NameIdentifier.of(metalakeName));
@@ -837,7 +820,6 @@ public class TrinoConnectorIT extends AbstractIT {
   }
 
   @Test
-  @Order(16)
   void testMySQLCatalogCreatedByGravitino() throws InterruptedException {
     String catalogName = GravitinoITUtils.genRandomName("mysql_catalog").toLowerCase();
     GravitinoMetaLake createdMetalake = client.loadMetalake(NameIdentifier.of(metalakeName));
@@ -878,7 +860,6 @@ public class TrinoConnectorIT extends AbstractIT {
   }
 
   @Test
-  @Order(17)
   void testMySQLTableCreatedByGravitino() throws InterruptedException {
     String catalogName = GravitinoITUtils.genRandomName("mysql_catalog").toLowerCase();
     String schemaName = GravitinoITUtils.genRandomName("mysql_schema").toLowerCase();


### PR DESCRIPTION

### What changes were proposed in this pull request?

Remove Junit5 annotation `Order` in test.

### Why are the changes needed?

We need to remove sequence dependencies between test cases so that we can run them in parallelism. 

Fix: #995 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Only changes to the test code have been made.
