### PR TITLE
[#1551] improve(server): Optimize the error message

### DIFF
--- a/server/src/main/java/com/datastrato/gravitino/server/web/rest/ExceptionHandlers.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/rest/ExceptionHandlers.java
@@ -53,8 +53,7 @@ public class ExceptionHandlers {
     public Response handle(OperationType op, String table, String schema, Exception e) {
       String formatted = StringUtil.isBlank(table) ? "" : " [" + table + "]";
       String errorMsg =
-          String.format(
-              TABLE_MSG_TEMPLATE, formatted, op.name(), schema, e.getClass().getSimpleName());
+          String.format(TABLE_MSG_TEMPLATE, formatted, op.name(), schema, getErrorMsg(e));
       LOG.warn(errorMsg, e);
 
       if (e instanceof IllegalArgumentException) {
@@ -86,8 +85,7 @@ public class ExceptionHandlers {
     public Response handle(OperationType op, String schema, String catalog, Exception e) {
       String formatted = StringUtil.isBlank(schema) ? "" : " [" + schema + "]";
       String errorMsg =
-          String.format(
-              SCHEMA_MSG_TEMPLATE, formatted, op.name(), catalog, e.getClass().getSimpleName());
+          String.format(SCHEMA_MSG_TEMPLATE, formatted, op.name(), catalog, getErrorMsg(e));
       LOG.warn(errorMsg, e);
 
       if (e instanceof IllegalArgumentException) {
@@ -119,8 +117,7 @@ public class ExceptionHandlers {
     public Response handle(OperationType op, String catalog, String metalake, Exception e) {
       String formatted = StringUtil.isBlank(catalog) ? "" : " [" + catalog + "]";
       String errorMsg =
-          String.format(
-              CATALOG_MSG_TEMPLATE, formatted, op.name(), metalake, e.getClass().getSimpleName());
+          String.format(CATALOG_MSG_TEMPLATE, formatted, op.name(), metalake, getErrorMsg(e));
       LOG.warn(errorMsg, e);
 
       if (e instanceof IllegalArgumentException) {
@@ -148,8 +145,7 @@ public class ExceptionHandlers {
     @Override
     public Response handle(OperationType op, String metalake, String parent, Exception e) {
       String formatted = StringUtil.isBlank(metalake) ? "" : " [" + metalake + "]";
-      String errorMsg =
-          String.format(METALAKE_MSG_TEMPLATE, formatted, op.name(), e.getClass().getSimpleName());
+      String errorMsg = String.format(METALAKE_MSG_TEMPLATE, formatted, op.name(), getErrorMsg(e));
       LOG.warn(errorMsg, e);
 
       if (e instanceof IllegalArgumentException) {
@@ -181,13 +177,23 @@ public class ExceptionHandlers {
 
       String errorMsg =
           String.format(
-              BASE_MSG_TEMPLATE,
-              formattedObject,
-              op.name(),
-              formattedParent,
-              e.getClass().getSimpleName());
+              BASE_MSG_TEMPLATE, formattedObject, op.name(), formattedParent, getErrorMsg(e));
       LOG.error(errorMsg, e);
       return Utils.internalError(errorMsg, e);
+    }
+
+    protected String getErrorMsg(Throwable throwable) {
+      if (throwable == null || throwable.getMessage() == null) {
+        return "";
+      }
+
+      String message = throwable.getMessage();
+      int pos = message.lastIndexOf(": ");
+      if (pos == -1) {
+        return message;
+      } else {
+        return message.substring(pos + 2);
+      }
     }
   }
 }

--- a/server/src/main/java/com/datastrato/gravitino/server/web/rest/ExceptionHandlers.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/rest/ExceptionHandlers.java
@@ -13,6 +13,8 @@ import com.datastrato.gravitino.exceptions.SchemaAlreadyExistsException;
 import com.datastrato.gravitino.exceptions.TableAlreadyExistsException;
 import com.datastrato.gravitino.server.web.Utils;
 import javax.ws.rs.core.Response;
+
+import com.google.common.annotations.VisibleForTesting;
 import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -163,7 +165,8 @@ public class ExceptionHandlers {
     }
   }
 
-  private static class BaseExceptionHandler extends ExceptionHandler {
+  @VisibleForTesting
+  static class BaseExceptionHandler extends ExceptionHandler {
 
     private static final String EXCEPTION_KEYWORD = "Exception: ";
 
@@ -184,7 +187,8 @@ public class ExceptionHandlers {
       return Utils.internalError(errorMsg, e);
     }
 
-    protected String getErrorMsg(Throwable throwable) {
+    @VisibleForTesting
+    static String getErrorMsg(Throwable throwable) {
       if (throwable == null || throwable.getMessage() == null) {
         return "";
       }

--- a/server/src/main/java/com/datastrato/gravitino/server/web/rest/ExceptionHandlers.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/rest/ExceptionHandlers.java
@@ -165,6 +165,8 @@ public class ExceptionHandlers {
 
   private static class BaseExceptionHandler extends ExceptionHandler {
 
+    private static final String EXCEPTION_KEYWORD = "Exception: ";
+
     private static final ExceptionHandler INSTANCE = new BaseExceptionHandler();
 
     private static final String BASE_MSG_TEMPLATE =
@@ -188,11 +190,11 @@ public class ExceptionHandlers {
       }
 
       String message = throwable.getMessage();
-      int pos = message.lastIndexOf(": ");
+      int pos = message.lastIndexOf(EXCEPTION_KEYWORD);
       if (pos == -1) {
         return message;
       } else {
-        return message.substring(pos + 2);
+        return message.substring(pos + EXCEPTION_KEYWORD.length());
       }
     }
   }

--- a/server/src/main/java/com/datastrato/gravitino/server/web/rest/ExceptionHandlers.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/rest/ExceptionHandlers.java
@@ -12,9 +12,8 @@ import com.datastrato.gravitino.exceptions.NotFoundException;
 import com.datastrato.gravitino.exceptions.SchemaAlreadyExistsException;
 import com.datastrato.gravitino.exceptions.TableAlreadyExistsException;
 import com.datastrato.gravitino.server.web.Utils;
-import javax.ws.rs.core.Response;
-
 import com.google.common.annotations.VisibleForTesting;
+import javax.ws.rs.core.Response;
 import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/server/src/test/java/com/datastrato/gravitino/server/web/rest/TestExceptionHandlers.java
+++ b/server/src/test/java/com/datastrato/gravitino/server/web/rest/TestExceptionHandlers.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.server.web.rest;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestExceptionHandlers {
+
+  @Test
+  public void testGetErrorMsg() {
+    Exception e1 = new Exception("test1");
+    Exception e2 = new Exception("test2", e1);
+    Exception e3 = new Exception(e1);
+    Exception e4 = new Exception();
+    Exception e5 = new Exception(e2);
+    Exception e6 = null;
+
+    String msg1 = ExceptionHandlers.BaseExceptionHandler.getErrorMsg(e1);
+    Assertions.assertEquals("test1", msg1);
+
+    String msg2 = ExceptionHandlers.BaseExceptionHandler.getErrorMsg(e2);
+    Assertions.assertEquals("test2", msg2);
+
+    String msg3 = ExceptionHandlers.BaseExceptionHandler.getErrorMsg(e3);
+    Assertions.assertEquals("test1", msg3);
+
+    String msg4 = ExceptionHandlers.BaseExceptionHandler.getErrorMsg(e4);
+    Assertions.assertEquals("", msg4);
+
+    String msg5 = ExceptionHandlers.BaseExceptionHandler.getErrorMsg(e5);
+    Assertions.assertEquals("test2", msg5);
+
+    String msg6 = ExceptionHandlers.BaseExceptionHandler.getErrorMsg(e6);
+    Assertions.assertEquals("", msg6);
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR optimize the error message to make it more meaningful to the UI.

Previously it outputs the exception class name, which is not meaningful to users. Now change to the actual error message like below:

```
Failed to operate table(s) [ADMINISTRABLE_ROLE_AUTHORIZATIONS] operation [LOAD] under schema [information_schema], reason [Failed to parse create table information_schema.ADMINISTRABLE_ROLE_AUTHORIZATIONS SQL]
```

The reason field is only the error message now.


### Why are the changes needed?

To make the error message on UI more meaningful.

Fix: #1551 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Local verify.
