### PR TITLE
[#1279] feat(jdbc): MySQL supports auto_increment

### DIFF
--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
@@ -385,6 +385,7 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
                         .withType(column.dataType())
                         .withComment(column.comment())
                         .withNullable(column.nullable())
+                        .withAutoIncrement(column.autoIncrement())
                         .build())
             .toArray(JdbcColumn[]::new);
     String databaseName = NameIdentifier.of(tableIdent.namespace().levels()).name();

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcColumn.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcColumn.java
@@ -5,28 +5,14 @@
 package com.datastrato.gravitino.catalog.jdbc;
 
 import com.datastrato.gravitino.catalog.rel.BaseColumn;
-import java.util.List;
 
 /** Represents a column in the Jdbc column. */
 public class JdbcColumn extends BaseColumn {
-  private List<String> properties;
 
   private JdbcColumn() {}
 
-  public List<String> getProperties() {
-    return properties;
-  }
-
   /** A builder class for constructing JdbcColumn instances. */
   public static class Builder extends BaseColumnBuilder<Builder, JdbcColumn> {
-
-    /** Attribute value of the field, such as AUTO_INCREMENT, PRIMARY KEY, etc. */
-    private List<String> properties;
-
-    public Builder withProperties(List<String> properties) {
-      this.properties = properties;
-      return this;
-    }
 
     /**
      * Internal method to build a JdbcColumn instance using the provided values.
@@ -41,7 +27,6 @@ public class JdbcColumn extends BaseColumn {
       jdbcColumn.dataType = dataType;
       jdbcColumn.nullable = nullable;
       jdbcColumn.defaultValue = defaultValue;
-      jdbcColumn.properties = properties;
       jdbcColumn.autoIncrement = autoIncrement;
       return jdbcColumn;
     }

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/operation/JdbcTableOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/operation/JdbcTableOperations.java
@@ -282,7 +282,6 @@ public abstract class JdbcTableOperations implements TableOperation {
         .withName(column.getString("COLUMN_NAME"))
         .withType(typeConverter.toGravitinoType(typeBean))
         .withComment(StringUtils.isEmpty(comment) ? null : comment)
-        .withNullable(column.getBoolean("NULLABLE"))
-        .withProperties(Collections.emptyList());
+        .withNullable(column.getBoolean("NULLABLE"));
   }
 }

--- a/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlTableOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlTableOperations.java
@@ -19,6 +19,7 @@ import com.datastrato.gravitino.rel.TableChange;
 import com.datastrato.gravitino.rel.expressions.transforms.Transform;
 import com.datastrato.gravitino.rel.indexes.Index;
 import com.datastrato.gravitino.rel.indexes.Indexes;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
 import java.sql.Connection;
@@ -33,6 +34,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
@@ -45,6 +47,7 @@ import org.apache.commons.lang3.StringUtils;
 public class MysqlTableOperations extends JdbcTableOperations {
 
   public static final String BACK_QUOTE = "`";
+  public static final String MYSQL_AUTO_INCREMENT = "AUTO_INCREMENT";
 
   @Override
   public List<String> listTables(String databaseName) throws NoSuchSchemaException {
@@ -88,6 +91,7 @@ public class MysqlTableOperations extends JdbcTableOperations {
     if (ArrayUtils.isNotEmpty(partitioning)) {
       throw new UnsupportedOperationException("Currently we do not support Partitioning in mysql");
     }
+    validateIncrementCol(columns, indexes);
     StringBuilder sqlBuilder = new StringBuilder();
     sqlBuilder.append("CREATE TABLE ").append(tableName).append(" (\n");
 
@@ -130,6 +134,37 @@ public class MysqlTableOperations extends JdbcTableOperations {
 
     LOG.info("Generated create table:{} sql: {}", tableName, result);
     return result;
+  }
+
+  private static void validateIncrementCol(JdbcColumn[] columns, Index[] indexes) {
+    // Check auto increment column
+    List<JdbcColumn> autoIncrementCols =
+        Arrays.stream(columns).filter(Column::autoIncrement).collect(Collectors.toList());
+    String autoIncrementColsStr =
+        autoIncrementCols.stream().map(JdbcColumn::name).collect(Collectors.joining(",", "[", "]"));
+    Preconditions.checkArgument(
+        autoIncrementCols.size() <= 1,
+        "Only one column can be auto-incremented. There are multiple auto-increment columns in your table: "
+            + autoIncrementColsStr);
+    if (!autoIncrementCols.isEmpty()) {
+      Optional<Index> existAutoIncrementColIndexOptional =
+          Arrays.stream(indexes)
+              .filter(
+                  index ->
+                      Arrays.stream(index.fieldNames())
+                          .flatMap(Arrays::stream)
+                          .anyMatch(
+                              s ->
+                                  StringUtils.equalsIgnoreCase(autoIncrementCols.get(0).name(), s)))
+              .filter(
+                  index ->
+                      index.type() == Index.IndexType.PRIMARY_KEY
+                          || index.type() == Index.IndexType.UNIQUE_KEY)
+              .findAny();
+      Preconditions.checkArgument(
+          existAutoIncrementColIndexOptional.isPresent(),
+          "Incorrect table definition; there can be only one auto column and it must be defined as a key");
+    }
   }
 
   public static void appendIndexesSql(Index[] indexes, StringBuilder sqlBuilder) {
@@ -366,9 +401,9 @@ public class MysqlTableOperations extends JdbcTableOperations {
             // TODO #1531 will add default value.
             .withDefaultValue(null)
             .withNullable(change.nullable())
-            .withProperties(column.getProperties())
             .withType(column.dataType())
             .withComment(column.comment())
+            .withAutoIncrement(column.autoIncrement())
             .build();
     return "MODIFY COLUMN " + col + appendColumnDefinition(updateColumn, new StringBuilder());
   }
@@ -400,9 +435,9 @@ public class MysqlTableOperations extends JdbcTableOperations {
             // TODO #1531 will add default value.
             .withDefaultValue(null)
             .withNullable(column.nullable())
-            .withProperties(column.getProperties())
             .withType(column.dataType())
             .withComment(newComment)
+            .withAutoIncrement(column.autoIncrement())
             .build();
     return "MODIFY COLUMN " + col + appendColumnDefinition(updateColumn, new StringBuilder());
   }
@@ -455,10 +490,10 @@ public class MysqlTableOperations extends JdbcTableOperations {
             .withName(newColumnName)
             .withType(column.dataType())
             .withComment(column.comment())
-            .withProperties(column.getProperties())
             // TODO #1531 will add default value.
             .withDefaultValue(null)
             .withNullable(column.nullable())
+            .withAutoIncrement(column.autoIncrement())
             .build();
     return appendColumnDefinition(newColumn, sqlBuilder).toString();
   }
@@ -522,12 +557,9 @@ public class MysqlTableOperations extends JdbcTableOperations {
             .withName(col)
             .withType(updateColumnType.getNewDataType())
             .withComment(column.comment())
-            // Modifying a field type does not require adding its attributes. If
-            // additional attributes are required, they must be modified separately.
-            // TODO #839
-            .withProperties(null)
             .withDefaultValue(null)
             .withNullable(column.nullable())
+            .withAutoIncrement(column.autoIncrement())
             .build();
     return appendColumnDefinition(newColumn, sqlBuilder).toString();
   }
@@ -547,12 +579,11 @@ public class MysqlTableOperations extends JdbcTableOperations {
     }
     // TODO #1531 will add default value.
 
-    // Add column properties if specified
-    if (CollectionUtils.isNotEmpty(column.getProperties())) {
-      for (String property : column.getProperties()) {
-        sqlBuilder.append(property).append(SPACE);
-      }
+    // Add column auto_increment if specified
+    if (column.autoIncrement()) {
+      sqlBuilder.append(MYSQL_AUTO_INCREMENT).append(" ");
     }
+
     // Add column comment if specified
     if (StringUtils.isNotEmpty(column.comment())) {
       sqlBuilder.append("COMMENT '").append(column.comment()).append("' ");

--- a/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlTableOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlTableOperations.java
@@ -136,6 +136,13 @@ public class MysqlTableOperations extends JdbcTableOperations {
     return result;
   }
 
+  /**
+   * The auto-increment column will be verified. There can only be one auto-increment column and it
+   * must be the primary key or unique index.
+   *
+   * @param columns jdbc column
+   * @param indexes table indexes
+   */
   private static void validateIncrementCol(JdbcColumn[] columns, Index[] indexes) {
     // Check auto increment column
     List<JdbcColumn> autoIncrementCols =

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlTableOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlTableOperations.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import javax.sql.DataSource;
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.BooleanUtils;
@@ -146,11 +145,6 @@ public class PostgreSqlTableOperations extends JdbcTableOperations {
     //   sqlBuilder.append("DEFAULT '").append(column.getDefaultValue()).append("'").append(SPACE);
     // }
 
-    // Add column properties if specified
-    if (CollectionUtils.isNotEmpty(column.getProperties())) {
-      // TODO #804 will add properties
-      throw new IllegalArgumentException("Properties are not supported yet");
-    }
     return sqlBuilder;
   }
 

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/ColumnDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/ColumnDTO.java
@@ -204,10 +204,6 @@ public class ColumnDTO implements Column {
   }
 
   public void validate() throws IllegalArgumentException {
-    if (autoIncrement()) {
-      // TODO This part of the code will be deleted after underlying support.
-      throw new UnsupportedOperationException("Auto-increment column is not supported yet.");
-    }
     if (name() == null || name().isEmpty()) {
       throw new IllegalArgumentException("Column name cannot be null or empty.");
     }

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/TestJdbcAbstractIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/TestJdbcAbstractIT.java
@@ -94,10 +94,6 @@ public abstract class TestJdbcAbstractIT {
       // TODO: uncomment this after default value is supported.
       // Assertions.assertEquals(
       //    columns.get(i).getDefaultValue(), ((JdbcColumn) table.columns()[i]).getDefaultValue());
-      if (null != columns.get(i).getProperties()) {
-        Assertions.assertEquals(
-            columns.get(i).getProperties(), ((JdbcColumn) table.columns()[i]).getProperties());
-      }
     }
     for (Map.Entry<String, String> entry : properties.entrySet()) {
       Assertions.assertEquals(entry.getValue(), table.properties().get(entry.getKey()));


### PR DESCRIPTION
### What changes were proposed in this pull request?
1.Delete unnecessary code sections about the properties of the jdbc column
2.MySQL supports load properties of auto_increment

### Why are the changes needed?
Fix: #1279 

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
UT
