### PR TITLE
[MINOR] improve(web): redirect to homepage if the Gravitino server is not running

### DIFF
--- a/web/lib/provider/session.js
+++ b/web/lib/provider/session.js
@@ -58,7 +58,7 @@ const AuthProvider = ({ children }) => {
 
       if (authType === 'simple') {
         dispatch(initialVersion())
-      } else {
+      } else if (authType === 'oauth') {
         if (token) {
           dispatch(setIntervalId())
           dispatch(setAuthToken(token))


### PR DESCRIPTION
### What changes were proposed in this pull request?

Redirect to the homepage if the Gravitino server is not running.

### Why are the changes needed?

When the Gravitino server is not running, web redirects to login page.

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
