### PR TITLE
[#1151] fix(UI): Fix status cache after modified a Metalake

### DIFF
--- a/web/app/(home)/MetalakeList.js
+++ b/web/app/(home)/MetalakeList.js
@@ -182,6 +182,7 @@ const MetalakeList = () => {
             handleFilter={handleFilter}
             setOpenDialog={setOpenDialog}
             setDialogData={setDialogData}
+            setDialogType={setDialogType}
           />
           <DataGrid
             autoHeight

--- a/web/app/(home)/TableHeader.js
+++ b/web/app/(home)/TableHeader.js
@@ -8,11 +8,12 @@ import { Box, Button, TextField } from '@mui/material'
 import Icon from '@/components/Icon'
 
 const TableHeader = props => {
-  const { handleFilter, value, setOpenDialog, setDialogData } = props
+  const { handleFilter, value, setOpenDialog, setDialogData, setDialogType } = props
 
   const handleCreate = () => {
     setDialogData({})
     setOpenDialog(true)
+    setDialogType('create')
   }
 
   return (


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the issue with the status cache after modifying Metalake.

#### Before:
1. rename a metalake
<img width="480" alt="test2-test3" src="https://github.com/datastrato/gravitino/assets/17310559/c4f24dd8-9e07-4942-9f40-45c8b375bec6">

2. click `create metalake` button
<img width="480" alt="update-metalake" src="https://github.com/datastrato/gravitino/assets/17310559/4fcc1040-8f91-4dd5-b62a-30c44c5a1b82">

It should be `create dialog`, but displays `update dialog`.

#### After:
when click `create metalake` button, correctly display `create dialog`.
<img width="480" alt="create-metalake" src="https://github.com/datastrato/gravitino/assets/17310559/d833a7a7-d6cd-45ca-9e99-5156c68e5f10">


### Why are the changes needed?

Fix: #1151 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
