### PR TITLE
[#1493] fix(core):  fix testHistogram accidental error

### DIFF
--- a/core/src/test/java/com/datastrato/gravitino/metrics/source/TestMetricsSource.java
+++ b/core/src/test/java/com/datastrato/gravitino/metrics/source/TestMetricsSource.java
@@ -98,7 +98,10 @@ public class TestMetricsSource extends MetricsSource {
             .getSnapshot();
     Assertions.assertEquals(99, snapshot.getMax());
     Assertions.assertEquals(0, snapshot.getMin());
-    Assertions.assertEquals(94.0, snapshot.get95thPercentile());
+    // ExponentiallyDecayingReservoir offers a 99.9% confidence level with a 5%
+    // margin of error assuming a normal distribution, and an alpha factor of 0.015,
+    // which heavily biases the reservoir to the past 5 minutes of measurements.
+    // Assertions.assertEquals(94.0, snapshot.get95thPercentile());
     Assertions.assertEquals(100, snapshot.size());
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
remove get95thPercentile test from testHistogram, because the underlying algorithm have randomness.
```
 ExponentiallyDecayingReservoir offers a 99.9% confidence level with a 5% margin of error assuming a normal distribution, and an alpha factor of 0.015,
```

### Why are the changes needed?

Fix: #1493 

### Does this PR introduce _any_ user-facing change?

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)

### How was this patch tested?
no
