### PR TITLE
[#1530] feat(spark-connector): support specifying scala version to build and test Gravitino

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ if (extra["jdkVersion"] !in listOf("8", "11", "17")) {
 }
 
 val scalaVersion: String = project.properties["scalaVersion"] as? String ?: extra["defaultScalaVersion"].toString()
-if (scalaVersion !in listOf("2.12")) {
+if (scalaVersion !in listOf("2.12", "2.13")) {
   throw GradleException("Found unsupported Scala version: $scalaVersion")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,11 @@ if (extra["jdkVersion"] !in listOf("8", "11", "17")) {
   )
 }
 
+val scalaVersion: String = project.properties["scalaVersion"] as? String ?: extra["defaultScalaVersion"].toString()
+if (scalaVersion !in listOf("2.12")) {
+  throw GradleException("Found unsupported Scala version: $scalaVersion")
+}
+
 project.extra["extraJvmArgs"] = if (extra["jdkVersion"] in listOf("8", "11")) {
   listOf()
 } else {

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,3 @@ jdkVersion = 8
 
 # defaultScalaVersion is used to specify the version of Scala to build and test Gravitino
 defaultScalaVersion = 2.12
-
-# defaultSparkVersion is used to specify the version of Spark to build and test Gravitino
-defaultSparkVersion = 3.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,9 @@ SONATYPE_PASSWORD = password
 #jdkVersion is used to specify the version of JDK to build and test Gravitino, current
 # supported version is 8, 11, and 17.
 jdkVersion = 8
+
+# defaultScalaVersion is used to specify the version of Scala to build and test Gravitino
+defaultScalaVersion = 2.12
+
+# defaultSparkVersion is used to specify the version of Spark to build and test Gravitino
+defaultSparkVersion = 3.4

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -105,12 +105,8 @@ trino-testing= { group = "io.trino", name = "trino-testing", version.ref = "trin
 trino-memory= { group = "io.trino", name = "trino-memory", version.ref = "trino" }
 trino-cli= { group = "io.trino", name = "trino-cli", version.ref = "trino" }
 trino-client= { group = "io.trino", name = "trino-client", version.ref = "trino" }
-iceberg-spark-runtime = { group = "org.apache.iceberg", name = "iceberg-spark-runtime-3.4_2.13", version.ref = "iceberg" }
-spark-sql = { group = "org.apache.spark", name = "spark-sql_2.13", version.ref = "spark" }
-scala-collection-compat =  { group = "org.scala-lang.modules", name = "scala-collection-compat_2.13", version.ref = "scala-collection-compat" }
 sqlite-jdbc = { group = "org.xerial", name = "sqlite-jdbc", version.ref = "sqlite-jdbc" }
 testng = { group = "org.testng", name = "testng", version.ref = "testng" }
-spark-hive = { group = "org.apache.spark", name = "spark-hive_2.13", version.ref = "spark" }
 commons-dbcp2 = { group = "org.apache.commons", name = "commons-dbcp2", version.ref = "commons-dbcp2" }
 testcontainers = { group = "org.testcontainers", name = "testcontainers", version.ref = "testcontainers" }
 testcontainers-mysql = { group = "org.testcontainers", name = "mysql", version.ref = "testcontainers" }

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -12,6 +12,12 @@ plugins {
   id("idea")
 }
 
+val scalaVersion: String = project.properties["scalaVersion"] as? String ?: extra["defaultScalaVersion"].toString()
+val sparkMajorVersion: String = project.properties["sparkVersion"] as? String ?: extra["defaultSparkVersion"].toString()
+val sparkVersion: String = libs.versions.spark.get()
+val icebergVersion: String = libs.versions.iceberg.get()
+val scalaCollectionCompatVersion: String = libs.versions.scala.collection.compat.get()
+
 dependencies {
   implementation(project(":server"))
   implementation(project(":common"))
@@ -96,8 +102,10 @@ dependencies {
   testRuntimeOnly(libs.junit.jupiter.engine)
   testImplementation(libs.mockito.core)
   testImplementation(libs.bundles.log4j)
-  testImplementation(libs.iceberg.spark.runtime)
-  testImplementation(libs.spark.sql) {
+  testImplementation("org.apache.iceberg:iceberg-spark-runtime-${sparkMajorVersion}_$scalaVersion:$icebergVersion")
+  testImplementation("org.apache.spark:spark-hive_$scalaVersion:$sparkVersion")
+  testImplementation("org.scala-lang.modules:scala-collection-compat_$scalaVersion:$scalaCollectionCompatVersion")
+  testImplementation("org.apache.spark:spark-sql_$scalaVersion:$sparkVersion") {
     exclude("org.apache.hadoop")
     exclude("org.rocksdb")
     exclude("org.apache.avro")
@@ -105,9 +113,8 @@ dependencies {
     exclude("io.dropwizard.metrics")
   }
   testImplementation(libs.slf4j.jdk14)
-  testImplementation(libs.scala.collection.compat)
   testImplementation(libs.sqlite.jdbc)
-  testImplementation(libs.spark.hive)
+
   testImplementation(libs.testcontainers)
   testImplementation(libs.testcontainers.junit.jupiter)
   testImplementation(libs.testcontainers.mysql)

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -113,7 +113,6 @@ dependencies {
   }
   testImplementation(libs.slf4j.jdk14)
   testImplementation(libs.sqlite.jdbc)
-
   testImplementation(libs.testcontainers)
   testImplementation(libs.testcontainers.junit.jupiter)
   testImplementation(libs.testcontainers.mysql)

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -13,7 +13,6 @@ plugins {
 }
 
 val scalaVersion: String = project.properties["scalaVersion"] as? String ?: extra["defaultScalaVersion"].toString()
-val sparkMajorVersion: String = project.properties["sparkVersion"] as? String ?: extra["defaultSparkVersion"].toString()
 val sparkVersion: String = libs.versions.spark.get()
 val icebergVersion: String = libs.versions.iceberg.get()
 val scalaCollectionCompatVersion: String = libs.versions.scala.collection.compat.get()
@@ -102,7 +101,7 @@ dependencies {
   testRuntimeOnly(libs.junit.jupiter.engine)
   testImplementation(libs.mockito.core)
   testImplementation(libs.bundles.log4j)
-  testImplementation("org.apache.iceberg:iceberg-spark-runtime-${sparkMajorVersion}_$scalaVersion:$icebergVersion")
+  testImplementation("org.apache.iceberg:iceberg-spark-runtime-3.4_$scalaVersion:$icebergVersion")
   testImplementation("org.apache.spark:spark-hive_$scalaVersion:$sparkVersion")
   testImplementation("org.scala-lang.modules:scala-collection-compat_$scalaVersion:$scalaCollectionCompatVersion")
   testImplementation("org.apache.spark:spark-sql_$scalaVersion:$sparkVersion") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
support specify scala versions, by two methods:
1. `gradle build -PscalaVersion=xx`
2. set `defaultScalaVersion` in gradle.properties

method2 will be overwrite  by method1 if both existing, 
and supports scala 2.12 for now.

### Why are the changes needed?
spark hive connector just supports scala 2.12

Fix: #1530 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
existing UTs