### PR TITLE
[#1544] fix(hive): fix null comment in hive table property

### DIFF
--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveTable.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveTable.java
@@ -183,7 +183,7 @@ public class HiveTable extends BaseTable {
 
   private Map<String, String> buildTableParameters() {
     Map<String, String> parameters = Maps.newHashMap(properties());
-    parameters.put(COMMENT, comment);
+    Optional.ofNullable(comment).ifPresent(c -> parameters.put(COMMENT, c));
     String ignore =
         EXTERNAL_TABLE.name().equalsIgnoreCase(properties().get(TABLE_TYPE))
             ? parameters.put(EXTERNAL, "TRUE")

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/hive/CatalogHiveIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/hive/CatalogHiveIT.java
@@ -460,6 +460,17 @@ public class CatalogHiveIT extends AbstractIT {
     assertTableEquals(createdTable, hiveTab);
     checkTableReadWrite(hiveTab);
 
+    // test null comment
+    resetSchema();
+    createdTable =
+        catalog
+            .asTableCatalog()
+            .createTable(nameIdentifier, columns, null, properties, Transforms.EMPTY_TRANSFORM);
+    org.apache.hadoop.hive.metastore.api.Table hiveTab2 =
+        hiveClientPool.run(client -> client.getTable(schemaName, tableName));
+    assertTableEquals(createdTable, hiveTab2);
+    checkTableReadWrite(hiveTab);
+
     // test null partition
     resetSchema();
     Table createdTable1 =
@@ -662,7 +673,7 @@ public class CatalogHiveIT extends AbstractIT {
     Assertions.assertEquals(schemaName.toLowerCase(), hiveTab.getDbName());
     Assertions.assertEquals(tableName.toLowerCase(), hiveTab.getTableName());
     Assertions.assertEquals("MANAGED_TABLE", hiveTab.getTableType());
-    Assertions.assertEquals(TABLE_COMMENT, hiveTab.getParameters().get("comment"));
+    Assertions.assertEquals(createdTable.comment(), hiveTab.getParameters().get("comment"));
 
     Assertions.assertEquals(HIVE_COL_NAME1, actualColumns.get(0).getName());
     Assertions.assertEquals("tinyint", actualColumns.get(0).getType());


### PR DESCRIPTION
### What changes were proposed in this pull request?

set empty string as default value of comment when creating table

### Why are the changes needed?

Fix: #1544 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

IT added
