### PR TITLE
[MINOR] fix(web): fix click table path

### DIFF
--- a/web/app/ui/metalakes/TableView.js
+++ b/web/app/ui/metalakes/TableView.js
@@ -32,7 +32,10 @@ const TableView = props => {
   const [paginationModel, setPaginationModel] = useState(defaultPaginationConfig)
   const store = useAppSelector(state => state.metalakes)
 
-  const handleClickUrl = () => {
+  const handleClickUrl = path => {
+    if (!path) {
+      return
+    }
     const [metalake, catalog, schema, table] = new URLSearchParams(path)
 
     const id = `${(metalake && metalake[1]) ?? ''}${
@@ -66,9 +69,13 @@ const TableView = props => {
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
             <Typography
               noWrap
-              component={Link}
-              href={path ?? '/'}
-              onClick={() => handleClickUrl()}
+              {...(path
+                ? {
+                    component: Link,
+                    href: path
+                  }
+                : {})}
+              onClick={() => handleClickUrl(path)}
               sx={{
                 fontWeight: 400,
                 color: 'primary.main',


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the clickable table path.

Before fix this isssue, it shows a error tip in development mode.

<img width="1042" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/10db85ec-1013-4cc6-b814-083688488e82">


### Why are the changes needed?

Fix error caused by missing parameters.

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
