### PR TITLE
[#1282] bugfix(CI) Automatically trigger CI for auto-cherry-pick workflow

### DIFF
--- a/.github/workflows/auto-cherry-pick.yml
+++ b/.github/workflows/auto-cherry-pick.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Cherry pick into branch-0.1
         uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
         with:
+          token: ${{ secrets.BOT_TOKEN }}
           branch: branch-0.1
           labels: |
             cherry-pick
@@ -36,6 +37,7 @@ jobs:
       - name: Cherry pick into branch-0.2
         uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
         with:
+          token: ${{ secrets.BOT_TOKEN }}
           branch: branch-0.2
           labels: |
             cherry-pick
@@ -53,6 +55,7 @@ jobs:
       - name: Cherry pick into branch-0.3
         uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
         with:
+          token: ${{ secrets.BOT_TOKEN }}
           branch: branch-0.3
           labels: |
             cherry-pick


### PR DESCRIPTION
Based on the document of [`github-cherry-pick-action`](https://github.com/marketplace/actions/github-cherry-pick-action#action-inputs), add token input to change the default token that the auto-cherry-pick workflow used.

> [!WARNING]  
> Need to add a PAT to the organization with the name `BOT_TOKEN`.

### What changes were proposed in this pull request?

Automatically trigger CI for auto-cherry-pick workflow with a customized token, instead of the default `GITHUB_TOKEN`, which is prohibited from triggering another workflow.

### Why are the changes needed?

Fix: #1282 

### Does this PR introduce _any_ user-facing change?

No user-facing change, but we should add a PAT to the organization with the name `BOT_TOKEN`.

### How was this patch tested?

N/A
