### PR TITLE
[#1467] fix(UI): Fix refresh 404

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -40,7 +40,7 @@ const nextConfig = {
       }),
   output: process.env.OUTPUT_MODE || 'standalone',
   distDir: 'dist',
-  trailingSlash: false,
+  trailingSlash: true,
   reactStrictMode: false
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the problem of getting a 404 error when refreshing the page.

The reason is that when accessing `/metalakes`, the server did not correctly redirect to `/metalakes.html`, so accessing `/metalakes.html` is normal.

The temporary solution is to set the `trailingSlash` of the next.js configuration file to `true`.
`next.js` exports static files includes `/metalakes.html` and `/metalakes/index.html`.
When `trailingSlash = false`, accessing `/metalakes` reads the `/metalakes.html` file,
and when `trailingSlash = true`, accessing `/metalakes` reads the `/metalakes/index.html` file.

We can make relevant modifications based on the configuration of the `jetty` in the future.

`http://localhost:8090/metalakes/?metalake=test`
<img width="480" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/f0f46b8e-228c-4c4d-8446-0ef63a7b601c">


### Why are the changes needed?

Fix: #1467 
Fix: #1494 
Fix: #1554 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
