### PR TITLE
[#1383] Add more static methods of Literal for Java client usage

### DIFF
--- a/api/src/main/java/com/datastrato/gravitino/rel/expressions/literals/Literals.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/expressions/literals/Literals.java
@@ -6,6 +6,9 @@ package com.datastrato.gravitino.rel.expressions.literals;
 
 import com.datastrato.gravitino.rel.types.Type;
 import com.datastrato.gravitino.rel.types.Types;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Objects;
 
 /** The helper class to create literals to pass into Gravitino. */
@@ -24,6 +27,36 @@ public class Literals {
   }
 
   /**
+   * Creates a boolean type literal with the given value.
+   *
+   * @param value the boolean literal value
+   * @return a new {@link Literal} instance
+   */
+  public static LiteralImpl<Boolean> booleanLiteral(Boolean value) {
+    return of(value, Types.BooleanType.get());
+  }
+
+  /**
+   * Creates a byte type literal with the given value.
+   *
+   * @param value the byte literal value
+   * @return a new {@link Literal} instance
+   */
+  public static LiteralImpl<Byte> byteLiteral(Byte value) {
+    return of(value, Types.ByteType.get());
+  }
+
+  /**
+   * Creates a short type literal with the given value.
+   *
+   * @param value the short literal value
+   * @return a new {@link Literal} instance
+   */
+  public static LiteralImpl<Short> shortLiteral(Short value) {
+    return of(value, Types.ShortType.get());
+  }
+
+  /**
    * Creates an integer type literal with the given value.
    *
    * @param value the integer literal value
@@ -31,6 +64,66 @@ public class Literals {
    */
   public static LiteralImpl<Integer> integer(Integer value) {
     return of(value, Types.IntegerType.get());
+  }
+
+  /**
+   * Creates a long type literal with the given value.
+   *
+   * @param value the long literal value
+   * @return a new {@link Literal} instance
+   */
+  public static LiteralImpl<Long> longLiteral(Long value) {
+    return of(value, Types.LongType.get());
+  }
+
+  /**
+   * Creates a float type literal with the given value.
+   *
+   * @param value the float literal value
+   * @return a new {@link Literal} instance
+   */
+  public static LiteralImpl<Float> floatLiteral(Float value) {
+    return of(value, Types.FloatType.get());
+  }
+
+  /**
+   * Creates a double type literal with the given value.
+   *
+   * @param value the double literal value
+   * @return a new {@link Literal} instance
+   */
+  public static LiteralImpl<Double> doubleLiteral(Double value) {
+    return of(value, Types.DoubleType.get());
+  }
+
+  /**
+   * Creates a date type literal with the given value.
+   *
+   * @param value the date literal value
+   * @return a new {@link Literal} instance
+   */
+  public static LiteralImpl<LocalDate> date(LocalDate value) {
+    return of(value, Types.DateType.get());
+  }
+
+  /**
+   * Creates a time type literal with the given value.
+   *
+   * @param value the time literal value
+   * @return a new {@link Literal} instance
+   */
+  public static LiteralImpl<LocalTime> time(LocalTime value) {
+    return of(value, Types.TimeType.get());
+  }
+
+  /**
+   * Creates a timestamp type literal with the given value.
+   *
+   * @param value the timestamp literal value
+   * @return a new {@link Literal} instance
+   */
+  public static LiteralImpl<LocalDateTime> timestamp(LocalDateTime value) {
+    return of(value, Types.TimestampType.withoutTimeZone());
   }
 
   /**

--- a/api/src/test/java/com/datastrato/gravitino/rel/TestLiteral.java
+++ b/api/src/test/java/com/datastrato/gravitino/rel/TestLiteral.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.rel;
+
+import static com.datastrato.gravitino.rel.expressions.literals.Literals.booleanLiteral;
+import static com.datastrato.gravitino.rel.expressions.literals.Literals.byteLiteral;
+import static com.datastrato.gravitino.rel.expressions.literals.Literals.date;
+import static com.datastrato.gravitino.rel.expressions.literals.Literals.doubleLiteral;
+import static com.datastrato.gravitino.rel.expressions.literals.Literals.floatLiteral;
+import static com.datastrato.gravitino.rel.expressions.literals.Literals.integer;
+import static com.datastrato.gravitino.rel.expressions.literals.Literals.longLiteral;
+import static com.datastrato.gravitino.rel.expressions.literals.Literals.shortLiteral;
+import static com.datastrato.gravitino.rel.expressions.literals.Literals.string;
+import static com.datastrato.gravitino.rel.expressions.literals.Literals.time;
+import static com.datastrato.gravitino.rel.expressions.literals.Literals.timestamp;
+
+import com.datastrato.gravitino.rel.expressions.literals.Literal;
+import com.datastrato.gravitino.rel.types.Types;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestLiteral {
+
+  @Test
+  public void testLiterals() {
+    Literal literal = booleanLiteral(Boolean.valueOf("true"));
+    Assertions.assertEquals(literal.value(), true);
+    Assertions.assertEquals(literal.dataType(), Types.BooleanType.get());
+
+    literal = byteLiteral(Byte.valueOf("1"));
+    Assertions.assertEquals(literal.value(), (byte) 1);
+    Assertions.assertEquals(literal.dataType(), Types.ByteType.get());
+
+    literal = shortLiteral(Short.valueOf("1"));
+    Assertions.assertEquals(literal.value(), (short) 1);
+    Assertions.assertEquals(literal.dataType(), Types.ShortType.get());
+
+    literal = integer(Integer.valueOf("1"));
+    Assertions.assertEquals(literal.value(), 1);
+    Assertions.assertEquals(literal.dataType(), Types.IntegerType.get());
+
+    literal = longLiteral(Long.valueOf("1"));
+    Assertions.assertEquals(literal.value(), 1L);
+    Assertions.assertEquals(literal.dataType(), Types.LongType.get());
+
+    literal = floatLiteral(Float.valueOf("1.234"));
+    Assertions.assertEquals(literal.value(), 1.234f);
+    Assertions.assertEquals(literal.dataType(), Types.FloatType.get());
+
+    literal = doubleLiteral(Double.valueOf("1.234"));
+    Assertions.assertEquals(literal.value(), 1.234d);
+    Assertions.assertEquals(literal.dataType(), Types.DoubleType.get());
+
+    literal = date(LocalDate.parse("2020-01-01"));
+    Assertions.assertEquals(literal.value(), LocalDate.of(2020, 1, 1));
+    Assertions.assertEquals(literal.dataType(), Types.DateType.get());
+
+    literal = time(LocalTime.parse("12:34:56"));
+    Assertions.assertEquals(literal.value(), LocalTime.of(12, 34, 56));
+    Assertions.assertEquals(literal.dataType(), Types.TimeType.get());
+
+    literal = timestamp(LocalDateTime.parse("2020-01-01T12:34:56"));
+    Assertions.assertEquals(literal.value(), LocalDateTime.of(2020, 1, 1, 12, 34, 56));
+    Assertions.assertEquals(literal.dataType(), Types.TimestampType.withoutTimeZone());
+
+    literal = string("hello");
+    Assertions.assertEquals(literal.value(), "hello");
+    Assertions.assertEquals(literal.dataType(), Types.StringType.get());
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add more static methods of Literal for Java client usage

### Why are the changes needed?

Fix: #1383 

### Does this PR introduce _any_ user-facing change?

no, but users can use `Literal` more conveniently by Java client

### How was this patch tested?

UTs added
