### PR TITLE
[#1390]improvement(hive):Check whether a hive table is external when purge table

### DIFF
--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/ErrorHandlers.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/ErrorHandlers.java
@@ -139,6 +139,8 @@ public class ErrorHandlers {
 
         case ErrorConstants.INTERNAL_ERROR_CODE:
           throw new RuntimeException(errorMessage);
+        case ErrorConstants.UNSUPPORTED_OPERATION_CODE:
+          throw new UnsupportedOperationException(errorMessage);
       }
 
       super.accept(errorResponse);

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
@@ -245,21 +245,15 @@ public class RelationalCatalog extends CatalogDTO implements TableCatalog, Suppo
 
     Map<String, String> params = new HashMap<>();
     params.put("purge", "true");
-    try {
-      DropResponse resp =
-          restClient.delete(
-              formatTableRequestPath(ident.namespace()) + "/" + ident.name(),
-              params,
-              DropResponse.class,
-              Collections.emptyMap(),
-              ErrorHandlers.tableErrorHandler());
-      resp.validate();
-      return resp.dropped();
-
-    } catch (Exception e) {
-      LOG.warn("Failed to purge table {}", ident, e);
-      return false;
-    }
+    DropResponse resp =
+        restClient.delete(
+            formatTableRequestPath(ident.namespace()) + "/" + ident.name(),
+            params,
+            DropResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.tableErrorHandler());
+    resp.validate();
+    return resp.dropped();
   }
 
   /**

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
@@ -245,15 +245,23 @@ public class RelationalCatalog extends CatalogDTO implements TableCatalog, Suppo
 
     Map<String, String> params = new HashMap<>();
     params.put("purge", "true");
-    DropResponse resp =
-        restClient.delete(
-            formatTableRequestPath(ident.namespace()) + "/" + ident.name(),
-            params,
-            DropResponse.class,
-            Collections.emptyMap(),
-            ErrorHandlers.tableErrorHandler());
-    resp.validate();
-    return resp.dropped();
+    try {
+      DropResponse resp =
+          restClient.delete(
+              formatTableRequestPath(ident.namespace()) + "/" + ident.name(),
+              params,
+              DropResponse.class,
+              Collections.emptyMap(),
+              ErrorHandlers.tableErrorHandler());
+      resp.validate();
+      return resp.dropped();
+
+    } catch (UnsupportedOperationException e) {
+      throw e;
+    } catch (Exception e) {
+      LOG.warn("Failed to purge table {}", ident, e);
+      return false;
+    }
   }
 
   /**

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalCatalog.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalCatalog.java
@@ -934,7 +934,10 @@ public class TestRelationalCatalog extends TestBase {
     ErrorResponse errorResp = ErrorResponse.internalError("internal error");
     buildMockResource(Method.DELETE, tablePath, null, errorResp, SC_INTERNAL_SERVER_ERROR);
 
-    Assertions.assertFalse(catalog.asTableCatalog().purgeTable(tableId));
+    Assertions.assertThrows(
+        RuntimeException.class,
+        () -> catalog.asTableCatalog().purgeTable(tableId),
+        "internal error");
   }
 
   private void testAlterTable(NameIdentifier ident, TableUpdateRequest req, TableDTO updatedTable)

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalCatalog.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalCatalog.java
@@ -9,6 +9,7 @@ import static com.datastrato.gravitino.rel.expressions.sorts.SortDirection.DESCE
 import static org.apache.hc.core5.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.hc.core5.http.HttpStatus.SC_CONFLICT;
 import static org.apache.hc.core5.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
+import static org.apache.hc.core5.http.HttpStatus.SC_METHOD_NOT_ALLOWED;
 import static org.apache.hc.core5.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.hc.core5.http.HttpStatus.SC_OK;
 
@@ -934,10 +935,33 @@ public class TestRelationalCatalog extends TestBase {
     ErrorResponse errorResp = ErrorResponse.internalError("internal error");
     buildMockResource(Method.DELETE, tablePath, null, errorResp, SC_INTERNAL_SERVER_ERROR);
 
+    Assertions.assertFalse(catalog.asTableCatalog().purgeTable(tableId));
+  }
+
+  @Test
+  public void testPurgeExternalTable() throws JsonProcessingException {
+    NameIdentifier tableId = NameIdentifier.of(metalakeName, catalogName, "schema1", "table1");
+    String tablePath =
+        withSlash(
+            RelationalCatalog.formatTableRequestPath(tableId.namespace()) + "/" + tableId.name());
+    DropResponse resp = new DropResponse(true);
+    buildMockResource(Method.DELETE, tablePath, null, resp, SC_OK);
+
+    Assertions.assertTrue(catalog.asTableCatalog().purgeTable(tableId));
+
+    // return false
+    resp = new DropResponse(false);
+    buildMockResource(Method.DELETE, tablePath, null, resp, SC_OK);
+    Assertions.assertFalse(catalog.asTableCatalog().purgeTable(tableId));
+
+    // Test with exception
+    ErrorResponse errorResp = ErrorResponse.unsupportedOperation("Unsupported operation");
+    buildMockResource(Method.DELETE, tablePath, null, errorResp, SC_METHOD_NOT_ALLOWED);
+
     Assertions.assertThrows(
-        RuntimeException.class,
+        UnsupportedOperationException.class,
         () -> catalog.asTableCatalog().purgeTable(tableId),
-        "internal error");
+        "Unsupported operation");
   }
 
   private void testAlterTable(NameIdentifier ident, TableUpdateRequest req, TableDTO updatedTable)

--- a/common/src/main/java/com/datastrato/gravitino/dto/responses/ErrorConstants.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/responses/ErrorConstants.java
@@ -13,4 +13,5 @@ public class ErrorConstants {
   public static final int ALREADY_EXISTS_CODE = 1004;
   public static final int NON_EMPTY_CODE = 1005;
   public static final int UNKNOWN_ERROR_CODE = 1100;
+  public static final int UNSUPPORTED_OPERATION_CODE = 1101;
 }

--- a/common/src/main/java/com/datastrato/gravitino/dto/responses/ErrorConstants.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/responses/ErrorConstants.java
@@ -12,6 +12,6 @@ public class ErrorConstants {
   public static final int NOT_FOUND_CODE = 1003;
   public static final int ALREADY_EXISTS_CODE = 1004;
   public static final int NON_EMPTY_CODE = 1005;
+  public static final int UNSUPPORTED_OPERATION_CODE = 1006;
   public static final int UNKNOWN_ERROR_CODE = 1100;
-  public static final int UNSUPPORTED_OPERATION_CODE = 1101;
 }

--- a/common/src/main/java/com/datastrato/gravitino/dto/responses/ErrorResponse.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/responses/ErrorResponse.java
@@ -138,6 +138,18 @@ public class ErrorResponse extends BaseResponse {
     return new ErrorResponse(code, type, message, null);
   }
 
+  public static ErrorResponse unsupportedOperation(String message) {
+    return unsupportedOperation(message, null);
+  }
+
+  public static ErrorResponse unsupportedOperation(String message, Throwable throwable) {
+    return new ErrorResponse(
+        ErrorConstants.UNSUPPORTED_OPERATION_CODE,
+        UnsupportedOperationException.class.getSimpleName(),
+        message,
+        getStackTrace(throwable));
+  }
+
   private static List<String> getStackTrace(Throwable throwable) {
     if (throwable == null) {
       return null;

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/hive/CatalogHiveIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/hive/CatalogHiveIT.java
@@ -20,6 +20,7 @@ import static com.datastrato.gravitino.catalog.hive.HiveTablePropertiesMetadata.
 import static com.datastrato.gravitino.catalog.hive.HiveTablePropertiesMetadata.TOTAL_SIZE;
 import static com.datastrato.gravitino.catalog.hive.HiveTablePropertiesMetadata.TRANSIENT_LAST_DDL_TIME;
 import static org.apache.hadoop.hive.metastore.TableType.EXTERNAL_TABLE;
+import static org.apache.hadoop.hive.metastore.TableType.MANAGED_TABLE;
 import static org.apache.hadoop.hive.serde.serdeConstants.DATE_TYPE_NAME;
 import static org.apache.hadoop.hive.serde.serdeConstants.INT_TYPE_NAME;
 import static org.apache.hadoop.hive.serde.serdeConstants.STRING_TYPE_NAME;
@@ -68,6 +69,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
@@ -1125,5 +1127,64 @@ public class CatalogHiveIT extends AbstractIT {
 
     Assertions.assertThrows(
         NoSuchMetalakeException.class, () -> client.loadMetalake(NameIdentifier.of(metalakeName1)));
+  }
+
+  @Test
+  public void testPurgeHiveManagedTable() throws TException, InterruptedException, IOException {
+    ColumnDTO[] columns = createColumns();
+    catalog
+        .asTableCatalog()
+        .createTable(
+            NameIdentifier.of(metalakeName, catalogName, schemaName, tableName),
+            columns,
+            TABLE_COMMENT,
+            createProperties(),
+            new Partitioning[] {IdentityPartitioningDTO.of(columns[2].name())});
+    // Directly get table from hive metastore to check if the table is created successfully.
+    org.apache.hadoop.hive.metastore.api.Table hiveTab =
+        hiveClientPool.run(client -> client.getTable(schemaName, tableName));
+    checkTableReadWrite(hiveTab);
+    Assertions.assertEquals(MANAGED_TABLE.name(), hiveTab.getTableType());
+    catalog
+        .asTableCatalog()
+        .purgeTable(NameIdentifier.of(metalakeName, catalogName, schemaName, tableName));
+    Boolean existed = hiveClientPool.run(client -> client.tableExists(schemaName, tableName));
+    Assertions.assertFalse(existed, "The hive table should not exist");
+    Path tableDirectory = new Path(hiveTab.getSd().getLocation());
+    Assertions.assertFalse(hdfs.exists(tableDirectory), "The table directory should not exist");
+    Path trashDirectory = hdfs.getTrashRoot(tableDirectory);
+    Assertions.assertFalse(hdfs.exists(trashDirectory), "The trash should not exist");
+  }
+
+  @Test
+  public void testPurgeHiveExternalTable() throws TException, InterruptedException, IOException {
+    ColumnDTO[] columns = createColumns();
+    catalog
+        .asTableCatalog()
+        .createTable(
+            NameIdentifier.of(metalakeName, catalogName, schemaName, tableName),
+            columns,
+            TABLE_COMMENT,
+            ImmutableMap.of(TABLE_TYPE, EXTERNAL_TABLE.name().toLowerCase(Locale.ROOT)),
+            new Partitioning[] {IdentityPartitioningDTO.of(columns[2].name())});
+    // Directly get table from hive metastore to check if the table is created successfully.
+    org.apache.hadoop.hive.metastore.api.Table hiveTab =
+        hiveClientPool.run(client -> client.getTable(schemaName, tableName));
+    checkTableReadWrite(hiveTab);
+    Assertions.assertEquals(EXTERNAL_TABLE.name(), hiveTab.getTableType());
+    Assertions.assertThrows(
+        UnsupportedOperationException.class,
+        () -> {
+          catalog
+              .asTableCatalog()
+              .purgeTable(NameIdentifier.of(metalakeName, catalogName, schemaName, tableName));
+        },
+        "Can't purge a external hive table");
+
+    Boolean existed = hiveClientPool.run(client -> client.tableExists(schemaName, tableName));
+    Assertions.assertTrue(existed, "The table should be still exist");
+    Path tableDirectory = new Path(hiveTab.getSd().getLocation());
+    Assertions.assertTrue(
+        hdfs.listStatus(tableDirectory).length > 0, "The table should not be empty");
   }
 }

--- a/server/src/main/java/com/datastrato/gravitino/server/web/Utils.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/Utils.java
@@ -99,6 +99,17 @@ public class Utils {
         .build();
   }
 
+  public static Response unsupportedOperation(String message) {
+    return unsupportedOperation(message, null);
+  }
+
+  public static Response unsupportedOperation(String message, Throwable throwable) {
+    return Response.status(Response.Status.METHOD_NOT_ALLOWED)
+        .entity(ErrorResponse.unsupportedOperation(message, throwable))
+        .type(MediaType.APPLICATION_JSON)
+        .build();
+  }
+
   public static Response doAs(
       HttpServletRequest httpRequest, PrivilegedExceptionAction<Response> action) throws Exception {
     UserPrincipal principal =

--- a/server/src/main/java/com/datastrato/gravitino/server/web/rest/ExceptionHandlers.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/rest/ExceptionHandlers.java
@@ -66,6 +66,9 @@ public class ExceptionHandlers {
       } else if (e instanceof TableAlreadyExistsException) {
         return Utils.alreadyExists(errorMsg, e);
 
+      } else if (e instanceof UnsupportedOperationException) {
+        return Utils.unsupportedOperation(errorMsg, e);
+
       } else {
         return super.handle(op, table, schema, e);
       }

--- a/server/src/test/java/com/datastrato/gravitino/server/web/TestUtils.java
+++ b/server/src/test/java/com/datastrato/gravitino/server/web/TestUtils.java
@@ -119,4 +119,14 @@ public class TestUtils {
     assertEquals("RuntimeException", errorResponse.getType());
     assertEquals("New message", errorResponse.getMessage());
   }
+
+  @Test
+  public void testUnsupportedOperation() {
+    Response response = Utils.unsupportedOperation("Unsupported operation");
+    assertNotNull(response);
+    assertEquals(Response.Status.METHOD_NOT_ALLOWED.getStatusCode(), response.getStatus());
+    assertEquals(MediaType.APPLICATION_JSON, response.getMediaType().toString());
+    ErrorResponse errorResponse = (ErrorResponse) response.getEntity();
+    assertEquals("Invalid argument", errorResponse.getMessage());
+  }
 }

--- a/server/src/test/java/com/datastrato/gravitino/server/web/TestUtils.java
+++ b/server/src/test/java/com/datastrato/gravitino/server/web/TestUtils.java
@@ -127,6 +127,6 @@ public class TestUtils {
     assertEquals(Response.Status.METHOD_NOT_ALLOWED.getStatusCode(), response.getStatus());
     assertEquals(MediaType.APPLICATION_JSON, response.getMediaType().toString());
     ErrorResponse errorResponse = (ErrorResponse) response.getEntity();
-    assertEquals("Invalid argument", errorResponse.getMessage());
+    assertEquals("Unsupported operation", errorResponse.getMessage());
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

fix  #1390  

### Why are the changes needed?

(Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  - no
  2. If you fix a bug, describe the bug.)
  - Check whether a hive table is external when purge table

Fix: #1390 

### Does this PR introduce _any_ user-facing change?
- no

### How was this patch tested?
- added unit tests

