### PR TITLE
[Minor] Mention TCP port used by the playground docker containers

### DIFF
--- a/docs/how-to-use-the-playground.md
+++ b/docs/how-to-use-the-playground.md
@@ -16,6 +16,17 @@ Depending on your network and computer, startup time may take 3-5 minutes. Once 
 
 You first need to install git and docker-compose.
 
+## TCP ports used
+
+The playground runs a number of services. The TCP ports used may clash with existing services you run, such as MySQL or Postgres.
+
+| Docker container      | Ports used     |
+| playground-gravitino  | 8090 9001      |
+| playground-hive       | 3307 9000 9083 |
+| playground-mysql      | 3306           |
+| playground-postgresql | 5342           |
+| playground-trino      | 8080           |
+
 ## Start playground
 
 ```shell


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a table of TCP ports used by the playground docker containers.

### Why are the changes needed?

Make it clearer to users that they might have issues if running local services on those ports.

Fix: # N/A

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Build locally.
