### PR TITLE
[#1392] feat(api): add `defaultValue()` in Column API

### DIFF
--- a/api/src/main/java/com/datastrato/gravitino/rel/Column.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/Column.java
@@ -5,6 +5,7 @@
 package com.datastrato.gravitino.rel;
 
 import com.datastrato.gravitino.NameIdentifier;
+import com.datastrato.gravitino.rel.expressions.Expression;
 import com.datastrato.gravitino.rel.types.Type;
 import java.util.Map;
 
@@ -17,6 +18,8 @@ import java.util.Map;
  * Table#columns()} a default value and a generation expression.
  */
 public interface Column {
+
+  Expression DEFAULT_VALUE_NOT_SET = () -> Expression.EMPTY_EXPRESSION;
 
   /** @return The name of this column. */
   String name();
@@ -33,5 +36,8 @@ public interface Column {
   /** @return True if this column is an auto-increment column. Default is false. */
   boolean autoIncrement();
 
-  // TODO. Support column default value. @Jerry
+  /**
+   * @return The default value of this column, {@link Column#DEFAULT_VALUE_NOT_SET} if not specified
+   */
+  Expression defaultValue();
 }

--- a/api/src/test/java/com/datastrato/gravitino/rel/TestTransforms.java
+++ b/api/src/test/java/com/datastrato/gravitino/rel/TestTransforms.java
@@ -55,6 +55,11 @@ public class TestTransforms {
           public boolean autoIncrement() {
             return false;
           }
+
+          @Override
+          public Expression defaultValue() {
+            return Column.DEFAULT_VALUE_NOT_SET;
+          }
         };
     String[] fieldName = new String[] {column.name()};
 
@@ -106,6 +111,11 @@ public class TestTransforms {
           @Override
           public boolean autoIncrement() {
             return false;
+          }
+
+          @Override
+          public Expression defaultValue() {
+            return Column.DEFAULT_VALUE_NOT_SET;
           }
         };
     // partition by foo(col_1, 'bar')

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcColumn.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcColumn.java
@@ -9,15 +9,9 @@ import java.util.List;
 
 /** Represents a column in the Jdbc column. */
 public class JdbcColumn extends BaseColumn {
-  private String defaultValue;
-
   private List<String> properties;
 
   private JdbcColumn() {}
-
-  public String getDefaultValue() {
-    return defaultValue;
-  }
 
   public List<String> getProperties() {
     return properties;
@@ -26,18 +20,8 @@ public class JdbcColumn extends BaseColumn {
   /** A builder class for constructing JdbcColumn instances. */
   public static class Builder extends BaseColumnBuilder<Builder, JdbcColumn> {
 
-    /**
-     * The default value for this field. This value will be used if the corresponding value is null.
-     */
-    private String defaultValue;
-
     /** Attribute value of the field, such as AUTO_INCREMENT, PRIMARY KEY, etc. */
     private List<String> properties;
-
-    public Builder withDefaultValue(String defaultValue) {
-      this.defaultValue = defaultValue;
-      return this;
-    }
 
     public Builder withProperties(List<String> properties) {
       this.properties = properties;

--- a/catalogs/catalog-jdbc-common/src/test/java/com/datastrato/gravitino/catalog/jdbc/operation/SqliteTableOperations.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/com/datastrato/gravitino/catalog/jdbc/operation/SqliteTableOperations.java
@@ -81,7 +81,8 @@ public class SqliteTableOperations extends JdbcTableOperations {
         .withComment(null)
         .withType(typeConverter.toGravitinoType(resultSet.getString("TYPE_NAME")))
         .withNullable(resultSet.getBoolean("NULLABLE"))
-        .withDefaultValue(resultSet.getString("COLUMN_DEF"))
+        // TODO: uncomment this once we support column default values.
+        // .withDefaultValue(resultSet.getString("COLUMN_DEF"))
         .build();
   }
 

--- a/catalogs/catalog-jdbc-common/src/test/java/com/datastrato/gravitino/catalog/jdbc/operation/TestJdbcTableOperations.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/com/datastrato/gravitino/catalog/jdbc/operation/TestJdbcTableOperations.java
@@ -144,8 +144,9 @@ public class TestJdbcTableOperations {
       Assertions.assertEquals(jdbcColumn.comment(), column.comment());
       Assertions.assertEquals(jdbcColumn.dataType(), column.dataType());
       Assertions.assertEquals(jdbcColumn.nullable(), column.nullable());
-      Assertions.assertEquals(
-          jdbcColumn.getDefaultValue(), ((JdbcColumn) column).getDefaultValue());
+      // TODO: uncomment this once we support column default values.
+      // Assertions.assertEquals(
+      //    jdbcColumn.getDefaultValue(), ((JdbcColumn) column).getDefaultValue());
     }
 
     String newName = "table2";

--- a/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlTableOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlTableOperations.java
@@ -71,7 +71,8 @@ public class MysqlTableOperations extends JdbcTableOperations {
               .withType(typeConverter.toGravitinoType(columnDefinition.getColDataType()))
               .withNullable(nullable)
               .withComment(comment)
-              .withDefaultValue("NULL".equals(defaultValue) ? null : defaultValue)
+              // TODO: uncomment this once we support column default values.
+              // .withDefaultValue("NULL".equals(defaultValue) ? null : defaultValue)
               .withProperties(properties)
               .build());
     }
@@ -133,7 +134,8 @@ public class MysqlTableOperations extends JdbcTableOperations {
           .withType(typeConverter.toGravitinoType(columnDefinition.getColDataType()))
           .withNullable(nullable)
           .withComment(comment)
-          .withDefaultValue("NULL".equals(defaultValue) ? null : defaultValue)
+          // TODO: uncomment this once we support column default values.
+          // .withDefaultValue("NULL".equals(defaultValue) ? null : defaultValue)
           .withProperties(properties)
           .build();
     }
@@ -378,7 +380,8 @@ public class MysqlTableOperations extends JdbcTableOperations {
     JdbcColumn updateColumn =
         new JdbcColumn.Builder()
             .withName(col)
-            .withDefaultValue(column.getDefaultValue())
+            // TODO: uncomment this once we support column default values.
+            // .withDefaultValue(column.getDefaultValue())
             .withNullable(change.nullable())
             .withProperties(column.getProperties())
             .withType(column.dataType())
@@ -416,7 +419,8 @@ public class MysqlTableOperations extends JdbcTableOperations {
     JdbcColumn updateColumn =
         new JdbcColumn.Builder()
             .withName(col)
-            .withDefaultValue(column.getDefaultValue())
+            // TODO: uncomment this once we support column default values.
+            // .withDefaultValue(column.getDefaultValue())
             .withNullable(column.nullable())
             .withProperties(column.getProperties())
             .withType(column.dataType())
@@ -471,7 +475,8 @@ public class MysqlTableOperations extends JdbcTableOperations {
             .withType(column.dataType())
             .withComment(column.comment())
             .withProperties(column.getProperties())
-            .withDefaultValue(column.getDefaultValue())
+            // TODO: uncomment this once we support column default values.
+            // .withDefaultValue(column.getDefaultValue())
             .withNullable(column.nullable())
             .build();
     return appendColumnDefinition(newColumn, sqlBuilder).toString();
@@ -561,9 +566,10 @@ public class MysqlTableOperations extends JdbcTableOperations {
       sqlBuilder.append("NOT NULL ");
     }
     // Add DEFAULT value if specified
-    if (StringUtils.isNotEmpty(column.getDefaultValue())) {
-      sqlBuilder.append("DEFAULT '").append(column.getDefaultValue()).append("'").append(SPACE);
-    }
+    // TODO: uncomment this once we support column default values.
+    // if (StringUtils.isNotEmpty(column.getDefaultValue())) {
+    //   sqlBuilder.append("DEFAULT '").append(column.getDefaultValue()).append("'").append(SPACE);
+    // }
 
     // Add column properties if specified
     if (CollectionUtils.isNotEmpty(column.getProperties())) {

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlTableOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlTableOperations.java
@@ -126,7 +126,8 @@ public class PostgreSqlTableOperations extends JdbcTableOperations {
           JdbcColumn.Builder builder =
               new JdbcColumn.Builder()
                   .withName(columnName)
-                  .withDefaultValue(extractDefaultValue(resultSet.getString("column_default")))
+                  // TODO: uncomment this once we support column default values.
+                  // .withDefaultValue(extractDefaultValue(resultSet.getString("column_default")))
                   .withNullable("YES".equalsIgnoreCase(resultSet.getString("is_nullable")))
                   .withType(typeConverter.toGravitinoType(colDataType))
                   .withAutoIncrement("YES".equalsIgnoreCase(resultSet.getString("is_identity")));
@@ -304,9 +305,10 @@ public class PostgreSqlTableOperations extends JdbcTableOperations {
       sqlBuilder.append("NOT NULL ");
     }
     // Add DEFAULT value if specified
-    if (StringUtils.isNotEmpty(column.getDefaultValue())) {
-      sqlBuilder.append("DEFAULT '").append(column.getDefaultValue()).append("'").append(SPACE);
-    }
+    // TODO: uncomment this once we support column default values.
+    // if (StringUtils.isNotEmpty(column.getDefaultValue())) {
+    //   sqlBuilder.append("DEFAULT '").append(column.getDefaultValue()).append("'").append(SPACE);
+    // }
 
     // Add column properties if specified
     if (CollectionUtils.isNotEmpty(column.getProperties())) {

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/ColumnDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/ColumnDTO.java
@@ -6,6 +6,7 @@ package com.datastrato.gravitino.dto.rel;
 
 import com.datastrato.gravitino.json.JsonUtils;
 import com.datastrato.gravitino.rel.Column;
+import com.datastrato.gravitino.rel.expressions.Expression;
 import com.datastrato.gravitino.rel.types.Type;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -79,6 +80,11 @@ public class ColumnDTO implements Column {
   @Override
   public boolean autoIncrement() {
     return autoIncrement;
+  }
+
+  @Override
+  public Expression defaultValue() {
+    throw new UnsupportedOperationException("Column default value is not supported yet.");
   }
 
   /**

--- a/core/src/main/java/com/datastrato/gravitino/catalog/rel/BaseColumn.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/rel/BaseColumn.java
@@ -6,6 +6,7 @@
 package com.datastrato.gravitino.catalog.rel;
 
 import com.datastrato.gravitino.rel.Column;
+import com.datastrato.gravitino.rel.expressions.Expression;
 import com.datastrato.gravitino.rel.types.Type;
 import javax.annotation.Nullable;
 import lombok.EqualsAndHashCode;
@@ -25,6 +26,8 @@ public abstract class BaseColumn implements Column {
   protected boolean nullable;
 
   protected boolean autoIncrement;
+
+  protected Expression defaultValue;
 
   /**
    * Returns the name of the column.
@@ -70,6 +73,14 @@ public abstract class BaseColumn implements Column {
   }
 
   /**
+   * @return The default value of this column, {@link Column#DEFAULT_VALUE_NOT_SET} if not specified
+   */
+  @Override
+  public Expression defaultValue() {
+    return defaultValue;
+  }
+
+  /**
    * Builder interface for creating instances of {@link BaseColumn}.
    *
    * @param <SELF> The type of the builder.
@@ -85,6 +96,8 @@ public abstract class BaseColumn implements Column {
     SELF withNullable(boolean nullable);
 
     SELF withAutoIncrement(boolean autoIncrement);
+
+    SELF withDefaultValue(Expression defaultValue);
 
     T build();
   }
@@ -103,6 +116,7 @@ public abstract class BaseColumn implements Column {
     protected Type dataType;
     protected boolean nullable = true;
     protected boolean autoIncrement = false;
+    protected Expression defaultValue;
 
     /**
      * Sets the name of the column.
@@ -161,6 +175,18 @@ public abstract class BaseColumn implements Column {
     @Override
     public SELF withAutoIncrement(boolean autoIncrement) {
       this.autoIncrement = autoIncrement;
+      return self();
+    }
+
+    /**
+     * Sets the default value of the column.
+     *
+     * @param defaultValue The default value of the column.
+     * @return The builder instance.
+     */
+    @Override
+    public SELF withDefaultValue(Expression defaultValue) {
+      this.defaultValue = defaultValue;
       return self();
     }
 

--- a/core/src/test/java/com/datastrato/gravitino/TestColumn.java
+++ b/core/src/test/java/com/datastrato/gravitino/TestColumn.java
@@ -24,6 +24,7 @@ public class TestColumn extends BaseColumn {
       column.comment = comment;
       column.dataType = dataType;
       column.nullable = nullable;
+      column.defaultValue = defaultValue;
 
       return column;
     }

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/TestJdbcAbstractIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/TestJdbcAbstractIT.java
@@ -85,8 +85,9 @@ public abstract class TestJdbcAbstractIT {
       Assertions.assertEquals(columns.get(i).nullable(), table.columns()[i].nullable());
       Assertions.assertEquals(columns.get(i).comment(), table.columns()[i].comment());
       Assertions.assertEquals(columns.get(i).autoIncrement(), table.columns()[i].autoIncrement());
-      Assertions.assertEquals(
-          columns.get(i).getDefaultValue(), ((JdbcColumn) table.columns()[i]).getDefaultValue());
+      // TODO: uncomment this after default value is supported.
+      // Assertions.assertEquals(
+      //    columns.get(i).getDefaultValue(), ((JdbcColumn) table.columns()[i]).getDefaultValue());
       if (null != columns.get(i).getProperties()) {
         Assertions.assertEquals(
             columns.get(i).getProperties(), ((JdbcColumn) table.columns()[i]).getProperties());

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/TestMysqlTableOperations.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/TestMysqlTableOperations.java
@@ -73,7 +73,8 @@ public class TestMysqlTableOperations extends TestMysqlAbstractIT {
         new JdbcColumn.Builder()
             .withName("col_4")
             .withType(VARCHAR)
-            .withDefaultValue("hello world")
+            // TODO: uncomment this after supporting default values
+            // .withDefaultValue("hello world")
             .withNullable(false)
             .build());
     Map<String, String> properties = new HashMap<>();
@@ -179,7 +180,8 @@ public class TestMysqlTableOperations extends TestMysqlAbstractIT {
             .withName("col_2")
             .withType(VARCHAR)
             .withComment("name")
-            .withDefaultValue("hello world")
+            // TODO: uncomment this after supporting default values
+            // .withDefaultValue("hello world")
             .withNullable(false)
             .build();
     columns.add(col_2);
@@ -212,7 +214,8 @@ public class TestMysqlTableOperations extends TestMysqlAbstractIT {
             .withType(VARCHAR)
             .withComment(col_1.comment())
             .withNullable(col_1.nullable())
-            .withDefaultValue(col_1.getDefaultValue())
+            // TODO: uncomment this after supporting default values
+            // .withDefaultValue(col_1.getDefaultValue())
             .build();
     columns.add(col_1);
     columns.add(col_2);
@@ -235,7 +238,8 @@ public class TestMysqlTableOperations extends TestMysqlAbstractIT {
             .withComment(col_1.comment())
             .withProperties(col_1.getProperties())
             .withNullable(col_1.nullable())
-            .withDefaultValue(col_1.getDefaultValue())
+            // TODO: uncomment this after supporting default values
+            // .withDefaultValue(col_1.getDefaultValue())
             .build();
     col_2 =
         new JdbcColumn.Builder()
@@ -244,7 +248,8 @@ public class TestMysqlTableOperations extends TestMysqlAbstractIT {
             .withComment(newComment)
             .withProperties(col_2.getProperties())
             .withNullable(col_2.nullable())
-            .withDefaultValue(col_2.getDefaultValue())
+            // TODO: uncomment this after supporting default values
+            // .withDefaultValue(col_2.getDefaultValue())
             .build();
     columns.add(col_1);
     columns.add(col_2);
@@ -269,7 +274,8 @@ public class TestMysqlTableOperations extends TestMysqlAbstractIT {
             .withComment(col_1.comment())
             .withProperties(col_1.getProperties())
             .withNullable(col_1.nullable())
-            .withDefaultValue(col_1.getDefaultValue())
+            // TODO: uncomment this after supporting default values
+            // .withDefaultValue(col_1.getDefaultValue())
             .build();
     col_2 =
         new JdbcColumn.Builder()
@@ -278,7 +284,8 @@ public class TestMysqlTableOperations extends TestMysqlAbstractIT {
             .withComment(col_2.comment())
             .withProperties(col_2.getProperties())
             .withNullable(col_2.nullable())
-            .withDefaultValue(col_2.getDefaultValue())
+            // TODO: uncomment this after supporting default values
+            // .withDefaultValue(col_2.getDefaultValue())
             .build();
     columns.add(col_1);
     columns.add(col_2);
@@ -305,7 +312,8 @@ public class TestMysqlTableOperations extends TestMysqlAbstractIT {
             .withType(col_2.dataType())
             .withComment(newCol2Comment)
             .withProperties(col_2.getProperties())
-            .withDefaultValue(col_2.getDefaultValue())
+            // TODO: uncomment this after supporting default values
+            // .withDefaultValue(col_2.getDefaultValue())
             .withNullable(col_2.nullable())
             .build());
     columns.add(col_1);
@@ -354,14 +362,16 @@ public class TestMysqlTableOperations extends TestMysqlAbstractIT {
             .withType(Types.DecimalType.of(10, 2))
             .withComment("test_decimal")
             .withNullable(false)
-            .withDefaultValue("0.00")
+            // TODO: uncomment this after supporting default values
+            // .withDefaultValue("0.00")
             .build());
     columns.add(
         new JdbcColumn.Builder()
             .withName("col_2")
             .withType(Types.LongType.get())
             .withNullable(false)
-            .withDefaultValue("0")
+            // TODO: uncomment this after supporting default values
+            // .withDefaultValue("0")
             .withComment("long type")
             .build());
     columns.add(
@@ -371,7 +381,8 @@ public class TestMysqlTableOperations extends TestMysqlAbstractIT {
             // MySQL 5.7 doesn't support nullable timestamp
             .withNullable(false)
             .withComment("timestamp")
-            .withDefaultValue("2013-01-01 00:00:00")
+            // TODO: uncomment this after supporting default values
+            // .withDefaultValue("2013-01-01 00:00:00")
             .build());
     columns.add(
         new JdbcColumn.Builder()
@@ -540,7 +551,8 @@ public class TestMysqlTableOperations extends TestMysqlAbstractIT {
               .withType(Types.DecimalType.of(10, 2))
               .withComment("test_decimal")
               .withNullable(false)
-              .withDefaultValue("0.00")
+              // TODO: uncomment this after supporting default values
+              // .withDefaultValue("0.00")
               .build()
         },
         "test_comment",
@@ -563,7 +575,8 @@ public class TestMysqlTableOperations extends TestMysqlAbstractIT {
               .withType(Types.DecimalType.of(10, 2))
               .withComment("test_decimal")
               .withNullable(false)
-              .withDefaultValue("0.00")
+              // TODO: uncomment this after supporting default values
+              // .withDefaultValue("0.00")
               .build()
         },
         "test_comment",

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/TestPostgreSqlTableOperations.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/TestPostgreSqlTableOperations.java
@@ -63,7 +63,8 @@ public class TestPostgreSqlTableOperations extends TestPostgreSqlAbstractIT {
         new JdbcColumn.Builder()
             .withName("col_4")
             .withType(VARCHAR)
-            .withDefaultValue("hello world")
+            // TODO: umcomment this line when default value is supported
+            // .withDefaultValue("hello world")
             .withNullable(false)
             .build());
     Map<String, String> properties = new HashMap<>();


### PR DESCRIPTION
### What changes were proposed in this pull request?

- add `defaultValue()` in Column API
- remove the duplicate methods from the subclass.

### Why are the changes needed?

Fix: #1392 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

There is no specific implementation, so testing is not required.