### PR TITLE
[#1611] fix(web): fix click tree table error

### DIFF
--- a/web/components/ColumnTypeChip.js
+++ b/web/components/ColumnTypeChip.js
@@ -10,9 +10,9 @@ import { alpha } from '@/lib/utils/color'
 import { isString } from 'lodash-es'
 
 const ColumnTypeChip = props => {
-  const { type } = props
+  const { type = '' } = props
 
-  const label = isString(type) ? type : `${type.type}<${type.elementType ?? 'unknown'}>` ?? 'unknown'
+  const label = isString(type) ? type : `${type?.type}<${type?.elementType ?? 'unknown'}>` ?? 'unknown'
 
   const columnTypeColor = ColumnTypeColorEnum[type] || 'secondary'
   const color = colors[columnTypeColor]?.main || '#8592A3'

--- a/web/components/ColumnTypeChip.js
+++ b/web/components/ColumnTypeChip.js
@@ -12,9 +12,11 @@ import { isString } from 'lodash-es'
 const ColumnTypeChip = props => {
   const { type = '' } = props
 
+  const formatType = type && isString(type) ? type.replace(/\(.*\)/, '') : type
+
   const label = isString(type) ? type : `${type?.type}<${type?.elementType ?? 'unknown'}>` ?? 'unknown'
 
-  const columnTypeColor = ColumnTypeColorEnum[type] || 'secondary'
+  const columnTypeColor = ColumnTypeColorEnum[formatType] || 'secondary'
   const color = colors[columnTypeColor]?.main || '#8592A3'
   const bgColor = alpha(color, 0.1)
 

--- a/web/lib/enums/columnTypeEnum.ts
+++ b/web/lib/enums/columnTypeEnum.ts
@@ -10,8 +10,8 @@ export enum ColumnTypeColorEnum {
   long = 'primary',
   float = 'primary',
   double = 'primary',
-  'decimal(10,2)' = 'primary',
-  'fixed(16)' = 'primary',
+  decimal = 'primary',
+  fixed = 'primary',
 
   date = 'info',
   time = 'info',
@@ -21,8 +21,8 @@ export enum ColumnTypeColorEnum {
   interval_year = 'info',
 
   string = 'warning',
-  'char(10)' = 'warning',
-  'varchar(10)' = 'warning',
+  char = 'warning',
+  varchar = 'warning',
 
   byte = 'success',
   uuid = 'success',


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the issue of clicking on the `table` in the tree list.

After: when clicked the `hive-schema-table` on the tree view.
<img width="1040" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/ae534b7e-0288-4cff-a1b7-5874b5c461d0">


### Why are the changes needed?

Fix: #1611

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
