### PR TITLE
[#1295] improvement(CI): separate trino image for CI and users

### DIFF
--- a/dev/docker/build-docker.sh
+++ b/dev/docker/build-docker.sh
@@ -75,6 +75,8 @@ else
   exit 1
 fi
 
+build_args="${build_args} --build-arg IMAGE_NAME=${image_name}"
+
 # Create multi-arch builder
 BUILDER_NAME="gravitino-builder"
 builders=$(docker buildx ls)

--- a/dev/docker/trino/Dockerfile
+++ b/dev/docker/trino/Dockerfile
@@ -45,11 +45,20 @@ RUN rm -rf /usr/lib/trino/plugin/accumulo  \
     && rm -rf /usr/lib/trino/plugin/redis \
     && rm -rf /usr/lib/trino/plugin/session-property-managers \
     && rm -rf /usr/lib/trino/plugin/teradata-functions
-
 COPY --chown=trino:trino packages/trino/conf /etc/trino
 COPY --chown=trino:trino packages/gravitino-trino-connector/mysql-connector-java-8.0.27.jar /usr/lib/trino/plugin/iceberg/
 COPY --chown=trino:trino packages/gravitino-trino-connector/postgresql-42.7.0.jar /usr/lib/trino/plugin/iceberg/
-COPY --chown=trino:trino packages/gravitino-trino-connector /usr/lib/trino/plugin/gravitino
+
+RUN mkdir /tmp/gravitino
+COPY --chown=trino:trino packages/gravitino-trino-connector /tmp/gravitino
+
+ARG IMAGE_NAME
+RUN if [ "$IMAGE_NAME" = "datastrato/trino" ] ; then \
+    mv /tmp/gravitino /usr/lib/trino/plugin/; \
+    else echo "Copying files for other images"; \
+    fi
+
+
 
 # Use ARGs to update trino conf and start Trino server
 ARG GRAVITINO_HOST_IP

--- a/docs/docker-image-details.md
+++ b/docs/docker-image-details.md
@@ -118,6 +118,9 @@ You can use this image to test Trino.
 
 Changelog
 
+- gravitino-ci-trino:0.1.3
+  - Remove copy content in folder `gravitino-trino-connector` to plugin folder `/usr/lib/trino/plugin/gravitino`
+
 - gravitino-ci-trino:0.1.2
   - Copy JDBC driver 'mysql-connector-java' and 'postgres' to `/usr/lib/trino/iceberg/` folder
 


### PR DESCRIPTION

### What changes were proposed in this pull request?

Remove the Gravitino connector from the Trino CI image.

### Why are the changes needed?

In CI, we will mount the Gravitino connector to the Trino CI image to test the latest code base, so we can fully test our PR. 

Fix: #1295

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
