### PR TITLE
[#1328] fix(trino-connector): Fix the failed 'drop catalog' test on Trino image gravitino-ci-trino:0.1.3.

### DIFF
--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -283,7 +283,7 @@ tasks.test {
 
       // Gravitino CI Docker image
       environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "datastrato/gravitino-ci-hive:0.1.7")
-      environment("GRAVITINO_CI_TRINO_DOCKER_IMAGE", "datastrato/gravitino-ci-trino:0.1.2")
+      environment("GRAVITINO_CI_TRINO_DOCKER_IMAGE", "datastrato/gravitino-ci-trino:0.1.3")
 
       val testMode = project.properties["testMode"] as? String ?: "embedded"
       systemProperty("gravitino.log.path", buildDir.path + "/integration-test.log")

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoConnectorIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoConnectorIT.java
@@ -1038,7 +1038,7 @@ public class TrinoConnectorIT extends AbstractIT {
       createdMetalake.dropCatalog(NameIdentifier.of(metalakeName, catalogName));
       // We need to test we can't load this catalog any more by Trino.
       success = checkTrinoHasRemoved(sql, 30);
-      Assertions.assertFalse(success, "Trino should not load the catalog any more: " + sql);
+      Assertions.assertTrue(success, "Trino should not load the catalog any more: " + sql);
     }
   }
 

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoConnectorIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoConnectorIT.java
@@ -858,7 +858,8 @@ public class TrinoConnectorIT extends AbstractIT {
     final String sql1 =
         String.format("drop schema \"%s.%s\".%s cascade", metalakeName, catalogName, schemaName);
     // Will fail because the iceberg catalog does not support cascade drop
-    containerSuite.getTrinoContainer().executeUpdateSQL(sql1);
+    Assertions.assertThrows(
+        RuntimeException.class, () -> containerSuite.getTrinoContainer().executeUpdateSQL(sql1));
 
     final String sql2 =
         String.format("show schemas in \"%s.%s\" like '%s'", metalakeName, catalogName, schemaName);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the failed 'drop catalog' test on Trino image gravitino-ci-trino:0.1.3.
Trino image gravitino-ci-trino:0.1.2 use the gravitino-trino-connector-0.3.0-SNAPSHOT.jar, it does not support drop catalog, so the  tester has made it compatible with this.
Trino image gravitino-ci-trino:0.1.3 use the gravitino-trino-connector-0.4.0-SNAPSHOT.jar, it support drop catalog. 
 the test did not pass. 

### Why are the changes needed?

Fix: #1328

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

NO
