### PR TITLE
[#1361] test(postgres-jdbc) support multi pg version in IT

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/TestMultipleJdbcLoad.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/TestMultipleJdbcLoad.java
@@ -66,7 +66,7 @@ public class TestMultipleJdbcLoad extends AbstractIT {
             .withPassword("root");
     mySQLContainer.start();
     postgreSQLContainer =
-        new PostgreSQLContainer<>(CatalogPostgreSqlIT.POSTGRES_IMAGE)
+        new PostgreSQLContainer<>(CatalogPostgreSqlIT.DEFAULT_POSTGRES_IMAGE)
             .withDatabaseName(TEST_DB_NAME)
             .withUsername("root")
             .withPassword("root");

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
@@ -60,25 +60,25 @@ public class CatalogPostgreSqlIT extends AbstractIT {
   public static final String DOWNLOAD_JDBC_DRIVER_URL =
       "https://jdbc.postgresql.org/download/postgresql-42.7.0.jar";
 
-  public  String metalakeName = GravitinoITUtils.genRandomName("postgresql_it_metalake");
-  public  String catalogName = GravitinoITUtils.genRandomName("postgresql_it_catalog");
-  public  String schemaName = GravitinoITUtils.genRandomName("postgresql_it_schema");
-  public  String tableName = GravitinoITUtils.genRandomName("postgresql_it_table");
-  public  String alertTableName = "alert_table_name";
-  public  String table_comment = "table_comment";
-  public  String schema_comment = "schema_comment";
-  public  String POSTGRESQL_COL_NAME1 = "postgresql_col_name1";
-  public  String POSTGRESQL_COL_NAME2 = "postgresql_col_name2";
-  public  String POSTGRESQL_COL_NAME3 = "postgresql_col_name3";
-  private  final String provider = "jdbc-postgresql";
+  public String metalakeName = GravitinoITUtils.genRandomName("postgresql_it_metalake");
+  public String catalogName = GravitinoITUtils.genRandomName("postgresql_it_catalog");
+  public String schemaName = GravitinoITUtils.genRandomName("postgresql_it_schema");
+  public String tableName = GravitinoITUtils.genRandomName("postgresql_it_table");
+  public String alertTableName = "alert_table_name";
+  public String table_comment = "table_comment";
+  public String schema_comment = "schema_comment";
+  public String POSTGRESQL_COL_NAME1 = "postgresql_col_name1";
+  public String POSTGRESQL_COL_NAME2 = "postgresql_col_name2";
+  public String POSTGRESQL_COL_NAME3 = "postgresql_col_name3";
+  private final String provider = "jdbc-postgresql";
 
-  private  GravitinoMetaLake metalake;
+  private GravitinoMetaLake metalake;
 
-  private  Catalog catalog;
+  private Catalog catalog;
 
-  private  PostgreSqlService postgreSqlService;
+  private PostgreSqlService postgreSqlService;
 
-  private  PostgreSQLContainer<?> POSTGRESQL_CONTAINER;
+  private PostgreSQLContainer<?> POSTGRESQL_CONTAINER;
 
   protected final String TEST_DB_NAME = GravitinoITUtils.genRandomName("test_db");
 

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
@@ -49,40 +49,43 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 @Tag("gravitino-docker-it")
+@TestInstance(Lifecycle.PER_CLASS)
 public class CatalogPostgreSqlIT extends AbstractIT {
-  public static String metalakeName = GravitinoITUtils.genRandomName("postgresql_it_metalake");
-  public static String catalogName = GravitinoITUtils.genRandomName("postgresql_it_catalog");
-  public static String schemaName = GravitinoITUtils.genRandomName("postgresql_it_schema");
-  public static String tableName = GravitinoITUtils.genRandomName("postgresql_it_table");
-  public static String alertTableName = "alert_table_name";
-  public static String table_comment = "table_comment";
-
-  public static String schema_comment = "schema_comment";
-
-  public static String POSTGRESQL_COL_NAME1 = "postgresql_col_name1";
-  public static String POSTGRESQL_COL_NAME2 = "postgresql_col_name2";
-  public static String POSTGRESQL_COL_NAME3 = "postgresql_col_name3";
+  public static final String DEFAULT_POSTGRES_IMAGE = "postgres:13";
   public static final String DOWNLOAD_JDBC_DRIVER_URL =
       "https://jdbc.postgresql.org/download/postgresql-42.7.0.jar";
-  private static final String provider = "jdbc-postgresql";
 
-  private static GravitinoMetaLake metalake;
+  public  String metalakeName = GravitinoITUtils.genRandomName("postgresql_it_metalake");
+  public  String catalogName = GravitinoITUtils.genRandomName("postgresql_it_catalog");
+  public  String schemaName = GravitinoITUtils.genRandomName("postgresql_it_schema");
+  public  String tableName = GravitinoITUtils.genRandomName("postgresql_it_table");
+  public  String alertTableName = "alert_table_name";
+  public  String table_comment = "table_comment";
+  public  String schema_comment = "schema_comment";
+  public  String POSTGRESQL_COL_NAME1 = "postgresql_col_name1";
+  public  String POSTGRESQL_COL_NAME2 = "postgresql_col_name2";
+  public  String POSTGRESQL_COL_NAME3 = "postgresql_col_name3";
+  private  final String provider = "jdbc-postgresql";
 
-  private static Catalog catalog;
+  private  GravitinoMetaLake metalake;
 
-  private static PostgreSqlService postgreSqlService;
+  private  Catalog catalog;
 
-  private static PostgreSQLContainer<?> POSTGRESQL_CONTAINER;
+  private  PostgreSqlService postgreSqlService;
 
-  protected static final String TEST_DB_NAME = GravitinoITUtils.genRandomName("test_db");
+  private  PostgreSQLContainer<?> POSTGRESQL_CONTAINER;
 
-  public static final String POSTGRES_IMAGE = "postgres:13";
+  protected final String TEST_DB_NAME = GravitinoITUtils.genRandomName("test_db");
+
+  protected String postgreImageName = DEFAULT_POSTGRES_IMAGE;
 
   @BeforeAll
-  public static void startup() throws IOException {
+  public void startup() throws IOException {
 
     if (!ITUtils.EMBEDDED_TEST_MODE.equals(testMode)) {
       String gravitinoHome = System.getenv("GRAVITINO_HOME");
@@ -91,7 +94,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     }
 
     POSTGRESQL_CONTAINER =
-        new PostgreSQLContainer<>(POSTGRES_IMAGE)
+        new PostgreSQLContainer<>(postgreImageName)
             .withDatabaseName(TEST_DB_NAME)
             .withUsername("root")
             .withPassword("root");
@@ -103,7 +106,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
   }
 
   @AfterAll
-  public static void stop() {
+  public void stop() {
     clearTableAndSchema();
     client.dropMetalake(NameIdentifier.of(metalakeName));
     postgreSqlService.close();
@@ -116,7 +119,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     createSchema();
   }
 
-  private static void clearTableAndSchema() {
+  private void clearTableAndSchema() {
     NameIdentifier[] nameIdentifiers =
         catalog.asTableCatalog().listTables(Namespace.of(metalakeName, catalogName, schemaName));
     for (NameIdentifier nameIdentifier : nameIdentifiers) {
@@ -125,7 +128,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     catalog.asSchemas().dropSchema(NameIdentifier.of(metalakeName, catalogName, schemaName), false);
   }
 
-  private static void createMetalake() {
+  private void createMetalake() {
     GravitinoMetaLake[] gravitinoMetaLakes = client.listMetalakes();
     Assertions.assertEquals(0, gravitinoMetaLakes.length);
 
@@ -137,7 +140,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     metalake = loadMetalake;
   }
 
-  private static void createCatalog() {
+  private void createCatalog() {
     Map<String, String> catalogProperties = Maps.newHashMap();
 
     try {
@@ -166,7 +169,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     catalog = loadCatalog;
   }
 
-  private static void createSchema() {
+  private void createSchema() {
     NameIdentifier ident = NameIdentifier.of(metalakeName, catalogName, schemaName);
 
     Schema createdSchema =

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlVersion12IT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlVersion12IT.java
@@ -5,6 +5,9 @@
 
 package com.datastrato.gravitino.integration.test.catalog.jdbc.postgresql;
 
+import org.junit.jupiter.api.Tag;
+
+@Tag("gravitino-docker-it")
 public class CatalogPostgreSqlVersion12IT extends CatalogPostgreSqlIT {
   public CatalogPostgreSqlVersion12IT() {
     postgreImageName = "postgres:12";

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlVersion12IT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlVersion12IT.java
@@ -1,0 +1,12 @@
+/*
+ *  Copyright 2024 Datastrato Pvt Ltd.
+ *  This software is licensed under the Apache License version 2.
+ */
+
+package com.datastrato.gravitino.integration.test.catalog.jdbc.postgresql;
+
+public class CatalogPostgreSqlVersion12IT extends CatalogPostgreSqlIT {
+  public CatalogPostgreSqlVersion12IT() {
+    postgreImageName = "postgres:12";
+  }
+}

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlVersion14IT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlVersion14IT.java
@@ -5,6 +5,9 @@
 
 package com.datastrato.gravitino.integration.test.catalog.jdbc.postgresql;
 
+import org.junit.jupiter.api.Tag;
+
+@Tag("gravitino-docker-it")
 public class CatalogPostgreSqlVersion14IT extends CatalogPostgreSqlIT {
   public CatalogPostgreSqlVersion14IT() {
     postgreImageName = "postgres:14";

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlVersion14IT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlVersion14IT.java
@@ -1,0 +1,12 @@
+/*
+ *  Copyright 2024 Datastrato Pvt Ltd.
+ *  This software is licensed under the Apache License version 2.
+ */
+
+package com.datastrato.gravitino.integration.test.catalog.jdbc.postgresql;
+
+public class CatalogPostgreSqlVersion14IT extends CatalogPostgreSqlIT {
+  public CatalogPostgreSqlVersion14IT() {
+    postgreImageName = "postgres:14";
+  }
+}

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlVersion15IT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlVersion15IT.java
@@ -5,6 +5,9 @@
 
 package com.datastrato.gravitino.integration.test.catalog.jdbc.postgresql;
 
+import org.junit.jupiter.api.Tag;
+
+@Tag("gravitino-docker-it")
 public class CatalogPostgreSqlVersion15IT extends CatalogPostgreSqlIT {
   public CatalogPostgreSqlVersion15IT() {
     postgreImageName = "postgres:15";

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlVersion15IT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlVersion15IT.java
@@ -1,0 +1,12 @@
+/*
+ *  Copyright 2024 Datastrato Pvt Ltd.
+ *  This software is licensed under the Apache License version 2.
+ */
+
+package com.datastrato.gravitino.integration.test.catalog.jdbc.postgresql;
+
+public class CatalogPostgreSqlVersion15IT extends CatalogPostgreSqlIT {
+  public CatalogPostgreSqlVersion15IT() {
+    postgreImageName = "postgres:15";
+  }
+}

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlVersion16IT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlVersion16IT.java
@@ -5,6 +5,9 @@
 
 package com.datastrato.gravitino.integration.test.catalog.jdbc.postgresql;
 
+import org.junit.jupiter.api.Tag;
+
+@Tag("gravitino-docker-it")
 public class CatalogPostgreSqlVersion16IT extends CatalogPostgreSqlIT {
   public CatalogPostgreSqlVersion16IT() {
     postgreImageName = "postgres:16";

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlVersion16IT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlVersion16IT.java
@@ -1,0 +1,12 @@
+/*
+ *  Copyright 2024 Datastrato Pvt Ltd.
+ *  This software is licensed under the Apache License version 2.
+ */
+
+package com.datastrato.gravitino.integration.test.catalog.jdbc.postgresql;
+
+public class CatalogPostgreSqlVersion16IT extends CatalogPostgreSqlIT {
+  public CatalogPostgreSqlVersion16IT() {
+    postgreImageName = "postgres:16";
+  }
+}

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/TestPostgreSqlAbstractIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/TestPostgreSqlAbstractIT.java
@@ -22,7 +22,7 @@ public class TestPostgreSqlAbstractIT extends TestJdbcAbstractIT {
   @BeforeAll
   public static void startup() {
     CONTAINER =
-        new PostgreSQLContainer<>(CatalogPostgreSqlIT.POSTGRES_IMAGE)
+        new PostgreSQLContainer<>(CatalogPostgreSqlIT.DEFAULT_POSTGRES_IMAGE)
             .withDatabaseName(TEST_DB_NAME)
             .withUsername("root")
             .withPassword("root");


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use separate classes representing various PG versions.
junit5 doesn't support class-level ParameterizedTest. so use a separate class.

### Why are the changes needed?
Test compatibility with various versions of PG.

Fix: #1361 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
existing IT