### PR TITLE
[#1391] fix(UI): Fix update metalake error in the web UI

### DIFF
--- a/web/app/(home)/CreateMetalakeDialog.js
+++ b/web/app/(home)/CreateMetalakeDialog.js
@@ -118,7 +118,7 @@ const CreateMetalakeDialog = props => {
   useEffect(() => {
     if (open && JSON.stringify(data) !== '{}') {
       setCacheData(data)
-      const { properties } = data
+      const { properties = {} } = data
 
       const propsArr = Object.keys(properties).map(item => {
         return {

--- a/web/app/metalakes/CreateCatalogDialog.js
+++ b/web/app/metalakes/CreateCatalogDialog.js
@@ -215,7 +215,7 @@ const CreateCatalogDialog = props => {
   useEffect(() => {
     if (open && JSON.stringify(data) !== '{}') {
       setCacheData(data)
-      const { properties } = data
+      const { properties = {} } = data
 
       const propsArr = Object.keys(properties).map(item => {
         return {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix update metalake error in the web UI.

The reason for the error is that the existing metalake is not set with `properties`, causing an error unable to find properties when deconstructing the `properties` of metalake.

The solution is to set an empty object to the `properties`.

1. existed metalake without `properties`
<img width="389" alt="no-props" src="https://github.com/datastrato/gravitino/assets/17310559/42478741-3163-49c8-8ac5-54116abcc035">

2. click `update metalake` icon button, and now the update pop-up will display correctly.
<img width="596" alt="update-metalake" src="https://github.com/datastrato/gravitino/assets/17310559/7fc99516-abb9-4412-a032-326765357023">



### Why are the changes needed?

Fix: #1391
Fix: #1397

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
