### PR TITLE
[#1783] fix(web): fix duplicate key message and disabled the Select component

### DIFF
--- a/web/app/ui/CreateMetalakeDialog.js
+++ b/web/app/ui/CreateMetalakeDialog.js
@@ -29,6 +29,7 @@ import * as yup from 'yup'
 import { useForm, Controller } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 
+import { groupBy } from 'lodash-es'
 import { genUpdates } from '@/lib/utils'
 import { nameRegex, keyRegex } from '@/lib/utils/regex'
 
@@ -76,17 +77,23 @@ const CreateMetalakeDialog = props => {
   const handleFormChange = (index, event) => {
     let data = [...innerProps]
     data[index][event.target.name] = event.target.value
-    setInnerProps(data)
-
-    const nonEmptyKeys = data.filter(item => item.key.trim() !== '')
-
-    const duplicateKeys = nonEmptyKeys.some((item, i) => i !== index && item.key === event.target.value)
-    data[index].hasDuplicateKey = duplicateKeys
 
     if (event.target.name === 'key') {
       const invalidKey = !keyRegex.test(event.target.value)
       data[index].invalid = invalidKey
     }
+
+    const nonEmptyKeys = data.filter(item => item.key.trim() !== '')
+    const grouped = groupBy(nonEmptyKeys, 'key')
+    const duplicateKeys = Object.keys(grouped).some(key => grouped[key].length > 1)
+
+    if (duplicateKeys) {
+      data[index].hasDuplicateKey = duplicateKeys
+    } else {
+      data.forEach(it => (it.hasDuplicateKey = false))
+    }
+
+    setInnerProps(data)
   }
 
   const addFields = () => {

--- a/web/app/ui/metalakes/CreateCatalogDialog.js
+++ b/web/app/ui/metalakes/CreateCatalogDialog.js
@@ -34,6 +34,7 @@ import * as yup from 'yup'
 import { useForm, Controller } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 
+import { groupBy } from 'lodash-es'
 import { genUpdates } from '@/lib/utils'
 import { providers } from '@/lib/utils/initial'
 import { nameRegex, keyRegex } from '@/lib/utils/regex'
@@ -106,18 +107,24 @@ const CreateCatalogDialog = props => {
   const handleFormChange = ({ index, event }) => {
     let data = [...innerProps]
     data[index][event.target.name] = event.target.value
-    setInnerProps(data)
-    setValue('propItems', data)
-
-    const nonEmptyKeys = data.filter(item => item.key.trim() !== '')
-
-    const duplicateKeys = nonEmptyKeys.some((item, i) => i !== index && item.key === event.target.value)
-    data[index].hasDuplicateKey = duplicateKeys
 
     if (event.target.name === 'key') {
       const invalidKey = !keyRegex.test(event.target.value)
       data[index].invalid = invalidKey
     }
+
+    const nonEmptyKeys = data.filter(item => item.key.trim() !== '')
+    const grouped = groupBy(nonEmptyKeys, 'key')
+    const duplicateKeys = Object.keys(grouped).some(key => grouped[key].length > 1)
+
+    if (duplicateKeys) {
+      data[index].hasDuplicateKey = duplicateKeys
+    } else {
+      data.forEach(it => (it.hasDuplicateKey = false))
+    }
+
+    setInnerProps(data)
+    setValue('propItems', data)
   }
 
   const addFields = () => {
@@ -486,6 +493,7 @@ const CreateCatalogDialog = props => {
                                     value={item.value}
                                     size='small'
                                     sx={{ width: 195 }}
+                                    disabled={item.disabled}
                                     onChange={event => handleFormChange({ index, event })}
                                   >
                                     {item.select.map(selectItem => (

--- a/web/lib/utils/regex.js
+++ b/web/lib/utils/regex.js
@@ -5,4 +5,4 @@
 
 export const nameRegex = /^[a-zA-Z_][a-zA-Z0-9_]*$/
 
-export const propKeyRegex = /^[a-zA-Z_][a-zA-Z0-9-_.]*$/
+export const keyRegex = /^[a-zA-Z_][a-zA-Z0-9-_.]*$/


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix duplicate key message and disable the Select component.

1. disabled the Select component
<img width="1036" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/ebdf7076-42ba-4660-b3fa-648d271dd2c7">

2. fix duplicate key message

Step1: input the key field
<img width="549" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/32bc25d6-58dc-46df-9716-be861591ffed">

Step2: input the value field
<img width="547" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/605e0b4a-9dd9-49e0-a494-33c016d694df">


### Why are the changes needed?

Fix: #1783 
Fix: #1794 
Fix: #1808 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
