### PR TITLE
[#1449] fix(jdbc-postgres): audit info is empty

### DIFF
--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
@@ -204,12 +204,11 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
     }
     Map<String, String> properties =
         load.properties() == null ? Maps.newHashMap() : Maps.newHashMap(load.properties());
-    StringIdentifier.newPropertiesWithId(id, properties);
     return new JdbcSchema.Builder()
         .withAuditInfo(load.auditInfo())
         .withName(load.name())
         .withComment(StringIdentifier.removeIdFromComment(load.comment()))
-        .withProperties(properties)
+        .withProperties(StringIdentifier.newPropertiesWithId(id, properties))
         .build();
   }
 

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlSchemaOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlSchemaOperations.java
@@ -40,7 +40,7 @@ public class PostgreSqlSchemaOperations extends JdbcDatabaseOperations {
           });
 
   private static final String GET_SCHEMA_COMMENT_SQL_FORMAT =
-      "SELECT obj_description('%s'::regnamespace)";
+      "SELECT obj_description('%s'::regnamespace) as comment";
 
   private String database;
 
@@ -150,7 +150,7 @@ public class PostgreSqlSchemaOperations extends JdbcDatabaseOperations {
         connection.prepareStatement(getShowSchemaCommentSql(schema))) {
       try (ResultSet resultSet = preparedStatement.executeQuery()) {
         if (resultSet.next()) {
-          return resultSet.getString(1);
+          return resultSet.getString("comment");
         }
       }
     }

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlSchemaOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlSchemaOperations.java
@@ -142,11 +142,10 @@ public class PostgreSqlSchemaOperations extends JdbcDatabaseOperations {
   }
 
   private String getShowSchemaCommentSql(String schema) {
-    return String.format(GET_SCHEMA_COMMENT_SQL_FORMAT,schema);
+    return String.format(GET_SCHEMA_COMMENT_SQL_FORMAT, schema);
   }
 
-  private String getSchemaComment(String schema, Connection connection)
-      throws SQLException {
+  private String getSchemaComment(String schema, Connection connection) throws SQLException {
     try (PreparedStatement preparedStatement =
         connection.prepareStatement(getShowSchemaCommentSql(schema))) {
       try (ResultSet resultSet = preparedStatement.executeQuery()) {

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlSchemaOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlSchemaOperations.java
@@ -39,6 +39,9 @@ public class PostgreSqlSchemaOperations extends JdbcDatabaseOperations {
             }
           });
 
+  private static final String GET_SCHEMA_COMMENT_SQL_FORMAT =
+      "SELECT obj_description('%s'::regnamespace)";
+
   private String database;
 
   @Override
@@ -61,8 +64,10 @@ public class PostgreSqlSchemaOperations extends JdbcDatabaseOperations {
             throw new NoSuchSchemaException("No such schema: " + schema);
           }
           String schemaName = resultSet.getString(1);
+          String comment = getSchemaComment(schema, connection);
           return new JdbcSchema.Builder()
               .withName(schemaName)
+              .withComment(comment)
               .withAuditInfo(AuditInfo.EMPTY)
               .withProperties(Collections.emptyMap())
               .build();
@@ -134,5 +139,22 @@ public class PostgreSqlSchemaOperations extends JdbcDatabaseOperations {
   @Override
   protected boolean isSystemDatabase(String dbName) {
     return SYS_PG_DATABASE_NAMES.contains(dbName.toLowerCase(Locale.ROOT));
+  }
+
+  private String getShowSchemaCommentSql(String schema) {
+    return String.format(GET_SCHEMA_COMMENT_SQL_FORMAT,schema);
+  }
+
+  private String getSchemaComment(String schema, Connection connection)
+      throws SQLException {
+    try (PreparedStatement preparedStatement =
+        connection.prepareStatement(getShowSchemaCommentSql(schema))) {
+      try (ResultSet resultSet = preparedStatement.executeQuery()) {
+        if (resultSet.next()) {
+          return resultSet.getString(1);
+        }
+      }
+    }
+    return null;
   }
 }

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/CatalogMysqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/CatalogMysqlIT.java
@@ -562,15 +562,13 @@ public class CatalogMysqlIT extends AbstractIT {
                 .loadSchema(NameIdentifier.of(metalakeName, catalogName, schemaName)));
   }
 
-
   @Test
   void testCreateAndLoadSchema() {
     String testSchemaName = "ssss";
     NameIdentifier ident = NameIdentifier.of(metalakeName, catalogName, testSchemaName);
     System.out.println(ident);
 
-    Schema schema =
-        catalog.asSchemas().createSchema(ident, "comment", null);
+    Schema schema = catalog.asSchemas().createSchema(ident, "comment", null);
     System.out.println(schema.name());
     System.out.println(schema.comment());
     System.out.println(schema.auditInfo());

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/CatalogMysqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/CatalogMysqlIT.java
@@ -561,25 +561,4 @@ public class CatalogMysqlIT extends AbstractIT {
                 .asSchemas()
                 .loadSchema(NameIdentifier.of(metalakeName, catalogName, schemaName)));
   }
-
-  @Test
-  void testCreateAndLoadSchema() {
-    String testSchemaName = "ssss";
-    NameIdentifier ident = NameIdentifier.of(metalakeName, catalogName, testSchemaName);
-    System.out.println(ident);
-
-    Schema schema = catalog.asSchemas().createSchema(ident, "comment", null);
-    System.out.println(schema.name());
-    System.out.println(schema.comment());
-    System.out.println(schema.auditInfo());
-    System.out.println(schema.properties());
-    Assertions.assertEquals("comment", schema.comment());
-
-    schema = catalog.asSchemas().loadSchema(ident);
-    System.out.println(schema.name());
-    System.out.println(schema.comment());
-    System.out.println(schema.auditInfo());
-    System.out.println(schema.properties());
-    Assertions.assertEquals("comment", schema.comment());
-  }
 }

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/CatalogMysqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/CatalogMysqlIT.java
@@ -561,4 +561,27 @@ public class CatalogMysqlIT extends AbstractIT {
                 .asSchemas()
                 .loadSchema(NameIdentifier.of(metalakeName, catalogName, schemaName)));
   }
+
+
+  @Test
+  void testCreateAndLoadSchema() {
+    String testSchemaName = "ssss";
+    NameIdentifier ident = NameIdentifier.of(metalakeName, catalogName, testSchemaName);
+    System.out.println(ident);
+
+    Schema schema =
+        catalog.asSchemas().createSchema(ident, "comment", null);
+    System.out.println(schema.name());
+    System.out.println(schema.comment());
+    System.out.println(schema.auditInfo());
+    System.out.println(schema.properties());
+    Assertions.assertEquals("comment", schema.comment());
+
+    schema = catalog.asSchemas().loadSchema(ident);
+    System.out.println(schema.name());
+    System.out.println(schema.comment());
+    System.out.println(schema.auditInfo());
+    System.out.println(schema.properties());
+    Assertions.assertEquals("comment", schema.comment());
+  }
 }

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
@@ -523,4 +523,26 @@ public class CatalogPostgreSqlIT extends AbstractIT {
           catalog.asTableCatalog().dropTable(tableIdentifier);
         });
   }
+
+  @Test
+  void testCreateAndLoadSchema() {
+    String testSchemaName = "ssss";
+    NameIdentifier ident = NameIdentifier.of(metalakeName, catalogName, testSchemaName);
+    System.out.println(ident);
+
+    Schema schema =
+        catalog.asSchemas().createSchema(ident, "comment", null);
+    System.out.println(schema.name());
+    System.out.println(schema.comment());
+    System.out.println(schema.auditInfo());
+    System.out.println(schema.properties());
+    Assertions.assertEquals("comment", schema.comment());
+
+    schema = catalog.asSchemas().loadSchema(ident);
+    System.out.println(schema.name());
+    System.out.println(schema.comment());
+    System.out.println(schema.auditInfo());
+    System.out.println(schema.properties());
+    Assertions.assertEquals("comment", schema.comment());
+  }
 }

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.datanucleus.util.StringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -526,23 +527,26 @@ public class CatalogPostgreSqlIT extends AbstractIT {
 
   @Test
   void testCreateAndLoadSchema() {
-    String testSchemaName = "ssss";
+    String testSchemaName = "test";
     NameIdentifier ident = NameIdentifier.of(metalakeName, catalogName, testSchemaName);
-    System.out.println(ident);
 
-    Schema schema =
-        catalog.asSchemas().createSchema(ident, "comment", null);
-    System.out.println(schema.name());
-    System.out.println(schema.comment());
-    System.out.println(schema.auditInfo());
-    System.out.println(schema.properties());
+    Schema schema = catalog.asSchemas().createSchema(ident, "comment", null);
+    Assertions.assertEquals("anonymous", schema.auditInfo().creator());
     Assertions.assertEquals("comment", schema.comment());
-
     schema = catalog.asSchemas().loadSchema(ident);
-    System.out.println(schema.name());
-    System.out.println(schema.comment());
-    System.out.println(schema.auditInfo());
-    System.out.println(schema.properties());
+    Assertions.assertEquals("anonymous", schema.auditInfo().creator());
     Assertions.assertEquals("comment", schema.comment());
+
+    // test null comment
+    testSchemaName = "test2";
+    ident = NameIdentifier.of(metalakeName, catalogName, testSchemaName);
+
+    schema = catalog.asSchemas().createSchema(ident, null, null);
+    Assertions.assertEquals("anonymous", schema.auditInfo().creator());
+    // todo: Gravitino put id to comment, makes comment is empty string not null.
+    Assertions.assertTrue(StringUtils.isEmpty(schema.comment()));
+    schema = catalog.asSchemas().loadSchema(ident);
+    Assertions.assertEquals("anonymous", schema.auditInfo().creator());
+    Assertions.assertTrue(StringUtils.isEmpty(schema.comment()));
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
to get gravitino identifier id from schema, 
1. get comment from pg
2. add gravitino identifier to properties,
```
//  properties is not changed , we should use the returned properties.
    StringIdentifier.newPropertiesWithId(id, properties);
    JdbcSchema.Builder().withProperties(properties).build();
```

### Why are the changes needed?
we couldn't get audit info from entity store without  gravitino identifier id

Fix: #1449 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
add test to check audit info