### PR TITLE
[#1546] fix(lakehouse-iceberg): fix create Iceberg table failed if comment is null

### DIFF
--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergTable.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergTable.java
@@ -9,7 +9,6 @@ import com.datastrato.gravitino.catalog.lakehouse.iceberg.converter.FromIcebergP
 import com.datastrato.gravitino.catalog.lakehouse.iceberg.converter.FromIcebergSortOrder;
 import com.datastrato.gravitino.catalog.lakehouse.iceberg.converter.ToIcebergPartitionSpec;
 import com.datastrato.gravitino.catalog.lakehouse.iceberg.converter.ToIcebergSortOrder;
-import com.datastrato.gravitino.catalog.lakehouse.iceberg.ops.IcebergTableOpsHelper;
 import com.datastrato.gravitino.catalog.rel.BaseTable;
 import com.datastrato.gravitino.meta.AuditInfo;
 import com.google.common.collect.Maps;

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergTable.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergTable.java
@@ -45,16 +45,12 @@ public class IcebergTable extends BaseTable {
 
   public CreateTableRequest toCreateTableRequest() {
     Schema schema = ConvertUtil.toIcebergSchema(this);
-
-    Map<String, String> resultProperties =
-        Maps.newHashMap(IcebergTableOpsHelper.removeReservedProperties(properties));
-    resultProperties.putIfAbsent(ICEBERG_COMMENT_FIELD_NAME, comment);
     CreateTableRequest.Builder builder =
         CreateTableRequest.builder()
             .withName(name)
             .withLocation(location)
             .withSchema(schema)
-            .setProperties(resultProperties)
+            .setProperties(properties)
             .withPartitionSpec(ToIcebergPartitionSpec.toPartitionSpec(schema, partitioning))
             .withWriteOrder(ToIcebergSortOrder.toSortOrder(schema, sortOrders));
     return builder.build();

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/ops/IcebergTableOpsHelper.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/ops/IcebergTableOpsHelper.java
@@ -28,9 +28,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.ws.rs.NotSupportedException;
 import lombok.Getter;
 import lombok.Setter;
@@ -307,12 +305,6 @@ public class IcebergTableOpsHelper {
     }
 
     return icebergTableChange;
-  }
-
-  public static Map<String, String> removeReservedProperties(Map<String, String> createProperties) {
-    return createProperties.entrySet().stream()
-        .filter(entry -> !IcebergReservedProperties.contains(entry.getKey()))
-        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
   /**

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/lakehouse/iceberg/CatalogIcebergIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/lakehouse/iceberg/CatalogIcebergIT.java
@@ -334,14 +334,7 @@ public class CatalogIcebergIT extends AbstractIT {
 
     TableCatalog tableCatalog = catalog.asTableCatalog();
     Table createdTable =
-        tableCatalog.createTable(
-            tableIdentifier,
-            columns,
-            null,
-            null,
-            null,
-            null,
-            null);
+        tableCatalog.createTable(tableIdentifier, columns, null, null, null, null, null);
     Assertions.assertNull(createdTable.comment());
 
     Table loadTable = tableCatalog.loadTable(tableIdentifier);

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/lakehouse/iceberg/CatalogIcebergIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/lakehouse/iceberg/CatalogIcebergIT.java
@@ -327,7 +327,7 @@ public class CatalogIcebergIT extends AbstractIT {
   }
 
   @Test
-  void testCreateCreateWithNullComment() {
+  void testCreateTableWithNullComment() {
     ColumnDTO[] columns = createColumns();
     NameIdentifier tableIdentifier =
         NameIdentifier.of(metalakeName, catalogName, schemaName, tableName);

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/lakehouse/iceberg/CatalogIcebergIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/lakehouse/iceberg/CatalogIcebergIT.java
@@ -327,6 +327,28 @@ public class CatalogIcebergIT extends AbstractIT {
   }
 
   @Test
+  void testCreateCreateWithNullComment() {
+    ColumnDTO[] columns = createColumns();
+    NameIdentifier tableIdentifier =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, tableName);
+
+    TableCatalog tableCatalog = catalog.asTableCatalog();
+    Table createdTable =
+        tableCatalog.createTable(
+            tableIdentifier,
+            columns,
+            null,
+            null,
+            null,
+            null,
+            null);
+    Assertions.assertNull(createdTable.comment());
+
+    Table loadTable = tableCatalog.loadTable(tableIdentifier);
+    Assertions.assertNull(loadTable.comment());
+  }
+
+  @Test
   void testCreateAndLoadIcebergTable() {
     // Create table from Gravitino API
     ColumnDTO[] columns = createColumns();


### PR DESCRIPTION
### What changes were proposed in this pull request?
remove  reserveProperties logic from CreateTableRequest since reserved properties is handled by property system

### Why are the changes needed?

1. when build IcebergTable,  comment equals to null is checked when comment added to properties .
```
      if (null != comment) {
        icebergTable.properties.putIfAbsent(ICEBERG_COMMENT_FIELD_NAME, comment);
      }
```
2. when build CreateTableRequest, the previous implement remove all reserved properties from property map including comment,  and then add comment to map, the bug happens, not checking the null, but this overall  code is redundant


Fix: #1546 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
add UT
