### PR TITLE
[#1401] chore: Download the exact version of `gradle-wrapper.jar`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -206,9 +206,6 @@
    This product bundles various third-party components also under the
    Apache Software License 2.0.
 
-   Gradle Wrapper
-   ./gradlew
-
    Apache Spark
    ./api/src/main/java/com/datastrato/gravitino/rel/SchemaChange.java
    ./api/src/main/java/com/datastrato/gravitino/rel/SupportsSchemas.java
@@ -241,6 +238,7 @@
    ./core/src/main/java/com/datastrato/gravitino/utils/ClientPoolImpl.java
    ./common/src/main/java/com/datastrato/gravitino/dto/responses/OAuth2TokenResponse.java
    ./clients/client-java/src/main/java/com/datastrato/gravitino/client/OAuth2ClientUtil.java
+   ./gradlew
 
    Apache Hive
    ./catalogs/catalog-hive/src/test/resources/hive-schema-3.1.0.derby.sql

--- a/gradlew
+++ b/gradlew
@@ -93,7 +93,7 @@ if [ ! -e $APP_HOME/gradle/wrapper/gradle-wrapper.jar ]; then
     GRADLE_VERSION=${GRADLE_VERSION%-bin}
     GRADLE_VERSION=${GRADLE_VERSION%-all}
     # when GRADLE_VERSION is X.Y, the tag is vX.Y.0
-    if [[ $GRADLE_VERSION =~ ^[1-9]+\.[1-9]+$ ]]; then
+    if [[ $(echo $GRADLE_VERSION | tr -cd '.' | wc -c) -eq 1 ]]; then
       GRADLE_TAG="v$GRADLE_VERSION.0"
     else
       GRADLE_TAG="v$GRADLE_VERSION"

--- a/gradlew
+++ b/gradlew
@@ -86,7 +86,21 @@ APP_BASE_NAME=${0##*/}
 APP_HOME=$( cd "${APP_HOME:-./}" && pwd -P ) || exit
 
 if [ ! -e $APP_HOME/gradle/wrapper/gradle-wrapper.jar ]; then
-    curl -o $APP_HOME/gradle/wrapper/gradle-wrapper.jar https://raw.githubusercontent.com/gradle/gradle/v8.1.1/gradle/wrapper/gradle-wrapper.jar
+    GRADLE_WRAPPER_FILENAME=$(grep 'distributionUrl' gradle/wrapper/gradle-wrapper.properties | awk -F '/' '{print $NF}')
+    # the GRADLE_WRAPPER_FILENAME could be either "gradle-X.Y[.Z]-all.zip" or "gradle-X.Y[.Z]-bin.zip"
+    GRADLE_VERSION=${GRADLE_WRAPPER_FILENAME#gradle-}
+    GRADLE_VERSION=${GRADLE_VERSION%.zip}
+    GRADLE_VERSION=${GRADLE_VERSION%-bin}
+    GRADLE_VERSION=${GRADLE_VERSION%-all}
+    # when GRADLE_VERSION is X.Y, the tag is vX.Y.0
+    if [[ $GRADLE_VERSION =~ ^[1-9]+\.[1-9]+$ ]]; then
+      GRADLE_TAG="v$GRADLE_VERSION.0"
+    else
+      GRADLE_TAG="v$GRADLE_VERSION"
+    fi
+    GRADLE_WRAPPER_URL="https://raw.githubusercontent.com/gradle/gradle/${GRADLE_TAG}/gradle/wrapper/gradle-wrapper.jar"
+    echo "Downloading $GRADLE_WRAPPER_URL"
+    curl -o $APP_HOME/gradle/wrapper/gradle-wrapper.jar "$GRADLE_WRAPPER_URL"
 fi
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.

--- a/gradlew
+++ b/gradlew
@@ -93,7 +93,7 @@ if [ ! -e $APP_HOME/gradle/wrapper/gradle-wrapper.jar ]; then
     GRADLE_VERSION=${GRADLE_VERSION%-bin}
     GRADLE_VERSION=${GRADLE_VERSION%-all}
     # when GRADLE_VERSION is X.Y, the tag is vX.Y.0
-    if [[ $(echo $GRADLE_VERSION | tr -cd '.' | wc -c) -eq 1 ]]; then
+    if [ $(echo $GRADLE_VERSION | tr -cd '.' | wc -c) -eq 1 ]; then
       GRADLE_TAG="v$GRADLE_VERSION.0"
     else
       GRADLE_TAG="v$GRADLE_VERSION"


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Update the `./gradlew` to extract the Gradle version and calculate the tag to download the exact version of `gradle-wrapper.jar`

### Why are the changes needed?

Fix: #1401

### Does this PR introduce _any_ user-facing change?

No. It's devs only

### How was this patch tested?

Manually test, and pass GA.

With this patch, performing `./gradlew` command will download the exact version declared in `gradle/wrapper/gradle-wrapper.properties`
```
➜  gravitino git:(1401) ./gradlew clean
download https://raw.githubusercontent.com/gradle/gradle/v8.2.0/gradle/wrapper/gradle-wrapper.jar
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 63375  100 63375    0     0  95041      0 --:--:-- --:--:-- --:--:-- 95014
```
