### PR TITLE
[#1540] fix(UI): Add default type color for the tag in table

### DIFF
--- a/web/components/ColumnTypeChip.js
+++ b/web/components/ColumnTypeChip.js
@@ -7,15 +7,20 @@ import { Chip } from '@mui/material'
 import { ColumnTypeColorEnum } from '@/lib/enums/columnTypeEnum'
 import colors from '@/lib/theme/colors'
 import { alpha } from '@/lib/utils/color'
+import { isString } from 'lodash-es'
 
 const ColumnTypeChip = props => {
   const { type } = props
+
+  const label = isString(type) ? type : `${type.type}<${type.elementType ?? 'unknown'}>` ?? 'unknown'
 
   const columnTypeColor = ColumnTypeColorEnum[type] || 'secondary'
   const color = colors[columnTypeColor]?.main || '#8592A3'
   const bgColor = alpha(color, 0.1)
 
-  return <Chip size='small' label={type} sx={{ backgroundColor: bgColor }} color={columnTypeColor} variant='outlined' />
+  return (
+    <Chip size='small' label={label} sx={{ backgroundColor: bgColor }} color={columnTypeColor} variant='outlined' />
+  )
 }
 
 export default ColumnTypeChip

--- a/web/components/ColumnTypeChip.js
+++ b/web/components/ColumnTypeChip.js
@@ -11,17 +11,11 @@ import { alpha } from '@/lib/utils/color'
 const ColumnTypeChip = props => {
   const { type } = props
 
-  const bgColor = alpha(colors[ColumnTypeColorEnum[type]].main, 0.1)
+  const columnTypeColor = ColumnTypeColorEnum[type] || 'secondary'
+  const color = colors[columnTypeColor]?.main || '#8592A3'
+  const bgColor = alpha(color, 0.1)
 
-  return (
-    <Chip
-      size='small'
-      label={type}
-      sx={{ backgroundColor: bgColor }}
-      color={ColumnTypeColorEnum[type]}
-      variant='outlined'
-    />
-  )
+  return <Chip size='small' label={type} sx={{ backgroundColor: bgColor }} color={columnTypeColor} variant='outlined' />
 }
 
 export default ColumnTypeChip


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add default type color for the tag in table.

For example, when the type is not found in the enums and it's a `string`, this tag is default gray.

<img width="480" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/460d3be7-dbb1-4a2c-a4c6-bba09e97a819">


### Why are the changes needed?

Fix: #1540 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
