### PR TITLE
[#1507] improvement(clients, catalogs): Remove unnecessary build directory of project `catalogs` and `clients`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,39 +88,40 @@ licenseReport {
 repositories { mavenCentral() }
 
 allprojects {
-  apply(plugin = "com.diffplug.spotless")
+  if ((project.name != "catalogs") && project.name != "clients") {
+    apply(plugin = "com.diffplug.spotless")
+    repositories {
+      mavenCentral()
+      mavenLocal()
+    }
 
-  repositories {
-    mavenCentral()
-    mavenLocal()
-  }
+    plugins.withType<com.diffplug.gradle.spotless.SpotlessPlugin>().configureEach {
+      configure<com.diffplug.gradle.spotless.SpotlessExtension> {
+        java {
+          // Fix the Google Java Format version to 1.7. Since JDK8 only support Google Java Format
+          // 1.7, which is not compatible with JDK17. We will use a newer version when we upgrade to
+          // JDK17.
+          googleJavaFormat("1.7")
+          removeUnusedImports()
+          trimTrailingWhitespace()
+          replaceRegex(
+            "Remove wildcard imports",
+            "import\\s+[^\\*\\s]+\\*;(\\r\\n|\\r|\\n)",
+            "$1"
+          )
+          replaceRegex(
+            "Remove static wildcard imports",
+            "import\\s+(?:static\\s+)?[^*\\s]+\\*;(\\r\\n|\\r|\\n)",
+            "$1"
+          )
 
-  plugins.withType<com.diffplug.gradle.spotless.SpotlessPlugin>().configureEach {
-    configure<com.diffplug.gradle.spotless.SpotlessExtension> {
-      java {
-        // Fix the Google Java Format version to 1.7. Since JDK8 only support Google Java Format
-        // 1.7, which is not compatible with JDK17. We will use a newer version when we upgrade to
-        // JDK17.
-        googleJavaFormat("1.7")
-        removeUnusedImports()
-        trimTrailingWhitespace()
-        replaceRegex(
-          "Remove wildcard imports",
-          "import\\s+[^\\*\\s]+\\*;(\\r\\n|\\r|\\n)",
-          "$1"
-        )
-        replaceRegex(
-          "Remove static wildcard imports",
-          "import\\s+(?:static\\s+)?[^*\\s]+\\*;(\\r\\n|\\r|\\n)",
-          "$1"
-        )
+          targetExclude("**/build/**")
+        }
 
-        targetExclude("**/build/**")
-      }
-
-      kotlinGradle {
-        target("*.gradle.kts")
-        ktlint().editorConfigOverride(mapOf("indent_size" to 2))
+        kotlinGradle {
+          target("*.gradle.kts")
+          ktlint().editorConfigOverride(mapOf("indent_size" to 2))
+        }
       }
     }
   }
@@ -170,6 +171,12 @@ subprojects {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
       }
+    }
+  }
+
+  if ((project.name == "catalogs") || project.name == "clients") {
+    tasks.withType<Jar> {
+      enabled = false
     }
   }
 


### PR DESCRIPTION


### What changes were proposed in this pull request?

Change the build script to avoid generating build directory in project `catalogs` and `clients`

### Why are the changes needed?

Make the project more formal and well designed.  

Fix: #1507 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Test locally. after build
<img width="596" alt="image" src="https://github.com/datastrato/gravitino/assets/15794564/0d22116d-8bf5-48e6-8da4-848dcc7e0f06">

