### PR TITLE
[#1474] improvement(tests): Fix TestHTTPClient crashed for port conflict

### DIFF
--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestHTTPClient.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestHTTPClient.java
@@ -58,8 +58,6 @@ import org.mockserver.model.HttpResponse;
  */
 public class TestHTTPClient {
 
-  private static final int PORT = 1080;
-  private static final String URI = String.format("http://127.0.0.1:%d", PORT);
   private static final ObjectMapper MAPPER = JsonUtils.objectMapper();
 
   private static ClientAndServer mockServer;
@@ -67,8 +65,11 @@ public class TestHTTPClient {
 
   @BeforeAll
   public static void beforeClass() {
-    mockServer = startClientAndServer(PORT);
-    restClient = HTTPClient.builder(ImmutableMap.of()).uri(URI).build();
+    mockServer = startClientAndServer();
+    restClient =
+        HTTPClient.builder(ImmutableMap.of())
+            .uri(String.format("http://127.0.0.1:%d", mockServer.getPort()))
+            .build();
   }
 
   @AfterAll


### PR DESCRIPTION
### What changes were proposed in this pull request?

fix TestHTTPClient crash when port 1080 is using by another process.

### Why are the changes needed?

Fix: #1474 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
No need.
