### PR TITLE
[#1641] improve(web):  change treeview click area hover cursor

### DIFF
--- a/web/app/ui/metalakes/MetalakeTree.js
+++ b/web/app/ui/metalakes/MetalakeTree.js
@@ -86,6 +86,7 @@ const StyledTreeItemRoot = styled(TreeItem)(({ theme, level = 0 }) => ({
     backgroundColor: theme.palette.action.hover
   },
   '& .MuiTreeItem-content': {
+    cursor: 'default',
     paddingRight: theme.spacing(3),
     fontWeight: theme.typography.fontWeightMedium
   },


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change the cursor hover area for the treeview click.

![IMG47](https://github.com/datastrato/gravitino/assets/17310559/8e154799-4db3-48ed-a2c8-643b03f2272f)
![IMG48](https://github.com/datastrato/gravitino/assets/17310559/bee8bd9b-3af2-4690-b029-51b2043052ce)


### Why are the changes needed?

Fix: #1641 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
