### PR TITLE
[#1760] Fix(core): Fix bug when introducing fileset api in CatalogOperationDispatcher

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/catalog/CatalogOperationDispatcher.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/CatalogOperationDispatcher.java
@@ -398,7 +398,7 @@ public class CatalogOperationDispatcher implements TableCatalog, FilesetCatalog,
           .withHiddenPropertiesSet(
               getHiddenPropertyNames(
                   catalogIdentifier,
-                  HasPropertyMetadata::filesetPropertiesMetadata,
+                  HasPropertyMetadata::tablePropertiesMetadata,
                   table.properties()));
     }
 
@@ -667,7 +667,9 @@ public class CatalogOperationDispatcher implements TableCatalog, FilesetCatalog,
     return EntityCombinedFileset.of(fileset)
         .withHiddenPropertiesSet(
             getHiddenPropertyNames(
-                catalogIdent, HasPropertyMetadata::tablePropertiesMetadata, fileset.properties()));
+                catalogIdent,
+                HasPropertyMetadata::filesetPropertiesMetadata,
+                fileset.properties()));
   }
 
   @Override
@@ -705,7 +707,7 @@ public class CatalogOperationDispatcher implements TableCatalog, FilesetCatalog,
         .withHiddenPropertiesSet(
             getHiddenPropertyNames(
                 catalogIdent,
-                HasPropertyMetadata::tablePropertiesMetadata,
+                HasPropertyMetadata::filesetPropertiesMetadata,
                 createdFileset.properties()));
   }
 
@@ -725,7 +727,7 @@ public class CatalogOperationDispatcher implements TableCatalog, FilesetCatalog,
         .withHiddenPropertiesSet(
             getHiddenPropertyNames(
                 catalogIdent,
-                HasPropertyMetadata::tablePropertiesMetadata,
+                HasPropertyMetadata::filesetPropertiesMetadata,
                 alteredFileset.properties()));
   }
 

--- a/core/src/test/java/com/datastrato/gravitino/TestCatalogOperations.java
+++ b/core/src/test/java/com/datastrato/gravitino/TestCatalogOperations.java
@@ -63,7 +63,7 @@ public class TestCatalogOperations
     filesets = Maps.newHashMap();
     tablePropertiesMetadata = new TestBasePropertiesMetadata();
     schemaPropertiesMetadata = new TestBasePropertiesMetadata();
-    filesetPropertiesMetadata = new TestBasePropertiesMetadata();
+    filesetPropertiesMetadata = new TestFilesetPropertiesMetadata();
     this.config = config;
   }
 

--- a/core/src/test/java/com/datastrato/gravitino/TestFilesetPropertiesMetadata.java
+++ b/core/src/test/java/com/datastrato/gravitino/TestFilesetPropertiesMetadata.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino;
+
+import com.datastrato.gravitino.catalog.PropertyEntry;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import java.util.List;
+import java.util.Map;
+
+public class TestFilesetPropertiesMetadata extends TestBasePropertiesMetadata {
+
+  public static final String TEST_FILESET_HIDDEN_KEY = "fileset_key";
+
+  private static final Map<String, PropertyEntry<?>> TEST_FILESET_PROPERTY;
+
+  static {
+    List<PropertyEntry<?>> tablePropertyMetadata =
+        ImmutableList.of(
+            PropertyEntry.stringPropertyEntry(
+                TEST_FILESET_HIDDEN_KEY,
+                "test fileset required k1 property",
+                false,
+                false,
+                "test",
+                true,
+                false));
+
+    TEST_FILESET_PROPERTY = Maps.uniqueIndex(tablePropertyMetadata, PropertyEntry::getName);
+  }
+
+  @Override
+  protected Map<String, PropertyEntry<?>> specificPropertyEntries() {
+    return ImmutableMap.<String, PropertyEntry<?>>builder()
+        .putAll(super.specificPropertyEntries())
+        .putAll(TEST_FILESET_PROPERTY)
+        .build();
+  }
+}

--- a/core/src/test/java/com/datastrato/gravitino/catalog/TestCatalogOperationDispatcher.java
+++ b/core/src/test/java/com/datastrato/gravitino/catalog/TestCatalogOperationDispatcher.java
@@ -8,6 +8,7 @@ import static com.datastrato.gravitino.Entity.EntityType.SCHEMA;
 import static com.datastrato.gravitino.Entity.EntityType.TABLE;
 import static com.datastrato.gravitino.StringIdentifier.ID_KEY;
 import static com.datastrato.gravitino.TestBasePropertiesMetadata.COMMENT_KEY;
+import static com.datastrato.gravitino.TestFilesetPropertiesMetadata.TEST_FILESET_HIDDEN_KEY;
 import static com.datastrato.gravitino.catalog.BasePropertiesMetadata.GRAVITINO_MANAGED_ENTITY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -678,6 +679,7 @@ public class TestCatalogOperationDispatcher {
         });
     Assertions.assertFalse(testProps.containsKey(StringIdentifier.ID_KEY));
     Assertions.assertFalse(testProps.containsKey(GRAVITINO_MANAGED_ENTITY));
+    Assertions.assertFalse(testProps.containsKey(TEST_FILESET_HIDDEN_KEY));
   }
 
   private void testPropertyException(Executable operation, String... errorMessage) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Using the correct PropertiesMetadata to check the value when doing operations.

### Why are the changes needed?

This is bug introduced in #1667 , fix it here.

Fix: #1706 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Add UTs.
