### PR TITLE
[#1259] fix(trino-connector): Fix cannot create same name of catalog when the old catalog has deleted

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoQueryIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoQueryIT.java
@@ -41,6 +41,8 @@ public class TrinoQueryIT extends TrinoQueryITBase {
   protected AtomicInteger testCount = new AtomicInteger(0);
   protected AtomicInteger totalCount = new AtomicInteger(0);
 
+  private static int testParallelism = 2;
+
   private static Map<String, String> queryParams = new HashMap<>();
 
   public static Set<String> ciTestsets = new HashSet<>();
@@ -121,6 +123,7 @@ public class TrinoQueryIT extends TrinoQueryITBase {
       throws Exception {
     String path = ITUtils.joinPath(testSetDirName, filename);
     String sqls = TrinoQueryITBase.readFileToString(path);
+    sqls = removeSqlComments(sqls);
 
     Matcher sqlMatcher =
         Pattern.compile("(\\w.*?);", Pattern.DOTALL | Pattern.UNIX_LINES).matcher(sqls);
@@ -148,6 +151,10 @@ public class TrinoQueryIT extends TrinoQueryITBase {
     }
   }
 
+  private static String removeSqlComments(String sql) {
+    return sql.replaceAll("--.*?\\n", "");
+  }
+
   private static String resolveParameters(String sql) throws Exception {
     Matcher sqlMatcher = Pattern.compile("\\$\\{([\\w_]+)\\}").matcher(sql);
     StringBuffer replacedString = new StringBuffer();
@@ -172,9 +179,11 @@ public class TrinoQueryIT extends TrinoQueryITBase {
 
   void executeSqlFileWithCheckResult(
       String testSetDirName, String filename, TrinoQueryRunner queryRunner, String catalog)
-      throws IOException {
+      throws Exception {
     String path = ITUtils.joinPath(testSetDirName, filename);
     String sqls = TrinoQueryITBase.readFileToString(path);
+    sqls = removeSqlComments(sqls);
+
     String resultFileName = path.replace(".sql", ".txt");
     String testResults = TrinoQueryITBase.readFileToString(resultFileName);
 
@@ -186,6 +195,7 @@ public class TrinoQueryIT extends TrinoQueryITBase {
 
     while (sqlMatcher.find()) {
       String sql = sqlMatcher.group(1);
+      sql = resolveParameters(sql);
       String expectResult = "";
       if (resultMatcher.find()) {
         expectResult = resultMatcher.group(1).trim();
@@ -231,10 +241,14 @@ public class TrinoQueryIT extends TrinoQueryITBase {
       return false;
     }
 
-    // match text
-    boolean match = expectResult.equals(result);
-    if (match) {
-      return true;
+    // match black line
+    // E.g., the expected result can be matched with the following actual result:
+    // query result:
+    //
+    // expectResult:
+    // <BLANK_LINE>
+    if (expectResult.equals("<BLANK_LINE>")) {
+      return result.isEmpty();
     }
 
     // Match query failed result.
@@ -243,10 +257,20 @@ public class TrinoQueryIT extends TrinoQueryITBase {
     // Query 20240103_132722_00006_pijfx failed: line 8:6: Schema must be specified when session
     // schema is not set
     // expectResult:
-    // Schema must be specified when session schema is not set
-    if (Pattern.compile("^Query \\w+ failed:").matcher(result).find()) {
-      match = Pattern.compile("^Query \\w+ failed.*: " + expectResult).matcher(result).find();
+    // <QUERY_FAILED> Schema must be specified when session schema is not set
+    if (expectResult.startsWith("<QUERY_FAILED>")) {
+      boolean match =
+          Pattern.compile(
+                  "^Query \\w+ failed.*: " + expectResult.replace("<QUERY_FAILED>", "").trim())
+              .matcher(result)
+              .find();
       return match;
+    }
+
+    // match text
+    boolean match = expectResult.equals(result);
+    if (match) {
+      return true;
     }
 
     // Match Wildcard.
@@ -269,7 +293,7 @@ public class TrinoQueryIT extends TrinoQueryITBase {
 
   @Test
   public void testSql() throws Exception {
-    ExecutorService executor = Executors.newFixedThreadPool(4);
+    ExecutorService executor = Executors.newFixedThreadPool(testParallelism);
     CompletionService completionService = new ExecutorCompletionService<>(executor);
 
     String[] testSetNames =
@@ -289,7 +313,7 @@ public class TrinoQueryIT extends TrinoQueryITBase {
 
   public void testSql(String testSetDirName, String catalogFileName, String testerPrefix)
       throws Exception {
-    ExecutorService executor = Executors.newFixedThreadPool(4);
+    ExecutorService executor = Executors.newFixedThreadPool(testParallelism);
     CompletionService completionService = new ExecutorCompletionService<>(executor);
 
     List<Future<Integer>> allFutures = new ArrayList<>();

--- a/integration-test/src/test/resources/trino-ci-testset/testsets/hive/00005_catalog.sql
+++ b/integration-test/src/test/resources/trino-ci-testset/testsets/hive/00005_catalog.sql
@@ -1,0 +1,27 @@
+call gravitino.system.create_catalog(
+    'gt_hive_xxx1',
+    'hive',
+     map(
+        array['metastore.uris'],
+        array['${hive_uri}']
+     )
+);
+
+show catalogs like 'test.gt_hive_xxx1';
+
+CALL gravitino.system.drop_catalog('gt_hive_xxx1');
+
+show catalogs like 'test.gt_hive_xxx1';
+
+call gravitino.system.create_catalog(
+    'gt_hive_xxx1',
+    'hive',
+     map(
+        array['metastore.uris'],
+        array['${hive_uri}']
+     )
+);
+
+show catalogs like 'test.gt_hive_xxx1';
+
+CALL gravitino.system.drop_catalog('gt_hive_xxx1');

--- a/integration-test/src/test/resources/trino-ci-testset/testsets/hive/00005_catalog.txt
+++ b/integration-test/src/test/resources/trino-ci-testset/testsets/hive/00005_catalog.txt
@@ -1,0 +1,13 @@
+CALL
+
+test.gt_hive_xxx1
+
+CALL
+
+<BLANK_LINE>
+
+CALL
+
+test.gt_hive_xxx1
+
+CALL

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/CatalogInjector.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/CatalogInjector.java
@@ -44,6 +44,8 @@ public class CatalogInjector {
   private CreateCatalogHandle createHandle;
   private String trinoVersion;
 
+  private ConcurrentHashMap<String, Object> internalCatalogs = new ConcurrentHashMap<>();
+
   private void checkTrinoSpiVersion(ConnectorContext context) {
     this.trinoVersion = context.getSpiVersion();
 
@@ -159,6 +161,7 @@ public class CatalogInjector {
             // Call catalogFactory.createCatalog() return CatalogConnector
             Object catalogConnector =
                 createCatalogMethod.invoke(catalogFactory, catalogPropertiesObject);
+            internalCatalogs.put(catalogName, catalogConnector);
 
             // The catalogConnector hierarchy:
             // --catalogConnector (CatalogConnector)
@@ -167,6 +170,7 @@ public class CatalogInjector {
 
             // Get a connector object from trino CatalogConnector.
             Object catalogConnectorObject = getFiledObject(catalogConnector, "catalogConnector");
+
             return getFiledObject(catalogConnectorObject, "connector");
           };
 
@@ -205,7 +209,16 @@ public class CatalogInjector {
       // The catalogManager is an instance of StaticCatalogManager
       ConcurrentHashMap catalogs = (ConcurrentHashMap) getFiledObject(catalogManager, "catalogs");
       Preconditions.checkNotNull(catalogs, "catalogs should not be null");
-      removeHandle = (catalogName) -> catalogs.remove(catalogName);
+      removeHandle =
+          (catalogName) -> {
+            Object catalogConnector = catalogs.remove(catalogName);
+            if (catalogConnector != null) {
+              Method shutdown = catalogConnector.getClass().getDeclaredMethod("shutdown");
+              shutdown.invoke(catalogConnector);
+              Object internalCatalogConnector = internalCatalogs.get(catalogName);
+              shutdown.invoke(internalCatalogConnector);
+            }
+          };
     }
   }
 


### PR DESCRIPTION

### What changes were proposed in this pull request?

Fix cannot create same name of catalog when the old catalog has deleted

### Why are the changes needed?

Fix: #1259

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

IT
