### PR TITLE
[#1447] improvement: Enable impersonation of Hive Docker image

### DIFF
--- a/dev/docker/hive/hive-site.xml
+++ b/dev/docker/hive/hive-site.xml
@@ -1,7 +1,7 @@
 <configuration>
   <property>
     <name>hive.server2.enable.doAs</name>
-    <value>false</value>
+    <value>true</value>
     <description>Disable user impersonation for HiveServer2</description>
   </property>
 

--- a/docs/docker-image-details.md
+++ b/docs/docker-image-details.md
@@ -69,7 +69,7 @@ You can use this kind of image to test the catalog of Apache Hive.
 Changelog
 
 - gravitino-ci-hive:0.1.8
-  - Change the configuration of `hive.server2.enable.doAs` to `true`
+  - Change the value of `hive.server2.enable.doAs` to `true`
 
 - gravitino-ci-hive:0.1.7
   - Download MySQL JDBC driver before building the Docker image

--- a/docs/docker-image-details.md
+++ b/docs/docker-image-details.md
@@ -68,6 +68,9 @@ You can use this kind of image to test the catalog of Apache Hive.
 
 Changelog
 
+- gravitino-ci-hive:0.1.8
+  - Change the configuration of `hive.server2.enable.doAs` to `true`
+
 - gravitino-ci-hive:0.1.7
   - Download MySQL JDBC driver before building the Docker image
   - Set `hdfs` as HDFS superuser group


### PR DESCRIPTION
### What changes were proposed in this pull request?

Enable Impersonation of Hive Docker image.

### Why are the changes needed?

Fix: #1447

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By hand. I ever builded a local image to test it.
