### PR TITLE
[#1405] Print warning message instead of failing the bootstrap when using Java prior 8u151

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -56,7 +56,7 @@ function check_java_version() {
     JVM_VERSION=$(echo "$jvmver"|sed -e 's|^1\.\([0-9][0-9]*\)\..*$|\1|')
   fi
 
-  if [ "$JVM_VERSION" -lt 8 ] || { [ "$JVM_VERSION" -eq 8 ] && [ "${jvmver#*_}" -lt 151 ]; } ; then
+  if [ "$JVM_VERSION" -lt 8 ]; then
     echo "Gravitino requires either Java 8 or newer"
     exit 1
   fi

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -63,7 +63,7 @@ function check_java_version() {
 
   # JDK 8u151 version fixed a number of security vulnerabilities and issues to improve system stability and security.
   # https://www.oracle.com/java/technologies/javase/8u151-relnotes.html
-  if [ "$JVM_VERSION" -lt 8 ] || { [ "$JVM_VERSION" -eq 8 ] && [ "${jvmver#*_}" -lt 151 ]; } ; then
+  if [[ "$JVM_VERSION" -eq 8 && "${jvmver#*_}" -lt 151 ]] ; then
     echo "[WARNING] Gravitino highly recommends using either Java 8 update 151 or newer"
   fi
 }

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -56,6 +56,11 @@ function check_java_version() {
     JVM_VERSION=$(echo "$jvmver"|sed -e 's|^1\.\([0-9][0-9]*\)\..*$|\1|')
   fi
 
+  if [ "$JVM_VERSION" -lt 8 ] || { [ "$JVM_VERSION" -eq 8 ] && [ "${jvmver#*_}" -lt 151 ]; } ; then
+    echo "Gravitino requires either Java 8 or newer"
+    exit 1
+  fi
+
   # JDK 8u151 version fixed a number of security vulnerabilities and issues to improve system stability and security.
   # https://www.oracle.com/java/technologies/javase/8u151-relnotes.html
   if [ "$JVM_VERSION" -lt 8 ] || { [ "$JVM_VERSION" -eq 8 ] && [ "${jvmver#*_}" -lt 151 ]; } ; then

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -59,8 +59,7 @@ function check_java_version() {
   # JDK 8u151 version fixed a number of security vulnerabilities and issues to improve system stability and security.
   # https://www.oracle.com/java/technologies/javase/8u151-relnotes.html
   if [ "$JVM_VERSION" -lt 8 ] || { [ "$JVM_VERSION" -eq 8 ] && [ "${jvmver#*_}" -lt 151 ]; } ; then
-    echo "Gravitino requires either Java 8 update 151 or newer"
-    exit 1;
+    echo "[WARNING] Gravitino highly recommends using either Java 8 update 151 or newer"
   fi
 }
 

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -63,7 +63,7 @@ function check_java_version() {
 
   # JDK 8u151 version fixed a number of security vulnerabilities and issues to improve system stability and security.
   # https://www.oracle.com/java/technologies/javase/8u151-relnotes.html
-  if [[ "$JVM_VERSION" -eq 8 && "${jvmver#*_}" -lt 151 ]] ; then
+  if [[ "$JVM_VERSION" -eq 8 && "${jvmver#*_}" -lt 151 ]]; then
     echo "[WARNING] Gravitino highly recommends using either Java 8 update 151 or newer"
   fi
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Print warning message instead of failing the bootstrap when using Java prior 8u151

### Why are the changes needed?

Fix: #1405

### Does this PR introduce _any_ user-facing change?

Yes, users who want to use Java prior 8u151 to bootstrap Gravitino just get an warning message instead of failing.

### How was this patch tested?

Manually review
