### PR TITLE
[#1709] fix(web): fix comment display

### DIFF
--- a/web/app/ui/DetailsDrawer.js
+++ b/web/app/ui/DetailsDrawer.js
@@ -42,7 +42,7 @@ const DetailsDrawer = props => {
     }
 
     return (
-      <Typography sx={{ fontWeight: 500, whiteSpace: linkBreak ? 'pre' : 'normal' }}>
+      <Typography sx={{ fontWeight: 500, whiteSpace: linkBreak ? 'pre-wrap' : 'normal' }}>
         {isValidDate(value) ? formatToDateTime(value) : value}
       </Typography>
     )

--- a/web/app/ui/metalakes/DetailsView.js
+++ b/web/app/ui/metalakes/DetailsView.js
@@ -29,7 +29,7 @@ const DetailsView = props => {
     }
 
     return (
-      <Typography sx={{ fontWeight: 500, whiteSpace: linkBreak ? 'pre' : 'normal' }}>
+      <Typography sx={{ fontWeight: 500, whiteSpace: linkBreak ? 'pre-wrap' : 'normal' }}>
         {isValidDate(value) ? formatToDateTime(value) : value}
       </Typography>
     )


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix comment display if length is too long.

After:
<img width="398" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/137144cd-014b-4ddf-8543-1129ccf6e454">
<img width="653" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/09a723e7-a23e-4381-abee-158208e75475">

### Why are the changes needed?

Fix: #1709 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
