### PR TITLE
[#1380] Add Literals class for managing the Literal helper methods

### DIFF
--- a/api/src/main/java/com/datastrato/gravitino/rel/expressions/Literal.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/expressions/Literal.java
@@ -28,7 +28,10 @@ import java.util.Objects;
  * Represents a constant literal value in the public expression API.
  *
  * @param <T> the JVM type of value held by the literal
+ * @deprecated This interface will be removed. Use {@link
+ *     com.datastrato.gravitino.rel.expressions.literals.Literal} instead.
  */
+@Deprecated
 public interface Literal<T> extends Expression {
   /** @return The literal value. */
   T value();

--- a/api/src/main/java/com/datastrato/gravitino/rel/expressions/literals/Literal.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/expressions/literals/Literal.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.rel.expressions.literals;
+
+import com.datastrato.gravitino.rel.expressions.Expression;
+import com.datastrato.gravitino.rel.types.Type;
+
+/**
+ * Represents a constant literal value in the public expression API.
+ *
+ * @param <T> the JVM type of value held by the literal
+ */
+public interface Literal<T> extends Expression {
+  /** @return The literal value. */
+  T value();
+
+  /** @return The data type of the literal. */
+  Type dataType();
+
+  @Override
+  default Expression[] children() {
+    return EMPTY_EXPRESSION;
+  }
+}

--- a/api/src/main/java/com/datastrato/gravitino/rel/expressions/literals/Literals.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/expressions/literals/Literals.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.rel.expressions.literals;
+
+import com.datastrato.gravitino.rel.types.Type;
+import com.datastrato.gravitino.rel.types.Types;
+import java.util.Objects;
+
+/** The helper class to create literals to pass into Gravitino. */
+public class Literals {
+
+  /**
+   * Creates a literal with the given value and data type.
+   *
+   * @param value the literal value
+   * @param dataType the data type of the literal
+   * @return a new {@link com.datastrato.gravitino.rel.expressions.Literal} instance
+   * @param <T> the JVM type of value held by the literal
+   */
+  public static <T> LiteralImpl<T> of(T value, Type dataType) {
+    return new LiteralImpl<>(value, dataType);
+  }
+
+  /**
+   * Creates an integer type literal with the given value.
+   *
+   * @param value the integer literal value
+   * @return a new {@link Literal} instance
+   */
+  public static LiteralImpl<Integer> integer(Integer value) {
+    return of(value, Types.IntegerType.get());
+  }
+
+  /**
+   * Creates a string type literal with the given value.
+   *
+   * @param value the string literal value
+   * @return a new {@link Literal} instance
+   */
+  public static LiteralImpl<String> string(String value) {
+    return of(value, Types.StringType.get());
+  }
+
+  /**
+   * Creates a literal with the given type value.
+   *
+   * @param <T> The JVM type of value held by the literal.
+   */
+  public static final class LiteralImpl<T> implements Literal<T> {
+    private final T value;
+    private final Type dataType;
+
+    private LiteralImpl(T value, Type dataType) {
+      this.value = value;
+      this.dataType = dataType;
+    }
+
+    @Override
+    public T value() {
+      return value;
+    }
+
+    @Override
+    public Type dataType() {
+      return dataType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      LiteralImpl<?> literal = (LiteralImpl<?>) o;
+      return Objects.equals(value, literal.value) && Objects.equals(dataType, literal.dataType);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(value, dataType);
+    }
+  }
+}

--- a/api/src/main/java/com/datastrato/gravitino/rel/expressions/transforms/Transforms.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/expressions/transforms/Transforms.java
@@ -5,8 +5,9 @@
 package com.datastrato.gravitino.rel.expressions.transforms;
 
 import com.datastrato.gravitino.rel.expressions.Expression;
-import com.datastrato.gravitino.rel.expressions.Literal;
 import com.datastrato.gravitino.rel.expressions.NamedReference;
+import com.datastrato.gravitino.rel.expressions.literals.Literal;
+import com.datastrato.gravitino.rel.expressions.literals.Literals;
 import com.google.common.collect.ObjectArrays;
 import java.util.Arrays;
 import java.util.Objects;
@@ -133,7 +134,7 @@ public class Transforms {
    */
   public static BucketTransform bucket(int numBuckets, String[]... fieldNames) {
     return new BucketTransform(
-        Literal.integer(numBuckets),
+        Literals.integer(numBuckets),
         Arrays.stream(fieldNames).map(NamedReference::field).toArray(NamedReference[]::new));
   }
 
@@ -166,7 +167,7 @@ public class Transforms {
    * @return The created transform
    */
   public static TruncateTransform truncate(int width, String[] fieldName) {
-    return new TruncateTransform(Literal.integer(width), NamedReference.field(fieldName));
+    return new TruncateTransform(Literals.integer(width), NamedReference.field(fieldName));
   }
 
   /**

--- a/api/src/test/java/com/datastrato/gravitino/rel/TestTransforms.java
+++ b/api/src/test/java/com/datastrato/gravitino/rel/TestTransforms.java
@@ -18,8 +18,8 @@ import static com.datastrato.gravitino.rel.expressions.transforms.Transforms.mon
 import static com.datastrato.gravitino.rel.expressions.transforms.Transforms.year;
 
 import com.datastrato.gravitino.rel.expressions.Expression;
-import com.datastrato.gravitino.rel.expressions.Literal;
 import com.datastrato.gravitino.rel.expressions.NamedReference;
+import com.datastrato.gravitino.rel.expressions.literals.Literals;
 import com.datastrato.gravitino.rel.expressions.transforms.Transform;
 import com.datastrato.gravitino.rel.types.Type;
 import com.datastrato.gravitino.rel.types.Types;
@@ -110,7 +110,7 @@ public class TestTransforms {
         };
     // partition by foo(col_1, 'bar')
     NamedReference.FieldReference arg1 = field(column.name());
-    Literal.LiteralImpl<String> arg2 = Literal.string("bar");
+    Literals.LiteralImpl<String> arg2 = Literals.string("bar");
     Transform applyTransform = apply("foo", new Expression[] {arg1, arg2});
     Assertions.assertEquals("foo", applyTransform.name());
     Assertions.assertEquals(2, applyTransform.arguments().length);

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/ToIcebergSortOrder.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/ToIcebergSortOrder.java
@@ -6,8 +6,8 @@ package com.datastrato.gravitino.catalog.lakehouse.iceberg.converter;
 
 import com.datastrato.gravitino.rel.expressions.Expression;
 import com.datastrato.gravitino.rel.expressions.FunctionExpression;
-import com.datastrato.gravitino.rel.expressions.Literal;
 import com.datastrato.gravitino.rel.expressions.NamedReference;
+import com.datastrato.gravitino.rel.expressions.literals.Literal;
 import com.datastrato.gravitino.rel.expressions.sorts.NullOrdering;
 import com.datastrato.gravitino.rel.expressions.sorts.SortDirection;
 import com.datastrato.gravitino.rel.expressions.sorts.SortOrder;

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/expressions/LiteralDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/expressions/LiteralDTO.java
@@ -4,7 +4,7 @@
  */
 package com.datastrato.gravitino.dto.rel.expressions;
 
-import com.datastrato.gravitino.rel.expressions.Literal;
+import com.datastrato.gravitino.rel.expressions.literals.Literal;
 import com.datastrato.gravitino.rel.types.Type;
 import lombok.EqualsAndHashCode;
 

--- a/common/src/main/java/com/datastrato/gravitino/dto/util/DTOConverters.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/util/DTOConverters.java
@@ -38,10 +38,11 @@ import com.datastrato.gravitino.rel.Schema;
 import com.datastrato.gravitino.rel.Table;
 import com.datastrato.gravitino.rel.expressions.Expression;
 import com.datastrato.gravitino.rel.expressions.FunctionExpression;
-import com.datastrato.gravitino.rel.expressions.Literal;
 import com.datastrato.gravitino.rel.expressions.NamedReference;
 import com.datastrato.gravitino.rel.expressions.distributions.Distribution;
 import com.datastrato.gravitino.rel.expressions.distributions.Distributions;
+import com.datastrato.gravitino.rel.expressions.literals.Literal;
+import com.datastrato.gravitino.rel.expressions.literals.Literals;
 import com.datastrato.gravitino.rel.expressions.sorts.SortOrder;
 import com.datastrato.gravitino.rel.expressions.sorts.SortOrders;
 import com.datastrato.gravitino.rel.expressions.transforms.Transform;
@@ -254,7 +255,7 @@ public class DTOConverters {
   public static Expression fromFunctionArg(FunctionArg arg) {
     switch (arg.argType()) {
       case LITERAL:
-        return Literal.of(((LiteralDTO) arg).value(), ((LiteralDTO) arg).dataType());
+        return Literals.of(((LiteralDTO) arg).value(), ((LiteralDTO) arg).dataType());
       case FIELD:
         return NamedReference.field(((FieldReferenceDTO) arg).fieldName());
       case FUNCTION:


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Add a Literals class for managing the Literal helper methods
- Make the old `Literal` API deprecated

### Why are the changes needed?

Fix: #1380 

### Does this PR introduce _any_ user-facing change?

Yes, make the old `Literal` API deprecated

### How was this patch tested?
existing tests
