### PR TITLE
[#1328] fix(trino-connector): Fix the failed 'drop catalog' test on Trino image gravitino-ci-trino:0.1.3.

### DIFF
--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -281,8 +281,8 @@ tasks.test {
       }
 
       // Gravitino CI Docker image
-      environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "datastrato/gravitino-ci-hive:0.1.6")
-      environment("GRAVITINO_CI_TRINO_DOCKER_IMAGE", "datastrato/gravitino-ci-trino:0.1.2")
+      environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "datastrato/gravitino-ci-hive:0.1.7")
+      environment("GRAVITINO_CI_TRINO_DOCKER_IMAGE", "datastrato/gravitino-ci-trino:0.1.3")
 
       val testMode = project.properties["testMode"] as? String ?: "embedded"
       systemProperty("gravitino.log.path", buildDir.path + "/integration-test.log")

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoConnectorIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoConnectorIT.java
@@ -850,7 +850,8 @@ public class TrinoConnectorIT extends AbstractIT {
     final String sql1 =
         String.format("drop schema \"%s.%s\".%s cascade", metalakeName, catalogName, schemaName);
     // Will fail because the iceberg catalog does not support cascade drop
-    containerSuite.getTrinoContainer().executeUpdateSQL(sql1);
+    Assertions.assertThrows(
+        RuntimeException.class, () -> containerSuite.getTrinoContainer().executeUpdateSQL(sql1));
 
     final String sql2 =
         String.format("show schemas in \"%s.%s\" like '%s'", metalakeName, catalogName, schemaName);
@@ -988,6 +989,49 @@ public class TrinoConnectorIT extends AbstractIT {
     success = checkTrinoHasLoaded(sql, 30);
     if (!success) {
       Assertions.fail("Trino fail to load table created by gravitino: " + sql);
+    }
+  }
+
+  @Test
+  void testDropCatalogAndCreateAgain() throws InterruptedException {
+    String catalogName = GravitinoITUtils.genRandomName("mysql_catalog").toLowerCase();
+    GravitinoMetaLake createdMetalake = client.loadMetalake(NameIdentifier.of(metalakeName));
+    String[] command = {
+      "mysql",
+      "-h127.0.0.1",
+      "-uroot",
+      "-pds123", // username and password are referred from Hive dockerfile.
+      "-e",
+      "grant all privileges on *.* to root@'%' identified by 'ds123'"
+    };
+
+    // There exists a mysql instance in Hive the container.
+    containerSuite.getHiveContainer().executeInContainer(command);
+    String hiveHost = containerSuite.getHiveContainer().getContainerIpAddress();
+
+    // Create the catalog and drop it for 3 times to test the create/drop catalog function work
+    // well.
+    for (int i = 0; i < 3; i++) {
+      createdMetalake.createCatalog(
+          NameIdentifier.of(metalakeName, catalogName),
+          Catalog.Type.RELATIONAL,
+          "jdbc-mysql",
+          "comment",
+          ImmutableMap.<String, String>builder()
+              .put("jdbc-driver", "com.mysql.cj.jdbc.Driver")
+              .put("jdbc-user", "root")
+              .put("jdbc-password", "ds123")
+              .put("jdbc-url", String.format("jdbc:mysql://%s:3306?useSSL=false", hiveHost))
+              .build());
+
+      String sql = String.format("show catalogs like '%s.%s'", metalakeName, catalogName);
+      boolean success = checkTrinoHasLoaded(sql, 30);
+      Assertions.assertTrue(success, "Trino should load the catalog: " + sql);
+
+      createdMetalake.dropCatalog(NameIdentifier.of(metalakeName, catalogName));
+      // We need to test we can't load this catalog any more by Trino.
+      success = checkTrinoHasRemoved(sql, 30);
+      Assertions.assertTrue(success, "Trino should not load the catalog any more: " + sql);
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the failed 'drop catalog' test on Trino image gravitino-ci-trino:0.1.3.
Trino image gravitino-ci-trino:0.1.2 use the gravitino-trino-connector-0.3.0-SNAPSHOT.jar, it does not support drop catalog, so the  tester has made it compatible with this.
Trino image gravitino-ci-trino:0.1.3 use the gravitino-trino-connector-0.4.0-SNAPSHOT.jar, it support drop catalog. 
 the test did not pass. 

### Why are the changes needed?

Fix: #1328

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

NO
