### PR TITLE
[#1208] feat(web): add catalog management via api

### DIFF
--- a/web/app/ui/metalakes/CreateCatalogDialog.js
+++ b/web/app/ui/metalakes/CreateCatalogDialog.js
@@ -262,10 +262,15 @@ const CreateCatalogDialog = props => {
       defaultProps = providers[providerItemIndex].defaultProps
 
       resetPropsFields(providers, providerItemIndex)
-      setInnerProps(defaultProps)
-      setValue('propItems', providers[providerItemIndex].defaultProps)
+
+      if (type === 'create') {
+        setInnerProps(defaultProps)
+        setValue('propItems', providers[providerItemIndex].defaultProps)
+      }
     }
-  }, [providerSelect, setInnerProps, setValue])
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [providerSelect])
 
   useEffect(() => {
     if (open && JSON.stringify(data) !== '{}') {
@@ -278,14 +283,27 @@ const CreateCatalogDialog = props => {
       setValue('provider', data.provider)
 
       const providerItem = providers.find(i => i.value === data.provider)
-      const propsItems = providerItem.defaultProps || []
+      let propsItems = [...providerItem.defaultProps]
 
-      for (let item of Object.keys(properties)) {
-        const findProp = propsItems.find(i => i.key === item)
+      propsItems = propsItems.map((it, idx) => {
+        let propItem = {
+          ...it,
+          disabled: true
+        }
+
+        const findProp = Object.keys(properties).find(i => i === it.key)
 
         if (findProp) {
-          findProp.value = properties[item]
-        } else {
+          propItem.value = properties[findProp]
+        }
+
+        return propItem
+      })
+
+      for (let item of Object.keys(properties)) {
+        const findPropIndex = propsItems.findIndex(i => i.key === item)
+
+        if (findPropIndex === -1) {
           let propItem = {
             key: item,
             value: properties[item]
@@ -469,6 +487,7 @@ const CreateCatalogDialog = props => {
                                     label='Value'
                                     error={item.required && item.value === ''}
                                     value={item.value}
+                                    disabled={item.disabled}
                                     onChange={event => handleFormChange({ index, event })}
                                   />
                                 )}

--- a/web/app/ui/metalakes/CreateCatalogDialog.js
+++ b/web/app/ui/metalakes/CreateCatalogDialog.js
@@ -269,40 +269,33 @@ const CreateCatalogDialog = props => {
 
   useEffect(() => {
     if (open && JSON.stringify(data) !== '{}') {
+      const { properties = {} } = data
+
       setCacheData(data)
       setValue('name', data.name)
       setValue('comment', data.comment)
       setValue('type', data.type)
       setValue('provider', data.provider)
-      const providerIndex = providers.findIndex(i => i.value === data.provider)
 
-      const propsItems = [...providers[providerIndex].defaultProps]
-
-      const { properties = {} } = data
-
-      let propsData = []
+      const providerItem = providers.find(i => i.value === data.provider)
+      const propsItems = providerItem.defaultProps || []
 
       for (let item of Object.keys(properties)) {
         const findProp = propsItems.find(i => i.key === item)
 
         if (findProp) {
-          let propItem = {
-            ...findProp,
-            value: properties[item]
-          }
-
-          propsData.push(propItem)
+          findProp.value = properties[item]
         } else {
           let propItem = {
             key: item,
             value: properties[item]
           }
-          propsData.push(propItem)
+          propsItems.push(propItem)
         }
       }
 
-      setInnerProps(propsData)
-      setValue('propItems', propsData)
+      setInnerProps(propsItems)
+      setValue('propItems', propsItems)
     }
   }, [open, data, setValue])
 
@@ -368,6 +361,7 @@ const CreateCatalogDialog = props => {
                       onChange={onChange}
                       error={Boolean(errors.type)}
                       labelId='select-catalog-type'
+                      disabled={type === 'update'}
                     >
                       <MenuItem value={'relational'}>relational</MenuItem>
                     </Select>
@@ -394,6 +388,7 @@ const CreateCatalogDialog = props => {
                       onChange={e => handleChangeProvider(onChange, e)}
                       error={Boolean(errors.provider)}
                       labelId='select-catalog-provider'
+                      disabled={type === 'update'}
                     >
                       <MenuItem value={'hive'}>hive</MenuItem>
                       <MenuItem value={'lakehouse-iceberg'}>iceberg</MenuItem>

--- a/web/app/ui/metalakes/DetailsDrawer.js
+++ b/web/app/ui/metalakes/DetailsDrawer.js
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+
+import { useEffect, useState } from 'react'
+
+import {
+  Box,
+  Grid,
+  Drawer,
+  IconButton,
+  Typography,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  TableContainer
+} from '@mui/material'
+
+import Icon from '@/components/Icon'
+
+import EmptyText from '@/components/EmptyText'
+
+import { formatToDateTime, isValidDate } from '@/lib/utils/date'
+
+const DetailsDrawer = props => {
+  const { openDrawer, setOpenDrawer, drawerData = {} } = props
+
+  const { audit = {} } = drawerData
+
+  const [properties, setProperties] = useState([])
+
+  const handleClose = () => {
+    setOpenDrawer(false)
+  }
+
+  const renderFieldText = (value, linkBreak = false) => {
+    if (!value) {
+      return <EmptyText />
+    }
+
+    return (
+      <Typography sx={{ fontWeight: 500, whiteSpace: linkBreak ? 'pre-wrap' : 'normal' }}>
+        {isValidDate(value) ? formatToDateTime(value) : value}
+      </Typography>
+    )
+  }
+
+  useEffect(() => {
+    if (drawerData.properties) {
+      const propsData = Object.keys(drawerData.properties).map(item => {
+        return {
+          key: item,
+          value: drawerData.properties[item]
+        }
+      })
+
+      setProperties(propsData)
+    }
+  }, [drawerData])
+
+  return (
+    <Drawer
+      open={openDrawer}
+      anchor='right'
+      variant='temporary'
+      onClose={handleClose}
+      ModalProps={{ keepMounted: true }}
+      PaperProps={{
+        sx: {
+          width: {
+            xs: 300,
+            sm: 400
+          }
+        }
+      }}
+    >
+      <Box
+        className={'drawer-header twc-flex twc-items-center twc-justify-between'}
+        sx={{
+          p: theme => theme.spacing(3, 4),
+          borderBottom: theme => `1px solid ${theme.palette.divider}`,
+          backgroundColor: theme => theme.palette.background.default
+        }}
+      >
+        <Typography variant='h6'>Details</Typography>
+        <IconButton size='small' onClick={handleClose} sx={{ color: 'text.primary' }}>
+          <Icon icon='bx:x' fontSize={20} />
+        </IconButton>
+      </Box>
+      <Box sx={{ p: 4 }}>
+        <Grid item xs={12} sx={{ mb: [0, 5] }}>
+          <Typography
+            variant='subtitle1'
+            className={'twc-py-2 twc-font-semibold twc-text-[1.2rem]'}
+            sx={{
+              borderBottom: theme => `1px solid ${theme.palette.divider}`
+            }}
+          >
+            {drawerData.name}
+          </Typography>
+        </Grid>
+
+        <Grid item xs={12} sx={{ mb: [0, 5] }}>
+          <Typography variant='body2' sx={{ mb: 2 }}>
+            Comment
+          </Typography>
+          {renderFieldText(drawerData.comment, true)}
+        </Grid>
+
+        <Grid item xs={12} sx={{ mb: [0, 5] }}>
+          <Typography variant='body2' sx={{ mb: 2 }}>
+            Created by
+          </Typography>
+          {renderFieldText(audit.creator)}
+        </Grid>
+
+        <Grid item xs={12} sx={{ mb: [0, 5] }}>
+          <Typography variant='body2' sx={{ mb: 2 }}>
+            Created at
+          </Typography>
+          {renderFieldText(audit.createTime)}
+        </Grid>
+
+        <Grid item xs={12} sx={{ mb: [0, 5] }}>
+          <Typography variant='body2' sx={{ mb: 2 }}>
+            Last modified by
+          </Typography>
+          {renderFieldText(audit.lastModifier)}
+        </Grid>
+
+        <Grid item xs={12} sx={{ mb: [0, 5] }}>
+          <Typography variant='body2' sx={{ mb: 2 }}>
+            Last modified at
+          </Typography>
+          {renderFieldText(audit.lastModifiedTime)}
+        </Grid>
+
+        <Grid item xs={12} sx={{ mb: [0, 5] }}>
+          <Typography variant='body2' sx={{ mb: 2 }}>
+            Properties
+          </Typography>
+
+          <TableContainer>
+            <Table>
+              <TableHead
+                sx={{
+                  backgroundColor: theme => theme.palette.action.hover
+                }}
+              >
+                <TableRow>
+                  <TableCell sx={{ py: 2 }}>Key</TableCell>
+                  <TableCell sx={{ py: 2 }}>Value</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {properties.map((item, index) => {
+                  return (
+                    <TableRow key={index}>
+                      <TableCell className={'twc-py-[0.7rem]'}>{item.key}</TableCell>
+                      <TableCell className={'twc-py-[0.7rem]'}>{item.value}</TableCell>
+                    </TableRow>
+                  )
+                })}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Grid>
+      </Box>
+    </Drawer>
+  )
+}
+
+export default DetailsDrawer

--- a/web/app/ui/metalakes/RightContent.js
+++ b/web/app/ui/metalakes/RightContent.js
@@ -60,7 +60,7 @@ const RightContent = props => {
       </Box>
 
       <Box sx={{ height: 'calc(100% - 4rem)' }}>
-        <TabsContent tableTitle={tableTitle} store={store} page={page} />
+        <TabsContent tableTitle={tableTitle} store={store} page={page} routeParams={routeParams} />
       </Box>
     </Box>
   )

--- a/web/app/ui/metalakes/TabsContent.js
+++ b/web/app/ui/metalakes/TabsContent.js
@@ -51,7 +51,7 @@ const CustomTabPanel = props => {
 }
 
 const TabsContent = props => {
-  const { tableTitle, store, page } = props
+  const { tableTitle, store, page, routeParams } = props
   const [tab, setTab] = useState('table')
 
   const handleChangeTab = (event, newValue) => {
@@ -67,7 +67,7 @@ const TabsContent = props => {
         </TabList>
       </Box>
       <CustomTabPanel value='table'>
-        <TableView page={page} />
+        <TableView page={page} routeParams={routeParams} />
       </CustomTabPanel>
       <CustomTabPanel value='details'>
         <DetailsView store={store} page={page} />

--- a/web/lib/api/catalogs/index.js
+++ b/web/lib/api/catalogs/index.js
@@ -8,7 +8,9 @@ import { defHttp } from '@/lib/utils/axios'
 const Apis = {
   GET: ({ metalake }) => `/api/metalakes/${metalake}/catalogs`,
   GET_DETAIL: ({ metalake, catalog }) => `/api/metalakes/${metalake}/catalogs/${catalog}`,
-  CREATE: ({ metalake }) => `/api/metalakes/${metalake}/catalogs`
+  CREATE: ({ metalake }) => `/api/metalakes/${metalake}/catalogs`,
+  UPDATE: ({ metalake, catalog }) => `/api/metalakes/${metalake}/catalogs/${catalog}`,
+  DELETE: ({ metalake, catalog }) => `/api/metalakes/${metalake}/catalogs/${catalog}`
 }
 
 export const getCatalogsApi = params => {
@@ -27,5 +29,18 @@ export const createCatalogApi = ({ data, metalake }) => {
   return defHttp.post({
     url: `${Apis.CREATE({ metalake })}`,
     data
+  })
+}
+
+export const updateCatalogApi = ({ metalake, catalog, data }) => {
+  return defHttp.put({
+    url: `${Apis.UPDATE({ metalake, catalog })}`,
+    data
+  })
+}
+
+export const deleteCatalogApi = ({ metalake, catalog }) => {
+  return defHttp.delete({
+    url: `${Apis.DELETE({ metalake, catalog })}`
   })
 }

--- a/web/lib/store/metalakes/index.js
+++ b/web/lib/store/metalakes/index.js
@@ -303,8 +303,8 @@ export const updateCatalog = createAsyncThunk(
     if (err || !res) {
       throw new Error(err)
     }
-    dispatch(fetchCatalogs({ ...data, page: 'metalakes', init: true }))
-    dispatch(initMetalakeTree({ ...data }))
+    dispatch(fetchCatalogs({ metalake, catalog, page: 'metalakes', init: true }))
+    dispatch(initMetalakeTree({ metalake, catalog }))
 
     return res
   }

--- a/web/lib/store/metalakes/index.js
+++ b/web/lib/store/metalakes/index.js
@@ -15,7 +15,13 @@ import {
   getMetalakeDetailsApi
 } from '@/lib/api/metalakes'
 
-import { getCatalogsApi, getCatalogDetailsApi, createCatalogApi } from '@/lib/api/catalogs'
+import {
+  getCatalogsApi,
+  getCatalogDetailsApi,
+  createCatalogApi,
+  updateCatalogApi,
+  deleteCatalogApi
+} from '@/lib/api/catalogs'
 import { getSchemasApi, getSchemaDetailsApi } from '@/lib/api/schemas'
 import { getTablesApi, getTableDetailsApi } from '@/lib/api/tables'
 
@@ -274,7 +280,9 @@ export const getCatalogDetails = createAsyncThunk('appMetalakes/getCatalogDetail
 export const createCatalog = createAsyncThunk(
   'appMetalakes/createCatalog',
   async ({ data, metalake }, { dispatch }) => {
+    dispatch(setTableLoading(true))
     const [err, res] = await to(createCatalogApi({ data, metalake }))
+    dispatch(setTableLoading(false))
 
     if (err || !res) {
       throw new Error(err)
@@ -287,6 +295,35 @@ export const createCatalog = createAsyncThunk(
     return res.catalog
   }
 )
+
+export const updateCatalog = createAsyncThunk(
+  'appMetalakes/updateCatalog',
+  async ({ metalake, catalog, data }, { dispatch }) => {
+    const [err, res] = await to(updateCatalogApi({ metalake, catalog, data }))
+    if (err || !res) {
+      throw new Error(err)
+    }
+    dispatch(fetchCatalogs({ ...data, page: 'metalakes', init: true }))
+    dispatch(initMetalakeTree({ ...data }))
+
+    return res
+  }
+)
+
+export const deleteCatalog = createAsyncThunk('appMetalakes/deleteCatalog', async (data, { dispatch }) => {
+  dispatch(setTableLoading(true))
+  const [err, res] = await to(deleteCatalogApi(data))
+  dispatch(setTableLoading(false))
+
+  if (err || !res) {
+    throw new Error(err)
+  }
+
+  dispatch(fetchCatalogs({ ...data, page: 'metalakes', init: true }))
+  dispatch(initMetalakeTree({ ...data }))
+
+  return res
+})
 
 export const fetchSchemas = createAsyncThunk(
   'appMetalakes/fetchSchemas',


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add API-based catalog management.

<img width="1036" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/7d1e4149-1e5c-42aa-9a82-31519710f45a">
<img width="1036" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/547256e5-a4cd-4397-821d-2a410c93b066">
<img width="1035" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/da4d6800-d1d4-4266-91ec-9c9f9f1b1ac0">
<img width="1038" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/75408e5b-f1ed-4fa5-ad51-eeb00ac9d36f">


### Why are the changes needed?

Fix: #1208 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
