### PR TITLE
[#1403] fix(UI): Remove unnecessary fields when creating a catalog in the web UI

### DIFF
--- a/web/app/metalakes/CreateCatalogDialog.js
+++ b/web/app/metalakes/CreateCatalogDialog.js
@@ -172,11 +172,30 @@ const CreateCatalogDialog = props => {
     schema
       .validate(validData)
       .then(() => {
-        const properties = innerProps.reduce((acc, item) => {
+        let properties = {}
+
+        const prevProperties = innerProps.reduce((acc, item) => {
           acc[item.key] = item.value
 
           return acc
         }, {})
+
+        const {
+          'catalog-backend': catalogBackend,
+          'jdbc-driver': jdbcDriver,
+          'jdbc-user': jdbcUser,
+          'jdbc-password': jdbcPwd,
+          ...others
+        } = prevProperties
+
+        if (catalogBackend && catalogBackend === 'hive') {
+          properties = {
+            'catalog-backend': catalogBackend,
+            ...others
+          }
+        } else {
+          properties = prevProperties
+        }
 
         const catalogData = {
           ...mainData,

--- a/web/lib/provider/session.js
+++ b/web/lib/provider/session.js
@@ -58,7 +58,6 @@ const AuthProvider = ({ children }) => {
 
       if (authType === 'simple') {
         dispatch(initialVersion())
-        router.replace('/')
       } else {
         if (token) {
           dispatch(setIntervalId())

--- a/web/lib/utils/axios/index.ts
+++ b/web/lib/utils/axios/index.ts
@@ -240,7 +240,10 @@ function createAxios(opt?: Partial<CreateAxiosOptions>) {
         // ** authentication schemes, e.g: Bearer
         authenticationScheme: 'Bearer',
         timeout: 0,
-        headers: { 'Content-Type': ContentTypeEnum.JSON },
+        headers: {
+          'Content-Type': ContentTypeEnum.JSON,
+          Accept: 'application/vnd.gravitino.v1+json'
+        },
         transform: clone(transform),
 
         // ** request configuration settings


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix submitted the unnecessary fields when create a catalog.

if `provider` is `iceberg`, and `catalog-backend` is `hive`, the properties payload should not includes `jdbc-*`

1. request payload
<img width="270" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/6b7a2947-0be9-49eb-8972-a302eea31d7f">

2. response data
<img width="269" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/c2b2880e-fd4e-417e-9fe9-e3dc41beef0a">


### Why are the changes needed?

Fix: #1403

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
