### PR TITLE
[#955] fix(test): change poll image pause timeout from 30s to 60s

### DIFF
--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -293,6 +293,9 @@ tasks.test {
       environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "datastrato/gravitino-ci-hive:0.1.8")
       environment("GRAVITINO_CI_TRINO_DOCKER_IMAGE", "datastrato/gravitino-ci-trino:0.1.3")
 
+      // Change poll image pause time from 30s to 60s
+      environment("TESTCONTAINERS_PULL_PAUSE_TIMEOUT", "60")
+
       val testMode = project.properties["testMode"] as? String ?: "embedded"
       systemProperty("gravitino.log.path", buildDir.path + "/integration-test.log")
       delete(buildDir.path + "/integration-test.log")


### PR DESCRIPTION
### What changes were proposed in this pull request?
 change poll image pause timeout from 30s to 60s

### Why are the changes needed?
There are 2 parameters control pull image:
1. PULL_RETRY_TIME_LIMIT,  2 mins, which isn't configable.
2. pull.pause.timeout, defaults 30s.

 if there are no progress for pulling image, it will check whether the total of  image pull time is beyond `PULL_RETRY_TIME_LIMIT`. In this pr we change pause timeout from 30s to 60s to adapt bad network.

Fix: #955 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
existing UT