### PR TITLE
[#1299] Fix the copyright year

### DIFF
--- a/web/lib/layout/Footer.js
+++ b/web/lib/layout/Footer.js
@@ -13,7 +13,7 @@ const Footer = props => {
       <Box className='footer-content-wrapper twc-px-6 twc-w-full twc-py-[0.75rem] [@media(min-width:1440px)]:twc-max-w-[1440px]'>
         <Box className={'twc-flex twc-flex-wrap twc-items-center twc-justify-between'}>
           <Typography className='twc-mr-2'>
-            {`© ${new Date().getFullYear()} `}
+            {`© 2023 `}
             <Link className={'twc-no-underline twc-text-primary-main'} target='_blank' href='https://datastrato.ai/'>
               Datastrato
             </Link>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the copyright year to be the year of the last release, not the current year.

### Why are the changes needed?

The copyright year should not automatically update to the current year.

Fix: #1299

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Built and tested locally in a browser.