### PR TITLE
[#1467] fix(web): The refresh of the UI will lead to 404

### DIFF
--- a/web/WEB-INF/web.xml
+++ b/web/WEB-INF/web.xml
@@ -31,6 +31,19 @@
     <location>/404.html</location>
   </error-page>
 
+  <servlet>
+    <servlet-name>default</servlet-name>
+    <servlet-class>org.eclipse.jetty.servlet.DefaultServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>default</servlet-name>
+    <url-pattern>/</url-pattern>
+  </servlet-mapping>
+  <servlet-mapping>
+    <servlet-name>default</servlet-name>
+    <url-pattern>*.html</url-pattern>
+  </servlet-mapping>
+
   <context-param>
     <param-name>configuration</param-name>
     <param-value>deployment</param-value>


### PR DESCRIPTION
### What changes were proposed in this pull request?

When you refresh a Gravitino web page, It leads to a 404 error page.

### Why are the changes needed?

We configured the `DefaultServlet` to handle the URL mapping. 
First, we mapped the `DefaultServlet` to the root path `/` so that when a user accesses `abc` it will be handled by the `DefaultServlet`. 
Then, we map the `DefaultServlet` to `*.html` so that when a user accesses `abc.html` it will also be handled by the `DefaultServlet`.

In this way, when the user accesses `abc`, it will actually be handled by the `DefaultServlet` and the request will be forwarded to `abc.html`. This realizes the effect of actually accessing `abc.html` when accessing the page `abc` without a suffix.

Fix: #1467 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Manually test passed.
