### PR TITLE
[MINOR] refactor: Use  replace `isEmpty()` replace `size() == 0`

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/aux/AuxiliaryServiceManager.java
+++ b/core/src/main/java/com/datastrato/gravitino/aux/AuxiliaryServiceManager.java
@@ -53,7 +53,7 @@ public class AuxiliaryServiceManager {
             .map(GravitinoAuxiliaryService::getClass)
             .collect(Collectors.toList());
 
-    if (providers.size() == 0) {
+    if (providers.isEmpty()) {
       throw new IllegalArgumentException("No GravitinoAuxiliaryService found for: " + provider);
     } else if (providers.size() > 1) {
       throw new IllegalArgumentException(

--- a/core/src/main/java/com/datastrato/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/CatalogManager.java
@@ -593,7 +593,7 @@ public class CatalogManager implements SupportsCatalogs, Closeable {
             .map(CatalogProvider::getClass)
             .collect(Collectors.toList());
 
-    if (providers.size() == 0) {
+    if (providers.isEmpty()) {
       throw new IllegalArgumentException("No catalog provider found for: " + provider);
     } else if (providers.size() > 1) {
       throw new IllegalArgumentException("Multiple catalog providers found for: " + provider);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Some collections have O(n) size method, it's a good way to use `isEmpty`. 

### Why are the changes needed?
Improve the quality of code.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI passed.
