### PR TITLE
[#1501] fix(UI): Fix tree view expand and collapse

### DIFF
--- a/web/app/metalakes/DetailsView.js
+++ b/web/app/metalakes/DetailsView.js
@@ -29,8 +29,6 @@ const DetailsView = props => {
     }
   })
 
-  console.log(activatedItem)
-
   return (
     <Box sx={{ p: 4 }}>
       <Grid container spacing={6}>

--- a/web/app/metalakes/MetalakePath.js
+++ b/web/app/metalakes/MetalakePath.js
@@ -6,7 +6,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 
 import { Link as MUILink, Breadcrumbs, Typography, styled } from '@mui/material'
 
@@ -24,6 +24,7 @@ const MetalakePath = props => {
   const { metalake, catalog, schema, table } = routeParams
 
   const router = useRouter()
+  const searchParams = useSearchParams()
 
   const metalakeUrl = `?metalake=${metalake}`
   const catalogUrl = `?metalake=${metalake}&catalog=${catalog}`
@@ -31,7 +32,7 @@ const MetalakePath = props => {
   const tableUrl = `?metalake=${metalake}&catalog=${catalog}&schema=${schema}&table=${table}`
 
   const handleClick = (event, path) => {
-    router.asPath === path && event.preventDefault()
+    path === `?${searchParams.toString()}` && event.preventDefault()
   }
 
   return (

--- a/web/app/metalakes/MetalakeView.js
+++ b/web/app/metalakes/MetalakeView.js
@@ -35,7 +35,9 @@ const MetalakeView = props => {
   useEffect(() => {
     const { metalake, catalog, schema, table } = routeParams
 
-    dispatch(initMetalakeTree({ metalake, catalog, schema, table }))
+    if (store.metalakeTree.length === 0) {
+      dispatch(initMetalakeTree({ metalake, catalog, schema, table }))
+    }
 
     switch (page) {
       case 'metalakes':

--- a/web/app/metalakes/TableView.js
+++ b/web/app/metalakes/TableView.js
@@ -7,7 +7,7 @@ import { useState } from 'react'
 
 import Link from 'next/link'
 
-import { Box, Typography, Chip } from '@mui/material'
+import { Box, Typography } from '@mui/material'
 import ColumnTypeChip from '@/components/ColumnTypeChip'
 import { DataGrid } from '@mui/x-data-grid'
 import { useAppSelector, useAppDispatch } from '@/lib/hooks/useStore'


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix tree view expand and collapse.

Default:
<img width="480" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/d22db106-4e33-44b5-89c3-ed49ac6fdf08">

Click to home page then click metalake:
<img width="480" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/3066739b-56be-499e-b53a-9ed0b8041d4b">

Click to `hive_table_2` and click `hive_table_2` again:
<img width="480" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/69940e95-049d-439c-91e2-6600a43f0f29">


### Why are the changes needed?

Fix: #1501
Fix: #1502
Fix: #1476 
Fix: #1591 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
