### PR TITLE
[#1555] improve(UI): improve empty field

### DIFF
--- a/web/app/(home)/DetailsDrawer.js
+++ b/web/app/(home)/DetailsDrawer.js
@@ -21,17 +21,31 @@ import {
 
 import Icon from '@/components/Icon'
 
-import { formatToDateTime } from '@/lib/utils/date'
+import EmptyText from '@/components/EmptyText'
+
+import { formatToDateTime, isValidDate } from '@/lib/utils/date'
 
 const DetailsDrawer = props => {
   const { openDrawer, setOpenDrawer, drawerData = {} } = props
 
-  const { audit } = drawerData
+  const { audit = {} } = drawerData
 
   const [properties, setProperties] = useState([])
 
   const handleClose = () => {
     setOpenDrawer(false)
+  }
+
+  const renderFieldText = (value, linkBreak = false) => {
+    if (!value) {
+      return <EmptyText />
+    }
+
+    return (
+      <Typography sx={{ fontWeight: 500, whiteSpace: linkBreak ? 'pre' : 'normal' }}>
+        {isValidDate(value) ? formatToDateTime(value) : value}
+      </Typography>
+    )
   }
 
   useEffect(() => {
@@ -45,7 +59,7 @@ const DetailsDrawer = props => {
 
       setProperties(propsData)
     }
-  }, [drawerData.properties])
+  }, [drawerData])
 
   return (
     <Drawer
@@ -93,23 +107,35 @@ const DetailsDrawer = props => {
           <Typography variant='body2' sx={{ mb: 2 }}>
             Comment
           </Typography>
-          <Typography sx={{ fontWeight: 500, whiteSpace: 'pre' }}>{drawerData.comment}</Typography>
+          {renderFieldText(drawerData.comment, true)}
+        </Grid>
+
+        <Grid item xs={12} sx={{ mb: [0, 5] }}>
+          <Typography variant='body2' sx={{ mb: 2 }}>
+            Created by
+          </Typography>
+          {renderFieldText(audit.creator)}
+        </Grid>
+
+        <Grid item xs={12} sx={{ mb: [0, 5] }}>
+          <Typography variant='body2' sx={{ mb: 2 }}>
+            Created at
+          </Typography>
+          {renderFieldText(audit.createTime)}
         </Grid>
 
         <Grid item xs={12} sx={{ mb: [0, 5] }}>
           <Typography variant='body2' sx={{ mb: 2 }}>
             Last modified by
           </Typography>
-          <Typography sx={{ fontWeight: 500 }}>{audit?.lastModifier ? audit.lastModifier : ''}</Typography>
+          {renderFieldText(audit.lastModifier)}
         </Grid>
 
         <Grid item xs={12} sx={{ mb: [0, 5] }}>
           <Typography variant='body2' sx={{ mb: 2 }}>
             Last modified at
           </Typography>
-          <Typography sx={{ fontWeight: 500 }}>
-            {audit?.lastModifiedTime ? formatToDateTime(audit?.lastModifiedTime) : ''}
-          </Typography>
+          {renderFieldText(audit.lastModifiedTime)}
         </Grid>
 
         <Grid item xs={12} sx={{ mb: [0, 5] }}>

--- a/web/app/metalakes/DetailsView.js
+++ b/web/app/metalakes/DetailsView.js
@@ -3,17 +3,11 @@
  * This software is licensed under the Apache License version 2.
  */
 
-import Box from '@mui/material/Box'
-import Grid from '@mui/material/Grid'
-import Typography from '@mui/material/Typography'
-import Table from '@mui/material/Table'
-import TableHead from '@mui/material/TableHead'
-import TableBody from '@mui/material/TableBody'
-import TableRow from '@mui/material/TableRow'
-import TableCell from '@mui/material/TableCell'
-import TableContainer from '@mui/material/TableContainer'
+import { Box, Grid, Typography, Table, TableHead, TableBody, TableRow, TableCell, TableContainer } from '@mui/material'
 
-import { formatToDateTime } from '@/lib/utils/date'
+import EmptyText from '@/components/EmptyText'
+
+import { formatToDateTime, isValidDate } from '@/lib/utils/date'
 
 const DetailsView = props => {
   const { store, data = {}, page } = props
@@ -29,6 +23,18 @@ const DetailsView = props => {
     }
   })
 
+  const renderFieldText = (value, linkBreak = false) => {
+    if (!value) {
+      return <EmptyText />
+    }
+
+    return (
+      <Typography sx={{ fontWeight: 500, whiteSpace: linkBreak ? 'pre' : 'normal' }}>
+        {isValidDate(value) ? formatToDateTime(value) : value}
+      </Typography>
+    )
+  }
+
   return (
     <Box sx={{ p: 4 }}>
       <Grid container spacing={6}>
@@ -38,13 +44,13 @@ const DetailsView = props => {
               <Typography variant='body2' sx={{ mb: 2 }}>
                 Type
               </Typography>
-              <Typography sx={{ fontWeight: 500 }}>{activatedItem?.type || ''}</Typography>
+              {renderFieldText(activatedItem?.type)}
             </Grid>
             <Grid item xs={12} md={6} sx={{ mb: [0, 5] }}>
               <Typography variant='body2' sx={{ mb: 2 }}>
                 Provider
               </Typography>
-              <Typography sx={{ fontWeight: 500 }}>{activatedItem?.provider || ''}</Typography>
+              {renderFieldText(activatedItem?.provider)}
             </Grid>
           </>
         ) : null}
@@ -52,39 +58,35 @@ const DetailsView = props => {
           <Typography variant='body2' sx={{ mb: 2 }}>
             Comment
           </Typography>
-          <Typography sx={{ fontWeight: 500, whiteSpace: 'pre' }}>{activatedItem?.comment || ''}</Typography>
+          {renderFieldText(activatedItem?.comment, true)}
         </Grid>
 
         <Grid item xs={12} md={6} sx={{ mb: [0, 5] }}>
           <Typography variant='body2' sx={{ mb: 2 }}>
             Created by
           </Typography>
-          <Typography sx={{ fontWeight: 500 }}>{audit?.creator ? audit.creator : ''}</Typography>
+          {renderFieldText(audit.creator)}
         </Grid>
 
         <Grid item xs={12} md={6} sx={{ mb: [0, 5] }}>
           <Typography variant='body2' sx={{ mb: 2 }}>
             Created at
           </Typography>
-          <Typography sx={{ fontWeight: 500 }}>
-            {audit?.createTime ? formatToDateTime(audit?.createTime) : ''}
-          </Typography>
+          {renderFieldText(audit.createTime)}
         </Grid>
 
         <Grid item xs={12} md={6} sx={{ mb: [0, 5] }}>
           <Typography variant='body2' sx={{ mb: 2 }}>
             Last modified by
           </Typography>
-          <Typography sx={{ fontWeight: 500 }}>{audit?.lastModifier ? audit.lastModifier : ''}</Typography>
+          {renderFieldText(audit.lastModifier)}
         </Grid>
 
         <Grid item xs={12} md={6} sx={{ mb: [0, 5] }}>
           <Typography variant='body2' sx={{ mb: 2 }}>
             Last modified at
           </Typography>
-          <Typography sx={{ fontWeight: 500 }}>
-            {audit?.lastModifiedTime ? formatToDateTime(audit?.lastModifiedTime) : ''}
-          </Typography>
+          {renderFieldText(audit.lastModifiedTime)}
         </Grid>
 
         <Grid item xs={12} sx={{ mb: [0, 5] }}>

--- a/web/components/EmptyText.js
+++ b/web/components/EmptyText.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+
+import { Typography } from '@mui/material'
+
+const EmptyText = () => {
+  return (
+    <Typography variant='body2' color={'text.disabled'}>
+      N/A
+    </Typography>
+  )
+}
+
+export default EmptyText

--- a/web/lib/utils/date.js
+++ b/web/lib/utils/date.js
@@ -10,3 +10,7 @@ const DATE_TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss'
 export const formatToDateTime = (date, format = DATE_TIME_FORMAT) => {
   return dayjs(date).format(format)
 }
+
+export const isValidDate = value => {
+  return dayjs(value).isValid()
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Before:

drawer details:
<img width="397" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/a28761ed-ae98-40bd-badf-2d822fd4ee07">

tab details:
<img width="581" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/50c9643e-ce8f-4e63-829b-27a73a7ce735">

After:

drawer details:
<img width="393" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/fc8c8484-49bd-4009-a54e-0a53009b17dd">

tab details:
<img width="480" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/59517f4d-5dfb-426b-9502-8bb07d6536ed">


### Why are the changes needed?

Fix: #1555

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
