### PR TITLE
[#1384] feat(api): Add `NullType` for representing NULL values

### DIFF
--- a/api/src/main/java/com/datastrato/gravitino/rel/expressions/literals/Literals.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/expressions/literals/Literals.java
@@ -13,6 +13,8 @@ import java.util.Objects;
 
 /** The helper class to create literals to pass into Gravitino. */
 public class Literals {
+  /** Used to represent a null literal. */
+  public static final Literal<Types.NullType> NULL = new LiteralImpl<>(null, Types.NullType.get());
 
   /**
    * Creates a literal with the given value and data type.

--- a/api/src/main/java/com/datastrato/gravitino/rel/types/Type.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/types/Type.java
@@ -36,7 +36,8 @@ public interface Type {
     STRUCT,
     LIST,
     MAP,
-    UNION
+    UNION,
+    NULL
   }
 
   /** The base type of all primitive types. */

--- a/api/src/main/java/com/datastrato/gravitino/rel/types/Types.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/types/Types.java
@@ -12,6 +12,28 @@ import java.util.StringJoiner;
 /** The helper class for {@link Type}. */
 public class Types {
 
+  /** The data type representing `NULL` values. */
+  public static class NullType implements Type {
+    private static final NullType INSTANCE = new NullType();
+
+    /** @return The singleton instance of {@link NullType}. */
+    public static NullType get() {
+      return INSTANCE;
+    }
+
+    private NullType() {}
+
+    @Override
+    public Name name() {
+      return Name.NULL;
+    }
+
+    @Override
+    public String simpleString() {
+      return "null";
+    }
+  }
+
   /** The boolean type in Gravitino. */
   public static class BooleanType extends Type.PrimitiveType {
     private static final BooleanType INSTANCE = new BooleanType();

--- a/api/src/test/java/com/datastrato/gravitino/rel/TestLiteral.java
+++ b/api/src/test/java/com/datastrato/gravitino/rel/TestLiteral.java
@@ -17,6 +17,7 @@ import static com.datastrato.gravitino.rel.expressions.literals.Literals.time;
 import static com.datastrato.gravitino.rel.expressions.literals.Literals.timestamp;
 
 import com.datastrato.gravitino.rel.expressions.literals.Literal;
+import com.datastrato.gravitino.rel.expressions.literals.Literals;
 import com.datastrato.gravitino.rel.types.Types;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -71,5 +72,7 @@ public class TestLiteral {
     literal = string("hello");
     Assertions.assertEquals(literal.value(), "hello");
     Assertions.assertEquals(literal.dataType(), Types.StringType.get());
+
+    Assertions.assertEquals(Literals.of(null, Types.NullType.get()), Literals.NULL);
   }
 }

--- a/api/src/test/java/com/datastrato/gravitino/rel/TestTypes.java
+++ b/api/src/test/java/com/datastrato/gravitino/rel/TestTypes.java
@@ -19,6 +19,11 @@ public class TestTypes {
     Assertions.assertSame(booleanType, Types.BooleanType.get());
     Assertions.assertEquals("boolean", booleanType.simpleString());
 
+    Types.NullType nullType = Types.NullType.get();
+    Assertions.assertEquals(Type.Name.NULL, nullType.name());
+    Assertions.assertSame(nullType, Types.NullType.get());
+    Assertions.assertEquals("null", nullType.simpleString());
+
     Types.ByteType byteType = Types.ByteType.get();
     Assertions.assertEquals(Type.Name.BYTE, byteType.name());
     Assertions.assertSame(byteType, Types.ByteType.get());


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `NullType` for representing NULL values

### Why are the changes needed?

Fix: #1384 

### Does this PR introduce _any_ user-facing change?

yes, users now can use null literal

### How was this patch tested?

UTs added
