### PR TITLE
[#879][#925] Docker network Pool overlaps with other one on this address space

### DIFF
--- a/dev/docker/tools/docker-connector.conf
+++ b/dev/docker/tools/docker-connector.conf
@@ -5,4 +5,4 @@
 
 # Fixed docker container network subnet in Gravitino integration testing module
 # Generate command: `docker network ls --filter driver=bridge --format "{{.ID}}" | xargs docker network inspect --format "route {{range .IPAM.Config}}{{.Subnet}}{{end}}" > ${bin}/docker-connector.conf`
-route 10.0.0.0/22
+route 10.20.30.0/26

--- a/dev/docker/tools/docker-connector.conf
+++ b/dev/docker/tools/docker-connector.conf
@@ -5,4 +5,4 @@
 
 # Fixed docker container network subnet in Gravitino integration testing module
 # Generate command: `docker network ls --filter driver=bridge --format "{{.ID}}" | xargs docker network inspect --format "route {{range .IPAM.Config}}{{.Subnet}}{{end}}" > ${bin}/docker-connector.conf`
-route 10.20.30.0/26
+route 10.20.30.0/28

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -271,6 +271,15 @@ tasks.test {
       environment("PROJECT_VERSION", version)
       environment("TRINO_CONF_DIR", buildDir.path + "/trino-conf")
 
+      val dockerRunning = project.extra["dockerRunning"] as? Boolean ?: false
+      val macDockerConnector = project.extra["macDockerConnector"] as? Boolean ?: false
+      if (OperatingSystem.current().isMacOsX() &&
+        dockerRunning &&
+        macDockerConnector
+      ) {
+        environment("NEED_CREATE_DOCKER_NETWORK", "true")
+      }
+
       // Gravitino CI Docker image
       environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "datastrato/gravitino-ci-hive:0.1.6")
       environment("GRAVITINO_CI_TRINO_DOCKER_IMAGE", "datastrato/gravitino-ci-trino:0.1.2")

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/BaseContainer.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/BaseContainer.java
@@ -189,7 +189,7 @@ public abstract class BaseContainer implements AutoCloseable {
     }
 
     public SELF withNetwork(Network network) {
-      this.network = network != null ? Optional.of(network) : Optional.empty();
+      this.network = Optional.ofNullable(network);
       return self;
     }
 

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/BaseContainer.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/BaseContainer.java
@@ -189,7 +189,7 @@ public abstract class BaseContainer implements AutoCloseable {
     }
 
     public SELF withNetwork(Network network) {
-      this.network = Optional.of(network);
+      this.network = network != null ? Optional.of(network) : Optional.empty();
       return self;
     }
 

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
@@ -221,6 +221,8 @@ public class ContainerSuite implements Closeable {
     return result.toString();
   }
 
+  // Classless Inter-Domain Routing (CIDR)
+  // https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing
   private static long[] cidrToRange(String cidr) throws Exception {
     String[] parts = cidr.split("/");
     InetAddress inetAddress = InetAddress.getByName(parts[0]);

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
@@ -17,7 +17,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.List;
-import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.DockerClientFactory;
@@ -46,8 +45,8 @@ public class ContainerSuite implements Closeable {
       Info info = dockerClient.infoCmd().exec();
       LOG.info("Docker info: {}", info);
 
-      if (System.getenv("NEED_CREATE_DOCKER_NETWORK") != null
-          && Objects.equals(System.getenv("NEED_CREATE_DOCKER_NETWORK"), "true")) {
+      String needCreateDockerNetwork = System.getenv("NEED_CREATE_DOCKER_NETWORK");
+      if (needCreateDockerNetwork != null && needCreateDockerNetwork.equalsIgnoreCase("true")) {
         network = createDockerNetwork();
       }
     } catch (Exception e) {

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
@@ -45,8 +45,7 @@ public class ContainerSuite implements Closeable {
       Info info = dockerClient.infoCmd().exec();
       LOG.info("Docker info: {}", info);
 
-      String needCreateDockerNetwork = System.getenv("NEED_CREATE_DOCKER_NETWORK");
-      if (needCreateDockerNetwork != null && needCreateDockerNetwork.equalsIgnoreCase("true")) {
+      if ("true".equalsIgnoreCase(System.getenv("NEED_CREATE_DOCKER_NETWORK"))) {
         network = createDockerNetwork();
       }
     } catch (Exception e) {

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/NetworksConflictTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/NetworksConflictTest.java
@@ -10,15 +10,15 @@ import org.junit.jupiter.api.Test;
 public class NetworksConflictTest {
   @Test
   public void networksConflictTest1() throws Exception {
-    final String subnet1 = "10.20.30.0/26"; // allocate IP ranger 10.20.30.1 ~ 10.20.30.62
-    final String subnet2 = "10.20.30.0/24"; // allocate IP ranger is 10.20.30.1 ~ 10.20.30.254
+    final String subnet1 = "10.20.30.0/28"; // allocate IP ranger 10.20.30.1 ~ 10.20.30.14
+    final String subnet2 = "10.20.30.0/26"; // allocate IP ranger is 10.20.30.1 ~ 10.20.30.62
     Assertions.assertTrue(ContainerSuite.ipRangesOverlap(subnet1, subnet2));
   }
 
   @Test
   public void networksConflictTest2() throws Exception {
-    final String subnet1 = "10.20.30.0/26"; // allocate IP ranger is 10.20.30.1 ~ 10.20.30.62
-    final String subnet2 = "10.20.31.0/26"; // allocate IP ranger is 10.20.31.1 ~ 10.20.31.62
+    final String subnet1 = "10.20.30.0/28"; // allocate IP ranger is 10.20.30.1 ~ 10.20.30.14
+    final String subnet2 = "10.20.31.0/28"; // allocate IP ranger is 10.20.31.1 ~ 10.20.31.14
     Assertions.assertFalse(ContainerSuite.ipRangesOverlap(subnet1, subnet2));
   }
 }

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/NetworksConflictTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/NetworksConflictTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.integration.test.container;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class NetworksConflictTest {
+  @Test
+  public void networksConflictTest1() throws Exception {
+    final String subnet1 = "10.20.30.0/26"; // allocate IP ranger 10.20.30.1 ~ 10.20.30.62
+    final String subnet2 = "10.20.30.0/24"; // allocate IP ranger is 10.20.30.1 ~ 10.20.30.254
+    Assertions.assertTrue(ContainerSuite.ipRangesOverlap(subnet1, subnet2));
+  }
+
+  @Test
+  public void networksConflictTest2() throws Exception {
+    final String subnet1 = "10.20.30.0/26"; // allocate IP ranger is 10.20.30.1 ~ 10.20.30.62
+    final String subnet2 = "10.20.31.0/26"; // allocate IP ranger is 10.20.31.1 ~ 10.20.31.62
+    Assertions.assertFalse(ContainerSuite.ipRangesOverlap(subnet1, subnet2));
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Added Docker network overlap detection
2. Reduced IP allocation ranges for lower conflict probability, Modified to `10.20.30.0/28` only allocate IP ranger `10.20.30.1` ~ `10.20.30.14`
3. Docker network only created on MacOS and default Docker server environment

### Why are the changes needed?

Fix: #879, #925

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

CI
