### PR TITLE
[#1649] fix(web): modified the display of the type field in the table

### DIFF
--- a/web/components/ColumnTypeChip.js
+++ b/web/components/ColumnTypeChip.js
@@ -14,7 +14,7 @@ const ColumnTypeChip = props => {
 
   const formatType = type && isString(type) ? type.replace(/\(.*\)/, '') : type
 
-  const label = isString(type) ? type : `${type?.type}<${type?.elementType ?? 'unknown'}>` ?? 'unknown'
+  const label = isString(type) ? type : `${type?.type}`
 
   const columnTypeColor = ColumnTypeColorEnum[formatType] || 'secondary'
   const color = colors[columnTypeColor]?.main || '#8592A3'


### PR DESCRIPTION
### What changes were proposed in this pull request?

Modified the display of the `type` field in the table.

Before:
![image](https://github.com/datastrato/gravitino/assets/17310559/c0c60c60-4dc6-4f29-9a34-115b43efd956)

After:
<img width="645" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/7b437e4f-a3d8-41c8-8e6d-d25f28a5fdc5">


### Why are the changes needed?

Complex types of `type` currently only display the main column type.
The details on how to display more specific information will be discussed in future iterations.


Fix: #1649

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
