### PR TITLE
[#1630] feat(api): Add `columnImpl` in API module

### DIFF
--- a/api/src/main/java/com/datastrato/gravitino/rel/Column.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/Column.java
@@ -7,6 +7,8 @@ package com.datastrato.gravitino.rel;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.rel.expressions.Expression;
 import com.datastrato.gravitino.rel.types.Type;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import java.util.Map;
 import java.util.Objects;
 
@@ -122,6 +124,8 @@ public interface Column {
         boolean nullable,
         boolean autoIncrement,
         Expression defaultValue) {
+      Preconditions.checkArgument(!Strings.isNullOrEmpty(name), "Column name cannot be null");
+      Preconditions.checkArgument(dataType != null, "Column data type cannot be null");
       this.name = name;
       this.dataType = dataType;
       this.comment = comment;

--- a/api/src/main/java/com/datastrato/gravitino/rel/Column.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/Column.java
@@ -8,6 +8,7 @@ import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.rel.expressions.Expression;
 import com.datastrato.gravitino.rel.types.Type;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * An interface representing a column of a {@link Table}. It defines basic properties of a column,
@@ -40,4 +41,145 @@ public interface Column {
    * @return The default value of this column, {@link Column#DEFAULT_VALUE_NOT_SET} if not specified
    */
   Expression defaultValue();
+
+  /**
+   * Create a {@link Column} instance.
+   *
+   * @param name The name of the column.
+   * @param dataType The data type of the column.
+   * @param comment The comment of the column.
+   * @param defaultValue The default value of the column. {@link Column#DEFAULT_VALUE_NOT_SET} if
+   *     null.
+   * @return A {@link Column} instance.
+   */
+  static ColumnImpl of(String name, Type dataType, String comment, Expression defaultValue) {
+    return of(name, dataType, comment, true, false, defaultValue);
+  }
+
+  /**
+   * Create a {@link Column} instance.
+   *
+   * @param name The name of the column.
+   * @param dataType The data type of the column.
+   * @param comment The comment of the column.
+   * @return A {@link Column} instance.
+   */
+  static ColumnImpl of(String name, Type dataType, String comment) {
+    return of(name, dataType, comment, true, false, DEFAULT_VALUE_NOT_SET);
+  }
+
+  /**
+   * Create a {@link Column} instance.
+   *
+   * @param name The name of the column.
+   * @param dataType The data type of the column.
+   * @return A {@link Column} instance.
+   */
+  static ColumnImpl of(String name, Type dataType) {
+    return of(name, dataType, null, true, false, DEFAULT_VALUE_NOT_SET);
+  }
+
+  /**
+   * Create a {@link Column} instance.
+   *
+   * @param name The name of the column.
+   * @param dataType The data type of the column.
+   * @param comment The comment of the column.
+   * @param nullable True if the column may produce null values.
+   * @param autoIncrement True if the column is an auto-increment column.
+   * @param defaultValue The default value of the column. {@link Column#DEFAULT_VALUE_NOT_SET} if
+   *     null.
+   * @return A {@link Column} instance.
+   */
+  static ColumnImpl of(
+      String name,
+      Type dataType,
+      String comment,
+      boolean nullable,
+      boolean autoIncrement,
+      Expression defaultValue) {
+    return new ColumnImpl(
+        name,
+        dataType,
+        comment,
+        nullable,
+        autoIncrement,
+        defaultValue == null ? DEFAULT_VALUE_NOT_SET : defaultValue);
+  }
+
+  class ColumnImpl implements Column {
+    private String name;
+    private Type dataType;
+    private String comment;
+    private boolean nullable;
+    private boolean autoIncrement;
+    private Expression defaultValue;
+
+    private ColumnImpl(
+        String name,
+        Type dataType,
+        String comment,
+        boolean nullable,
+        boolean autoIncrement,
+        Expression defaultValue) {
+      this.name = name;
+      this.dataType = dataType;
+      this.comment = comment;
+      this.nullable = nullable;
+      this.autoIncrement = autoIncrement;
+      this.defaultValue = defaultValue;
+    }
+
+    @Override
+    public String name() {
+      return name;
+    }
+
+    @Override
+    public Type dataType() {
+      return dataType;
+    }
+
+    @Override
+    public String comment() {
+      return comment;
+    }
+
+    @Override
+    public boolean nullable() {
+      return nullable;
+    }
+
+    @Override
+    public boolean autoIncrement() {
+      return autoIncrement;
+    }
+
+    @Override
+    public Expression defaultValue() {
+      return defaultValue;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ColumnImpl column = (ColumnImpl) o;
+      return nullable == column.nullable
+          && autoIncrement == column.autoIncrement
+          && Objects.equals(name, column.name)
+          && Objects.equals(dataType, column.dataType)
+          && Objects.equals(comment, column.comment)
+          && Objects.equals(defaultValue, column.defaultValue);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, dataType, comment, nullable, autoIncrement, defaultValue);
+    }
+  }
 }

--- a/api/src/test/java/com/datastrato/gravitino/rel/TestColumn.java
+++ b/api/src/test/java/com/datastrato/gravitino/rel/TestColumn.java
@@ -20,4 +20,15 @@ public class TestColumn {
     actualColumn = Column.of("col_1", Types.ByteType.get(), null);
     Assertions.assertEquals(expectedColumn, actualColumn);
   }
+
+  @Test
+  public void testColumnException() {
+    IllegalArgumentException exception =
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Column.of(null, null));
+    Assertions.assertEquals("Column name cannot be null", exception.getMessage());
+
+    exception =
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Column.of("col_1", null));
+    Assertions.assertEquals("Column data type cannot be null", exception.getMessage());
+  }
 }

--- a/api/src/test/java/com/datastrato/gravitino/rel/TestColumn.java
+++ b/api/src/test/java/com/datastrato/gravitino/rel/TestColumn.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.rel;
+
+import com.datastrato.gravitino.rel.types.Types;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestColumn {
+  @Test
+  public void testColumn() {
+    Column expectedColumn =
+        Column.of("col_1", Types.ByteType.get(), null, true, false, Column.DEFAULT_VALUE_NOT_SET);
+
+    Column actualColumn = Column.of("col_1", Types.ByteType.get());
+    Assertions.assertEquals(expectedColumn, actualColumn);
+
+    actualColumn = Column.of("col_1", Types.ByteType.get(), null);
+    Assertions.assertEquals(expectedColumn, actualColumn);
+  }
+}

--- a/api/src/test/java/com/datastrato/gravitino/rel/TestTransforms.java
+++ b/api/src/test/java/com/datastrato/gravitino/rel/TestTransforms.java
@@ -21,7 +21,6 @@ import com.datastrato.gravitino.rel.expressions.Expression;
 import com.datastrato.gravitino.rel.expressions.NamedReference;
 import com.datastrato.gravitino.rel.expressions.literals.Literals;
 import com.datastrato.gravitino.rel.expressions.transforms.Transform;
-import com.datastrato.gravitino.rel.types.Type;
 import com.datastrato.gravitino.rel.types.Types;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -29,38 +28,7 @@ import org.junit.jupiter.api.Test;
 public class TestTransforms {
   @Test
   public void testSingleFieldTransform() {
-    Column column =
-        new Column() {
-          @Override
-          public String name() {
-            return "col_1";
-          }
-
-          @Override
-          public Type dataType() {
-            return Types.ByteType.get();
-          }
-
-          @Override
-          public String comment() {
-            return null;
-          }
-
-          @Override
-          public boolean nullable() {
-            return true;
-          }
-
-          @Override
-          public boolean autoIncrement() {
-            return false;
-          }
-
-          @Override
-          public Expression defaultValue() {
-            return Column.DEFAULT_VALUE_NOT_SET;
-          }
-        };
+    Column column = Column.of("col_1", Types.ByteType.get());
     String[] fieldName = new String[] {column.name()};
 
     Transform.SingleFieldTransform identity = identity(fieldName);
@@ -86,38 +54,7 @@ public class TestTransforms {
 
   @Test
   public void testApplyTransform() {
-    Column column =
-        new Column() {
-          @Override
-          public String name() {
-            return "col_1";
-          }
-
-          @Override
-          public Type dataType() {
-            return Types.ByteType.get();
-          }
-
-          @Override
-          public String comment() {
-            return null;
-          }
-
-          @Override
-          public boolean nullable() {
-            return true;
-          }
-
-          @Override
-          public boolean autoIncrement() {
-            return false;
-          }
-
-          @Override
-          public Expression defaultValue() {
-            return Column.DEFAULT_VALUE_NOT_SET;
-          }
-        };
+    Column column = Column.of("col_1", Types.ByteType.get());
     // partition by foo(col_1, 'bar')
     NamedReference.FieldReference arg1 = field(column.name());
     Literals.LiteralImpl<String> arg2 = Literals.stringLiteral("bar");


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `columnImpl` in API module

### Why are the changes needed?

For client usage

Fix: #1630 

### Does this PR introduce _any_ user-facing change?

yes, the client now can use the helper method in `Column` API to get a column instance

### How was this patch tested?

UTs added
