### PR TITLE
[#1701] fix(mysql): Compatible with lower versions of MySQL driver, unable to obtain table comments.

### DIFF
--- a/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlTableOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlTableOperations.java
@@ -51,6 +51,9 @@ public class MysqlTableOperations extends JdbcTableOperations {
       }
       String comment = table.getString("REMARKS");
       if (StringUtils.isEmpty(comment)) {
+        // In Mysql version 5.7, the comment field value cannot be obtained in the driver API.
+        LOG.warn(
+            "Not found comment in mysql driver api. Will try to get comment from the system table");
         comment = loadCommentFromSysTable(connection, tableName);
       }
 

--- a/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlTableOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlTableOperations.java
@@ -52,9 +52,8 @@ public class MysqlTableOperations extends JdbcTableOperations {
       String comment = table.getString("REMARKS");
       if (StringUtils.isEmpty(comment)) {
         // In Mysql version 5.7, the comment field value cannot be obtained in the driver API.
-        LOG.warn(
-            "Not found comment in mysql driver api. Will try to get comment from the system table");
-        comment = loadCommentFromSysTable(connection, tableName);
+        LOG.warn("Not found comment in mysql driver api. Will try to get comment from sql");
+        comment = loadCommentFromSql(connection, tableName);
       }
 
       // 2.Get column information
@@ -91,8 +90,7 @@ public class MysqlTableOperations extends JdbcTableOperations {
     }
   }
 
-  private String loadCommentFromSysTable(Connection connection, String tableName)
-      throws SQLException {
+  private String loadCommentFromSql(Connection connection, String tableName) throws SQLException {
     try (PreparedStatement statement = connection.prepareStatement("SHOW TABLE STATUS LIKE ?")) {
       statement.setString(1, tableName);
       try (ResultSet resultSet = statement.executeQuery()) {

--- a/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlTableOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlTableOperations.java
@@ -93,18 +93,13 @@ public class MysqlTableOperations extends JdbcTableOperations {
 
   private String loadCommentFromSysTable(Connection connection, String tableName)
       throws SQLException {
-    try (PreparedStatement statement =
-        connection.prepareStatement(
-            "SELECT TABLE_NAME, TABLE_COMMENT\n"
-                + "FROM information_schema.TABLES\n"
-                + "WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?;")) {
-      statement.setString(1, connection.getCatalog());
-      statement.setString(2, tableName);
+    try (PreparedStatement statement = connection.prepareStatement("SHOW TABLE STATUS LIKE ?")) {
+      statement.setString(1, tableName);
       try (ResultSet resultSet = statement.executeQuery()) {
         if (!resultSet.next()) {
           return null;
         }
-        return resultSet.getString("TABLE_COMMENT");
+        return resultSet.getString("COMMENT");
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Compatible with lower versions of MySQL driver, unable to obtain table comments.


### Why are the changes needed?
Fix: #1701

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
UT/IT
