### PR TITLE
 [#1369] Add RAT support for 2024 copyright header

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -297,6 +297,7 @@ subprojects {
 
 tasks.rat {
   substringMatcher("DS", "Datastrato", "Copyright 2023 Datastrato Pvt Ltd.")
+  substringMatcher("DS", "Datastrato", "Copyright 2024 Datastrato Pvt Ltd.")
   approvedLicense("Datastrato")
   approvedLicense("Apache License Version 2.0")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add RAT support for 2024 copyright header.

### Why are the changes needed?

Otherwise, RAT check will fail.

Fix: #1369

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Tested locally.
