### PR TITLE
[MINOR] improve(UI): add the current year to the page footer

### DIFF
--- a/web/lib/layout/Footer.js
+++ b/web/lib/layout/Footer.js
@@ -13,7 +13,7 @@ const Footer = props => {
       <Box className='footer-content-wrapper twc-px-6 twc-w-full twc-py-[0.75rem] [@media(min-width:1440px)]:twc-max-w-[1440px]'>
         <Box className={'twc-flex twc-flex-wrap twc-items-center twc-justify-between'}>
           <Typography className='twc-mr-2'>
-            {`© 2023 `}
+            {`© 2023-${new Date().getFullYear()} `}
             <Link className={'twc-no-underline twc-text-primary-main'} target='_blank' href='https://datastrato.ai/'>
               Datastrato
             </Link>

--- a/web/lib/provider/session.js
+++ b/web/lib/provider/session.js
@@ -58,7 +58,7 @@ const AuthProvider = ({ children }) => {
 
       if (authType === 'simple') {
         dispatch(initialVersion())
-      } else {
+      } else if (authType === 'oauth') {
         if (token) {
           dispatch(setIntervalId())
           dispatch(setAuthToken(token))


### PR DESCRIPTION
### What changes were proposed in this pull request?

<img width="215" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/2768e836-b68d-4726-948f-ba2b77f6816b">

### Why are the changes needed?

Add the current year to the page footer.
Redirect to the homepage if the server is not running.

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
