### PR TITLE
[#1722] fix: Fix the start command of Java17

### DIFF
--- a/bin/gravitino.sh
+++ b/bin/gravitino.sh
@@ -153,7 +153,7 @@ if [ "$JVM_VERSION" -eq 17 ]; then
   JAVA_OPTS+=" --add-opens java.base/sun.nio.cs=ALL-UNNAMED"
   JAVA_OPTS+=" --add-opens java.base/sun.security.action=ALL-UNNAMED"
   JAVA_OPTS+=" --add-opens java.base/sun.util.calendar=ALL-UNNAMED"
-  JAVA_OPTS+=" --add-opens", "java.security.jgss/sun.security.krb5=ALL-UNNAMED"
+  JAVA_OPTS+=" --add-opens java.security.jgss/sun.security.krb5=ALL-UNNAMED"
 fi
 
 addJarInDir "${GRAVITINO_HOME}/libs"


### PR DESCRIPTION
### What changes were proposed in this pull request?
I add error start options in previous pull request.

I will fix the start command of Java17 in this pull request.

### Why are the changes needed?

Fix: #1722 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
```
export JAVA_HOME=<jdk17>
./gradlew compileDistribution
cd distribution/package/
sh bin/gravitino.sh restart
```
run the command successfully.
