### PR TITLE
[#1492] fix(UI): Fix tree view icon and add column type chip styles

### DIFF
--- a/web/app/metalakes/LeftContent.js
+++ b/web/app/metalakes/LeftContent.js
@@ -19,7 +19,7 @@ const SidebarLeft = props => {
 
         <Box
           className={`twc-overflow-y-auto`}
-          sx={{ p: theme => theme.spacing(2.5, 2.5, 2.5), height: `calc(100% - 4rem)` }}
+          sx={{ p: theme => theme.spacing(2.5, 2.5, 2.5), height: `calc(100% - 1.5rem)` }}
         >
           <MetalakeTree routeParams={routeParams} />
         </Box>

--- a/web/app/metalakes/MetalakePath.js
+++ b/web/app/metalakes/MetalakePath.js
@@ -8,10 +8,15 @@
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 
-import MUILink from '@mui/material/Link'
-import Breadcrumbs from '@mui/material/Breadcrumbs'
+import { Link as MUILink, Breadcrumbs, Typography, styled } from '@mui/material'
 
 import Icon from '@/components/Icon'
+
+const Text = styled(Typography)(({ theme }) => ({
+  maxWidth: '120px',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis'
+}))
 
 const MetalakePath = props => {
   const { routeParams } = props
@@ -52,19 +57,19 @@ const MetalakePath = props => {
       {catalog && (
         <MUILink component={Link} href={catalogUrl} onClick={event => handleClick(event, catalogUrl)} underline='hover'>
           <Icon icon='bx:book' fontSize={20} />
-          {catalog}
+          <Text title={catalog}>{catalog}</Text>
         </MUILink>
       )}
       {schema && (
         <MUILink component={Link} href={schemaUrl} onClick={event => handleClick(event, schemaUrl)} underline='hover'>
           <Icon icon='bx:coin-stack' fontSize={20} />
-          {schema}
+          <Text title={schema}>{schema}</Text>
         </MUILink>
       )}
       {table && (
         <MUILink component={Link} href={tableUrl} onClick={event => handleClick(event, tableUrl)} underline='hover'>
           <Icon icon='bx:table' fontSize={20} />
-          {table}
+          <Text title={table}>{table}</Text>
         </MUILink>
       )}
     </Breadcrumbs>

--- a/web/app/metalakes/MetalakeTree.js
+++ b/web/app/metalakes/MetalakeTree.js
@@ -99,7 +99,8 @@ const StyledTreeItem = props => {
           <Icon icon={labelIcon} color='inherit' />
           <Typography
             variant='body2'
-            sx={{ flexGrow: 1, fontWeight: 'inherit' }}
+            sx={{ fontWeight: 'inherit', width: '100%', overflow: 'hidden', textOverflow: 'ellipsis' }}
+            title={labelText}
             {...(href
               ? {
                   component: StyledLink,

--- a/web/app/metalakes/TableView.js
+++ b/web/app/metalakes/TableView.js
@@ -7,7 +7,8 @@ import { useState } from 'react'
 
 import Link from 'next/link'
 
-import { Box, Typography } from '@mui/material'
+import { Box, Typography, Chip } from '@mui/material'
+import ColumnTypeChip from '@/components/ColumnTypeChip'
 import { DataGrid } from '@mui/x-data-grid'
 import { useAppSelector, useAppDispatch } from '@/lib/hooks/useStore'
 import { resetTableData } from '@/lib/store/metalakes'
@@ -43,7 +44,7 @@ const TableView = props => {
               href={path ?? '/'}
               onClick={() => handleClickUrl()}
               sx={{
-                fontWeight: 500,
+                fontWeight: 400,
                 color: 'primary.main',
                 textDecoration: 'none',
                 '&:hover': { color: 'primary.main', textDecoration: 'underline' }
@@ -71,7 +72,7 @@ const TableView = props => {
             <Typography
               noWrap
               sx={{
-                fontWeight: 500,
+                fontWeight: 400,
                 color: 'text.main',
                 textDecoration: 'none'
               }}
@@ -94,9 +95,10 @@ const TableView = props => {
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
             <Typography
               noWrap
+              variant='body2'
               sx={{
-                fontWeight: 500,
-                color: 'text.main',
+                fontWeight: 400,
+                color: 'text.secondary',
                 textDecoration: 'none'
               }}
             >
@@ -116,16 +118,7 @@ const TableView = props => {
 
         return (
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
-            <Typography
-              noWrap
-              sx={{
-                fontWeight: 500,
-                color: 'text.main',
-                textDecoration: 'none'
-              }}
-            >
-              {type}
-            </Typography>
+            <ColumnTypeChip type={type} />
           </Box>
         )
       }

--- a/web/components/ColumnTypeChip.js
+++ b/web/components/ColumnTypeChip.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+
+import { Chip } from '@mui/material'
+import { ColumnTypeColorEnum } from '@/lib/enums/columnTypeEnum'
+import colors from '@/lib/theme/colors'
+import { alpha } from '@/lib/utils/color'
+
+const ColumnTypeChip = props => {
+  const { type } = props
+
+  const bgColor = alpha(colors[ColumnTypeColorEnum[type]].main, 0.1)
+
+  return (
+    <Chip
+      size='small'
+      label={type}
+      sx={{ backgroundColor: bgColor }}
+      color={ColumnTypeColorEnum[type]}
+      variant='outlined'
+    />
+  )
+}
+
+export default ColumnTypeChip

--- a/web/lib/enums/columnTypeEnum.ts
+++ b/web/lib/enums/columnTypeEnum.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+
+export enum ColumnTypeColorEnum {
+  boolean = 'primary',
+  short = 'primary',
+  integer = 'primary',
+  long = 'primary',
+  float = 'primary',
+  double = 'primary',
+  'decimal(10,2)' = 'primary',
+  'fixed(16)' = 'primary',
+
+  date = 'info',
+  time = 'info',
+  timestamp = 'info',
+  timestamp_tz = 'info',
+  interval_day = 'info',
+  interval_year = 'info',
+
+  string = 'warning',
+  'char(10)' = 'warning',
+  'varchar(10)' = 'warning',
+
+  byte = 'success',
+  uuid = 'success',
+  binary = 'success'
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the tree view icon and add column type chip styles.

<img width="480" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/5dc5d646-d32e-417a-9ceb-dfec52c25234">



### Why are the changes needed?

Fix: #1492

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
