### PR TITLE
[#1231] Fix bugs in drop MySQL schemas

### DIFF
--- a/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlDatabaseOperations.java
@@ -12,6 +12,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.collections4.MapUtils;
@@ -53,16 +54,14 @@ public class MysqlDatabaseOperations extends JdbcDatabaseOperations {
     }
 
     try (final Connection connection = this.dataSource.getConnection()) {
-      String query = "SELECT * FROM information_schema.TABLES WHERE TABLE_SCHEMA = ?";
-      try (PreparedStatement preparedStatement = connection.prepareStatement(query)) {
-        preparedStatement.setString(1, databaseName);
-
+      String query = "SHOW TABLES IN " + databaseName;
+      try (Statement statement = connection.createStatement()) {
         // Execute the query and check if there exists any tables in the database
-        try (ResultSet resultSet = preparedStatement.executeQuery()) {
+        try (ResultSet resultSet = statement.executeQuery(query)) {
           if (resultSet.next()) {
             throw new IllegalStateException(
                 String.format(
-                    "Database %s is not empty. the value of cascade should be true.",
+                    "Database %s is not empty, the value of cascade should be true.",
                     databaseName));
           }
         }

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/TestJdbcAbstractIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/TestJdbcAbstractIT.java
@@ -62,17 +62,7 @@ public abstract class TestJdbcAbstractIT {
 
   protected static void testDropDatabase(String databaseName) {
     List<String> databases;
-    // delete database.
-    UnsupportedOperationException unsupportedOperationException =
-        Assertions.assertThrows(
-            UnsupportedOperationException.class,
-            () -> DATABASE_OPERATIONS.delete(databaseName, true));
-    Assertions.assertTrue(
-        unsupportedOperationException
-            .getMessage()
-            .contains("does not support CASCADE option for DROP DATABASE."));
-
-    Assertions.assertDoesNotThrow(() -> DATABASE_OPERATIONS.delete(databaseName, false));
+    DATABASE_OPERATIONS.delete(databaseName, true);
 
     Assertions.assertThrows(
         NoSuchSchemaException.class, () -> DATABASE_OPERATIONS.load(databaseName));

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/CatalogMysqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/CatalogMysqlIT.java
@@ -120,7 +120,7 @@ public class CatalogMysqlIT extends AbstractIT {
     NameIdentifier[] nameIdentifiers =
         catalog.asTableCatalog().listTables(Namespace.of(metalakeName, catalogName, schemaName));
     for (NameIdentifier nameIdentifier : nameIdentifiers) {
-      catalog.asTableCatalog().dropTable(nameIdentifier);
+      catalog.asTableCatalog().purgeTable(nameIdentifier);
     }
     catalog.asSchemas().dropSchema(NameIdentifier.of(metalakeName, catalogName, schemaName), false);
   }
@@ -455,5 +455,41 @@ public class CatalogMysqlIT extends AbstractIT {
         () -> {
           catalog.asTableCatalog().dropTable(tableIdentifier);
         });
+  }
+
+  @Test
+  void testDropMySQLDatabase() {
+    String schemaName = GravitinoITUtils.genRandomName("mysql_schema").toLowerCase();
+    String tableName = GravitinoITUtils.genRandomName("mysql_table").toLowerCase();
+
+    catalog
+        .asSchemas()
+        .createSchema(
+            NameIdentifier.of(metalakeName, catalogName, schemaName),
+            "Created by gravitino client",
+            ImmutableMap.<String, String>builder().build());
+
+    catalog
+        .asTableCatalog()
+        .createTable(
+            NameIdentifier.of(metalakeName, catalogName, schemaName, tableName),
+            createColumns(),
+            "Created by gravitino client",
+            ImmutableMap.<String, String>builder().build());
+
+    // Try to drop MySQL database without cascade equals to false, it should not be allowed.
+    catalog.asSchemas().dropSchema(NameIdentifier.of(metalakeName, catalogName, schemaName), false);
+    // Check database still exists
+    catalog.asSchemas().loadSchema(NameIdentifier.of(metalakeName, catalogName, schemaName));
+
+    // Try to drop MySQL database with cascade equals to true, it should be allowed.
+    catalog.asSchemas().dropSchema(NameIdentifier.of(metalakeName, catalogName, schemaName), true);
+    // Check database has been dropped
+    Assertions.assertThrows(
+        NoSuchSchemaException.class,
+        () ->
+            catalog
+                .asSchemas()
+                .loadSchema(NameIdentifier.of(metalakeName, catalogName, schemaName)));
   }
 }

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/CatalogMysqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/CatalogMysqlIT.java
@@ -477,12 +477,12 @@ public class CatalogMysqlIT extends AbstractIT {
             "Created by gravitino client",
             ImmutableMap.<String, String>builder().build());
 
-    // Try to drop MySQL database without cascade equals to false, it should not be allowed.
+    // Try to drop a database, and cascade equals to false, it should not be allowed.
     catalog.asSchemas().dropSchema(NameIdentifier.of(metalakeName, catalogName, schemaName), false);
-    // Check database still exists
+    // Check the database still exists
     catalog.asSchemas().loadSchema(NameIdentifier.of(metalakeName, catalogName, schemaName));
 
-    // Try to drop MySQL database with cascade equals to true, it should be allowed.
+    // Try to drop a database, and cascade equals to true, it should be allowed.
     catalog.asSchemas().dropSchema(NameIdentifier.of(metalakeName, catalogName, schemaName), true);
     // Check database has been dropped
     Assertions.assertThrows(


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Allow dropping a database when `cascase` is `true`.
- If the database is not empty and `cascade` is `false`, disable the drop operation. 

### Why are the changes needed?

Align the logic with Gravitino EntityStore.

Fix: #1231 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Add UT `testDropMySQLDatabase`
