### PR TITLE
[#1823] feat(ci): Add *.ipr file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,10 @@ replay_pid*
 **/build
 gen
 **/.DS_Store
-*.iml
+**/*.iml
 out/**
 *.iws
+*.ipr
 
 distribution
 server/src/main/resources/project.properties


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Add `*.ipr` to `.gitignore` file.

### Why are the changes needed?

We include [idea plugin](https://github.com/datastrato/gravitino/blob/dd2786a4ff7c84bcb067e1d8a67bdf052992a8d2/build.gradle.kts#L22) in Gradle, so users can run ./gradlew openIdea or ./gradlew idea to open IDEA editor. With the command, there is a new file gravitino.ipr. The file is not included in [.gitignore](https://github.com/datastrato/gravitino/blob/dd2786a4ff7c84bcb067e1d8a67bdf052992a8d2/.gitignore#L26-L34) or [exclusions](https://github.com/datastrato/gravitino/blob/dd2786a4ff7c84bcb067e1d8a67bdf052992a8d2/build.gradle.kts#L323-L343). If users run ./gradlew build -x test, they will get failed rat task.

Fix: https://github.com/datastrato/gravitino/issues/1823

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

Make sure the build doesn't get error when there is `gravitino.ipr` file.

```
./gradlew idea
./gradlew build -x test
```
