### PR TITLE
[#1557] feat(hive): Handle column default value in Hive catalog

### DIFF
--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveColumn.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveColumn.java
@@ -29,6 +29,7 @@ public class HiveColumn extends BaseColumn {
       hiveColumn.comment = comment;
       hiveColumn.dataType = dataType;
       hiveColumn.nullable = nullable;
+      hiveColumn.defaultValue = defaultValue == null ? DEFAULT_VALUE_NOT_SET : defaultValue;
       return hiveColumn;
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

throw an exception, when the Hive catalog detects default values specified during table creation

### Why are the changes needed?

Fix: #1557 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

UT added
