### PR TITLE
[#1396] improvement(UI): Reword update to edit

### DIFF
--- a/web/app/(home)/CreateMetalakeDialog.js
+++ b/web/app/(home)/CreateMetalakeDialog.js
@@ -52,7 +52,7 @@ const CreateMetalakeDialog = props => {
   const [innerProps, setInnerProps] = useState([])
   const [cacheData, setCacheData] = useState()
 
-  const typeText = type === 'create' ? 'Create' : 'Update'
+  const typeText = type === 'create' ? 'Create' : 'Edit'
 
   const {
     control,
@@ -250,7 +250,7 @@ const CreateMetalakeDialog = props => {
         </DialogContent>
         <DialogActions className={' twc-px-5 md:twc-px-15 twc-pb-5 md:twc-pb-[12.5 0.25 rem]'}>
           <Button variant='contained' type='submit'>
-            {typeText}
+            {typeText === 'Edit' ? 'Update' : typeText}
           </Button>
           <Button variant='outlined' className={'twc-ml-1'} onClick={handleClose} type='reset'>
             Cancel

--- a/web/app/(home)/MetalakeList.js
+++ b/web/app/(home)/MetalakeList.js
@@ -149,7 +149,7 @@ const MetalakeList = () => {
             </IconButton>
           </Tooltip>
 
-          <Tooltip title='Update' placement='top'>
+          <Tooltip title='Edit' placement='top'>
             <IconButton
               size='small'
               sx={{ color: theme => theme.palette.text.secondary }}


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Reword Metalakes Actions button list `Details`, `Update`, `Delete` to `Details`, `Edit`, `Delete` as per #1396  mentioned.

### Why are the changes needed?

Fix #1396 

### Does this PR introduce _any_ user-facing change?

Yes, web UI changed

### How was this patch tested?

<img width="1280" alt="Screenshot 2024-01-10 at 5 51 40 PM" src="https://github.com/datastrato/gravitino/assets/35886692/814c12bd-e743-4962-9029-4dc7322445bb">

