### PR TITLE
[#1114] improve(UI): Add `type` and `provider` properties in catalog details

### DIFF
--- a/web/app/metalakes/DetailsView.js
+++ b/web/app/metalakes/DetailsView.js
@@ -16,7 +16,7 @@ import TableContainer from '@mui/material/TableContainer'
 import { formatToDateTime } from '@/lib/utils/date'
 
 const DetailsView = props => {
-  const { store, data = {} } = props
+  const { store, data = {}, page } = props
 
   const activatedItem = store.activatedDetails
 
@@ -32,6 +32,22 @@ const DetailsView = props => {
   return (
     <Box sx={{ p: 4 }}>
       <Grid container spacing={6}>
+        {page && page === 'catalogs' ? (
+          <>
+            <Grid item xs={12} md={6} sx={{ mb: [0, 5] }}>
+              <Typography variant='body2' sx={{ mb: 2 }}>
+                Type
+              </Typography>
+              <Typography sx={{ fontWeight: 500 }}>{activatedItem?.type || ''}</Typography>
+            </Grid>
+            <Grid item xs={12} md={6} sx={{ mb: [0, 5] }}>
+              <Typography variant='body2' sx={{ mb: 2 }}>
+                Provider
+              </Typography>
+              <Typography sx={{ fontWeight: 500 }}>{activatedItem?.provider || ''}</Typography>
+            </Grid>
+          </>
+        ) : null}
         <Grid item xs={12} sx={{ mb: [0, 5] }}>
           <Typography variant='body2' sx={{ mb: 2 }}>
             Comment

--- a/web/app/metalakes/TabsContent.js
+++ b/web/app/metalakes/TabsContent.js
@@ -70,7 +70,7 @@ const TabsContent = props => {
         <TableView page={page} />
       </CustomTabPanel>
       <CustomTabPanel value='details'>
-        <DetailsView store={store} />
+        <DetailsView store={store} page={page} />
       </CustomTabPanel>
     </TabContext>
   )


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `type` and `provider` properties in catalog details.
<img width="480" alt="catalogs-type" src="https://github.com/datastrato/gravitino/assets/17310559/41e7cd8c-65e7-4c6a-9f02-97a060b2d5f4">

The current properties only shows in `details`. To display it in a tree list, advanced REST API support is required.

### Why are the changes needed?

Fix: #1114 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
