### PR TITLE
[#1311] bugfix(docker): Unable to run datastrato/trino Docker in AWS

### DIFF
--- a/dev/docker/trino/conf/node.properties
+++ b/dev/docker/trino/conf/node.properties
@@ -3,5 +3,6 @@
 # This software is licensed under the Apache License version 2.
 #
 node.environment = docker
+node.id = ffffffff-ffff-ffff-ffff-ffffffffffff
 node.data-dir = /data/trino
 plugin.dir = /usr/lib/trino/plugin


### PR DESCRIPTION
### What changes were proposed in this pull request?

Trino loss `node.id` configuration in the `node.properties` file.

```
root@ip-172-31-6-157:/# /usr/lib/trino/bin/run-trino
+ launcher_opts=(--etc-dir /etc/trino)
+ grep -s -q node.id /etc/trino/node.properties
+ launcher_opts+=("-Dnode.id=${HOSTNAME}")
+ exec /usr/lib/trino/bin/launcher run --etc-dir /etc/trino -Dnode.id=ip-172-31-6-157.ec2.internal
OpenJDK 64-Bit Server VM warning: Option UseBiasedLocking was deprecated in version 15.0 and will likely be removed in a future release.
Jan 02, 2024 2:33:42 PM io.airlift.log.Logger info
INFO: Java version: 17.0.8.1
2024-01-02T14:33:42.382Z	INFO	main	io.airlift.log.Logging	Logging to stderr
2024-01-02T14:33:42.383Z	INFO	main	Bootstrap	Loading configuration
2024-01-02T14:33:42.645Z	INFO	main	org.hibernate.validator.internal.util.Version	HV000001: Hibernate Validator 8.0.0.Final
2024-01-02T14:33:43.052Z	INFO	main	Bootstrap	Initializing logging
2024-01-02T14:33:46.142Z	ERROR	main	io.trino.server.Server	Configuration is invalid
==========
Errors:
1) Invalid configuration property node.id: is malformed (for class io.airlift.node.NodeConfig.nodeId)
==========
```

### Why are the changes needed?

Fix: #1311

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Manually test in the AWS
