### PR TITLE
[#1781] fix:(trino-connector) Remove warning messages from the query execution output in Trino.

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoQueryIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoQueryIT.java
@@ -55,7 +55,7 @@ public class TrinoQueryIT extends TrinoQueryITBase {
     ciTestsets.add("lakehouse-iceberg");
     ciTestsets.add("jdbc-mysql");
     ciTestsets.add("jdbc-postgresql");
-    ciTestsets.add("tpcds");
+    ciTestsets.add("tpch");
   }
 
   @BeforeAll
@@ -206,6 +206,7 @@ public class TrinoQueryIT extends TrinoQueryITBase {
       }
 
       String result = queryRunner.runQuery(sql).trim();
+      result = result.replaceAll("WARNING:.*?\\n", "");
       boolean match = match(expectResult, result);
 
       if (match) {

--- a/integration-test/src/test/resources/trino-ci-testset/testsets/tpcds/00014.txt
+++ b/integration-test/src/test/resources/trino-ci-testset/testsets/tpcds/00014.txt
@@ -1,4 +1,3 @@
-WARNING: Number of stages in the query (%) exceeds the soft limit (50). If the query contains multiple aggregates with DISTINCT over different columns, please set the 'mark_distinct_strategy' session property to 'none'. If the query contains WITH clauses that are referenced more than once, please create temporary table(s) for the queries in those clauses.
 "catalog","1001001","1","5","24855.29","3"
 "catalog","1001001","1","","24855.29","3"
 "catalog","1001001","2","2","14819.17","3"


### PR DESCRIPTION

### What changes were proposed in this pull request?

Remove warning messages from the query execution output in Trino.
Set the TPC-H test set as the default for CI.

### Why are the changes needed?

Fix: #1781

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

TrinoQueryIT