### PR TITLE
[#1681] fix: allow blank property value when update table property

### DIFF
--- a/common/src/main/java/com/datastrato/gravitino/dto/requests/TableUpdateRequest.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/requests/TableUpdateRequest.java
@@ -141,8 +141,7 @@ public interface TableUpdateRequest extends RESTRequest {
     public void validate() throws IllegalArgumentException {
       Preconditions.checkArgument(
           StringUtils.isNotBlank(property), "\"property\" field is required and cannot be empty");
-      Preconditions.checkArgument(
-          StringUtils.isNotBlank(value), "\"value\" field is required and cannot be empty");
+      Preconditions.checkArgument(value != null, "\"value\" field is required and cannot be null");
     }
 
     @Override

--- a/common/src/test/java/com/datastrato/gravitino/dto/requests/TestTableUpdatesRequest.java
+++ b/common/src/test/java/com/datastrato/gravitino/dto/requests/TestTableUpdatesRequest.java
@@ -102,6 +102,11 @@ public class TestTableUpdatesRequest {
             + "}";
     Assertions.assertEquals(
         JsonUtils.objectMapper().readTree(expected), JsonUtils.objectMapper().readTree(jsonString));
+
+    // test validate blank property value
+    TableUpdateRequest.SetTablePropertyRequest setTablePropertyRequest =
+        new TableUpdateRequest.SetTablePropertyRequest("key", " ");
+    Assertions.assertDoesNotThrow(setTablePropertyRequest::validate);
   }
 
   @Test

--- a/common/src/test/java/com/datastrato/gravitino/dto/requests/TestTableUpdatesRequest.java
+++ b/common/src/test/java/com/datastrato/gravitino/dto/requests/TestTableUpdatesRequest.java
@@ -107,6 +107,9 @@ public class TestTableUpdatesRequest {
     TableUpdateRequest.SetTablePropertyRequest setTablePropertyRequest =
         new TableUpdateRequest.SetTablePropertyRequest("key", " ");
     Assertions.assertDoesNotThrow(setTablePropertyRequest::validate);
+
+    setTablePropertyRequest = new TableUpdateRequest.SetTablePropertyRequest("key", "");
+    Assertions.assertDoesNotThrow(setTablePropertyRequest::validate);
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

allow blank property value when update table property

### Why are the changes needed?

Fix: #1681 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

UT added
