### PR TITLE
[#1515] fix(jdbc): The format of jdbc-mysql.conf and jdbc-postgresql.conf is not correct.

### DIFF
--- a/catalogs/catalog-jdbc-mysql/src/main/resources/jdbc-mysql.conf
+++ b/catalogs/catalog-jdbc-mysql/src/main/resources/jdbc-mysql.conf
@@ -2,8 +2,8 @@
 # Copyright 2023 Datastrato Pvt Ltd.
 # This software is licensed under the Apache License version 2.
 #
-# jdbc-url: jdbc:mysql://localhost:3306/
-# jdbc-user: strato
-# jdbc-password: strato
-# jdbc-driver: com.mysql.jdbc.Driver
-# jdbc-driver: com.mysql.cj.jdbc.Driver
+# jdbc-url = jdbc:mysql://localhost:3306/
+# jdbc-user = strato
+# jdbc-password = strato
+# The selection of Driver should be filled in according to your needs, such as `com.mysql.jdbc.Driver` or `com.mysql.cj.jdbc.Driver`
+# jdbc-driver = com.mysql.cj.jdbc.Driver

--- a/catalogs/catalog-jdbc-postgresql/src/main/resources/jdbc-postgresql.conf
+++ b/catalogs/catalog-jdbc-postgresql/src/main/resources/jdbc-postgresql.conf
@@ -2,8 +2,8 @@
 # Copyright 2023 Datastrato Pvt Ltd.
 # This software is licensed under the Apache License version 2.
 #
-# jdbc-url: jdbc:postgresql://localhost:5432/your_database
-# jdbc-user: strato
-# jdbc-password: strato
-# jdbc-database: your_database
-# jdbc-driver: org.postgresql.Driver
+# jdbc-url = jdbc:postgresql://localhost:5432/your_database
+# jdbc-user = strato
+# jdbc-password = strato
+# jdbc-database = your_database
+# jdbc-driver = org.postgresql.Driver


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change the connector between the key and value in the configuration file to an equal sign.

### Why are the changes needed?

Fix: #1515

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
NO