### PR TITLE
[#1789] fix(mysql): The table properties values extracted from MySQL need to go through the Gravitino conversion logic.

### DIFF
--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
@@ -280,7 +280,7 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
     } else {
       properties = StringIdentifier.newPropertiesWithId(id, properties);
       // Remove id from comment
-      comment = StringIdentifier.removeIdFromComment(load.comment());
+      comment = StringIdentifier.removeIdFromComment(comment);
     }
     return new JdbcTable.Builder()
         .withAuditInfo(load.auditInfo())

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
@@ -268,25 +268,26 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
     String databaseName = NameIdentifier.of(tableIdent.namespace().levels()).name();
     String tableName = tableIdent.name();
     JdbcTable load = tableOperation.load(databaseName, tableName);
+    Map<String, String> properties =
+        load.properties() == null
+            ? Maps.newHashMap()
+            : jdbcTablePropertiesMetadata.convertFromJdbcProperties(load.properties());
     String comment = load.comment();
     StringIdentifier id = StringIdentifier.fromComment(comment);
     if (id == null) {
       LOG.warn(
           "The table {} comment {} does not contain gravitino id attribute", tableName, comment);
-      return load;
+    } else {
+      properties = StringIdentifier.newPropertiesWithId(id, properties);
+      // Remove id from comment
+      comment = StringIdentifier.removeIdFromComment(load.comment());
     }
-    Map<String, String> properties =
-        load.properties() == null
-            ? Maps.newHashMap()
-            : jdbcTablePropertiesMetadata.convertFromJdbcProperties(load.properties());
-    properties = StringIdentifier.newPropertiesWithId(id, properties);
     return new JdbcTable.Builder()
         .withAuditInfo(load.auditInfo())
         .withName(tableName)
         .withColumns(load.columns())
         .withAuditInfo(load.auditInfo())
-        // Remove id from comment
-        .withComment(StringIdentifier.removeIdFromComment(load.comment()))
+        .withComment(comment)
         .withProperties(properties)
         .withIndexes(load.index())
         .build();


### PR DESCRIPTION
### What changes were proposed in this pull request?

The table properties values extracted from MySQL need to go through the Gravitino conversion logic.

### Why are the changes needed?
Fix: #1789 

### Does this PR introduce _any_ user-facing change?
NO
### How was this patch tested?
Conducted end-to-end testing

