### PR TITLE
[#1306] improvement(dev): mac-docker-connector.sh uses curl instead of wget to download docker-connector-darwin.tar.gz

### DIFF
--- a/dev/docker/tools/mac-docker-connector.sh
+++ b/dev/docker/tools/mac-docker-connector.sh
@@ -23,7 +23,7 @@ fi
 DOCKER_CONNECTOR_PACKAGE_NAME="docker-connector-darwin.tar.gz"
 DOCKER_CONNECTOR_DOWNLOAD_URL="https://github.com/wenjunxiao/mac-docker-connector/releases/download/v3.2/${DOCKER_CONNECTOR_PACKAGE_NAME}"
 if [ ! -f "${bin}/docker-connector" ]; then
-  wget -q -P "${bin}" ${DOCKER_CONNECTOR_DOWNLOAD_URL}
+  curl -s -L -o "${bin}/${DOCKER_CONNECTOR_PACKAGE_NAME}" ${DOCKER_CONNECTOR_DOWNLOAD_URL}
   tar -xzf "${bin}/${DOCKER_CONNECTOR_PACKAGE_NAME}" -C "${bin}"
   rm -rf "${bin}/${DOCKER_CONNECTOR_PACKAGE_NAME}"
 fi


### PR DESCRIPTION
### What changes were proposed in this pull request?

`mac-docker-connector.sh` uses `curl` instead of `wget` to download `docker-connector-darwin.tar.gz` for MacOS.

### Why are the changes needed?

`curl` is installed by default and `wget` is not installed for MacOS. Therefore it's recommended to use `curl` instead of `wget` to download `docker-connector-darwin.tar.gz` for `mac-docker-connector.sh`.

Fix: #1306 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Local test.