### PR TITLE
[#1830] improvement(core,hive):  TableOperations support impersonation

### DIFF
--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveProxyPlugin.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveProxyPlugin.java
@@ -79,5 +79,6 @@ class HiveProxyPlugin implements ProxyPlugin {
   @Override
   public void bindCatalogOperation(CatalogOperations ops) {
     this.ops = ((HiveCatalogOperations) ops);
+    this.ops.setProxyPlugin(this);
   }
 }

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveTable.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveTable.java
@@ -378,6 +378,7 @@ public class HiveTable extends BaseTable {
       hiveTable.schemaName = schemaName;
       hiveTable.clientPool = clientPool;
       hiveTable.sd = sd;
+      hiveTable.proxyPlugin = proxyPlugin;
 
       // HMS put table comment in parameters
       if (comment != null) {

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
@@ -124,7 +124,7 @@ public class RelationalCatalog extends CatalogDTO implements TableCatalog, Suppo
             ErrorHandlers.tableErrorHandler());
     resp.validate();
 
-    return resp.getTable();
+    return RelationalTable.from(ident.namespace(), resp.getTable(), restClient);
   }
 
   /**
@@ -207,7 +207,7 @@ public class RelationalCatalog extends CatalogDTO implements TableCatalog, Suppo
             ErrorHandlers.tableErrorHandler());
     resp.validate();
 
-    return resp.getTable();
+    return RelationalTable.from(ident.namespace(), resp.getTable(), restClient);
   }
 
   /**

--- a/core/src/main/java/com/datastrato/gravitino/catalog/OperationsProxy.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/OperationsProxy.java
@@ -22,10 +22,13 @@ public class OperationsProxy<T> implements InvocationHandler {
   }
 
   public static <T> T createProxy(T ops, ProxyPlugin plugin) {
-    if (!(ops instanceof CatalogOperations)) {
-      throw new IllegalArgumentException("Method only supports the type of CatalogOperations");
+    if (!(ops instanceof CatalogOperations) && !(ops instanceof TableOperations)) {
+      throw new IllegalArgumentException(
+          "Method only supports the type of CatalogOperations or TableOperations");
     }
-    plugin.bindCatalogOperation((CatalogOperations) ops);
+    if (ops instanceof CatalogOperations) {
+      plugin.bindCatalogOperation((CatalogOperations) ops);
+    }
     return createProxyInternal(ops, plugin, ops.getClass().getInterfaces());
   }
 

--- a/core/src/main/java/com/datastrato/gravitino/catalog/rel/BaseTable.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/rel/BaseTable.java
@@ -4,6 +4,8 @@
  */
 package com.datastrato.gravitino.catalog.rel;
 
+import com.datastrato.gravitino.catalog.OperationsProxy;
+import com.datastrato.gravitino.catalog.ProxyPlugin;
 import com.datastrato.gravitino.catalog.TableOperations;
 import com.datastrato.gravitino.meta.AuditInfo;
 import com.datastrato.gravitino.rel.Column;
@@ -13,6 +15,7 @@ import com.datastrato.gravitino.rel.expressions.sorts.SortOrder;
 import com.datastrato.gravitino.rel.expressions.transforms.Transform;
 import com.datastrato.gravitino.rel.indexes.Index;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import lombok.ToString;
 
@@ -38,6 +41,8 @@ public abstract class BaseTable implements Table {
 
   @Nullable protected Index[] indexes;
 
+  protected Optional<ProxyPlugin> proxyPlugin;
+
   private volatile TableOperations ops;
 
   /**
@@ -56,7 +61,14 @@ public abstract class BaseTable implements Table {
     if (ops == null) {
       synchronized (this) {
         if (ops == null) {
-          ops = newOps();
+          TableOperations newOps = newOps();
+          ops =
+              proxyPlugin
+                  .map(
+                      proxyPlugin -> {
+                        return OperationsProxy.createProxy(newOps, proxyPlugin);
+                      })
+                  .orElse(newOps);
         }
       }
     }
@@ -148,6 +160,8 @@ public abstract class BaseTable implements Table {
 
     SELF withIndexes(Index[] indexes);
 
+    SELF withProxyPlugin(ProxyPlugin plugin);
+
     T build();
   }
 
@@ -169,6 +183,7 @@ public abstract class BaseTable implements Table {
 
     protected Distribution distribution;
     protected Index[] indexes;
+    protected Optional<ProxyPlugin> proxyPlugin = Optional.empty();
 
     /**
      * Sets the name of the table.
@@ -254,6 +269,11 @@ public abstract class BaseTable implements Table {
 
     public SELF withIndexes(Index[] indexes) {
       this.indexes = indexes;
+      return (SELF) this;
+    }
+
+    public SELF withProxyPlugin(ProxyPlugin proxyPlugin) {
+      this.proxyPlugin = Optional.ofNullable(proxyPlugin);
       return (SELF) this;
     }
 

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/hive/ProxyCatalogHiveIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/hive/ProxyCatalogHiveIT.java
@@ -21,12 +21,19 @@ import com.datastrato.gravitino.integration.test.util.AbstractIT;
 import com.datastrato.gravitino.integration.test.util.GravitinoITUtils;
 import com.datastrato.gravitino.rel.Column;
 import com.datastrato.gravitino.rel.Table;
+import com.datastrato.gravitino.rel.expressions.literals.Literal;
+import com.datastrato.gravitino.rel.expressions.literals.Literals;
+import com.datastrato.gravitino.rel.expressions.transforms.Transform;
+import com.datastrato.gravitino.rel.expressions.transforms.Transforms;
+import com.datastrato.gravitino.rel.partitions.Partition;
+import com.datastrato.gravitino.rel.partitions.Partitions;
 import com.datastrato.gravitino.rel.types.Types;
 import com.datastrato.gravitino.server.auth.OAuthConfig;
 import com.datastrato.gravitino.server.web.JettyServerConfig;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import java.lang.reflect.Field;
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
@@ -114,27 +121,20 @@ public class ProxyCatalogHiveIT extends AbstractIT {
     // create schema normally using user datastrato
     String schemaName = GravitinoITUtils.genRandomName(SCHEMA_PREFIX);
     String anotherSchemaName = GravitinoITUtils.genRandomName(SCHEMA_PREFIX);
+
     NameIdentifier ident = NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, schemaName);
     NameIdentifier anotherIdent = NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, anotherSchemaName);
-    Map<String, String> properties = Maps.newHashMap();
-    properties.put("key1", "val1");
-    properties.put("key2", "val2");
-    properties.put(
-        "location",
-        String.format(
-            "hdfs://%s:%d/user/hive/warehouse/%s.db",
-            containerSuite.getHiveContainer().getContainerIpAddress(),
-            HiveContainer.HDFS_DEFAULTFS_PORT,
-            schemaName.toLowerCase()));
-    String comment = "comment";
 
-    catalog.asSchemas().createSchema(ident, comment, properties);
+    String comment = "comment";
+    createSchema(schemaName, ident, comment);
+
     Database db = hiveClientPool.run(client -> client.getDatabase(schemaName));
     Assertions.assertEquals(EXPECT_USER, db.getOwnerName());
     Assertions.assertEquals(
         EXPECT_USER, hdfs.getFileStatus(new Path(db.getLocationUri())).getOwner());
 
     // create schema with exception using the system user
+    Map<String, String> properties = Maps.newHashMap();
     properties.put(
         "location",
         String.format(
@@ -156,23 +156,16 @@ public class ProxyCatalogHiveIT extends AbstractIT {
     String schemaName = GravitinoITUtils.genRandomName(SCHEMA_PREFIX);
     String tableName = GravitinoITUtils.genRandomName(TABLE_PREFIX);
     String anotherTableName = GravitinoITUtils.genRandomName(TABLE_PREFIX);
+
     NameIdentifier ident = NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, schemaName);
     NameIdentifier nameIdentifier =
         NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, schemaName, tableName);
     NameIdentifier anotherNameIdentifier =
         NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, schemaName, anotherTableName);
-    Map<String, String> properties = Maps.newHashMap();
-    properties.put("key1", "val1");
-    properties.put("key2", "val2");
-    properties.put(
-        "location",
-        String.format(
-            "hdfs://%s:%d/user/hive/warehouse/%s.db",
-            containerSuite.getHiveContainer().getContainerIpAddress(),
-            HiveContainer.HDFS_DEFAULTFS_PORT,
-            schemaName.toLowerCase()));
+
     String comment = "comment";
-    catalog.asSchemas().createSchema(ident, comment, properties);
+    createSchema(schemaName, ident, comment);
+
     Table createdTable =
         catalog
             .asTableCatalog()
@@ -204,6 +197,86 @@ public class ProxyCatalogHiveIT extends AbstractIT {
     Assertions.assertTrue(e.getMessage().contains("AccessControlException Permission denied"));
   }
 
+  private static void createSchema(String schemaName, NameIdentifier ident, String comment) {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("key1", "val1");
+    properties.put("key2", "val2");
+    properties.put(
+        "location",
+        String.format(
+            "hdfs://%s:%d/user/hive/warehouse/%s.db",
+            containerSuite.getHiveContainer().getContainerIpAddress(),
+            HiveContainer.HDFS_DEFAULTFS_PORT,
+            schemaName.toLowerCase()));
+    catalog.asSchemas().createSchema(ident, comment, properties);
+  }
+
+  @Test
+  public void testOperatePartition() throws Exception {
+
+    // create schema
+    String schemaName = GravitinoITUtils.genRandomName(SCHEMA_PREFIX);
+    String tableName = GravitinoITUtils.genRandomName(TABLE_PREFIX);
+
+    NameIdentifier ident = NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, schemaName);
+    NameIdentifier nameIdentifier =
+        NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, schemaName, tableName);
+
+    String comment = "comment";
+    createSchema(schemaName, ident, comment);
+
+    // create a partitioned table
+    Column[] columns = createColumns();
+
+    Table table =
+        catalog
+            .asTableCatalog()
+            .createTable(
+                nameIdentifier,
+                columns,
+                "comment",
+                createProperties(),
+                new Transform[] {
+                  Transforms.identity(columns[1].name()), Transforms.identity(columns[2].name())
+                });
+
+    // add partition "col2=2023-01-02/col3=gravitino_it_test2" by user datastrato
+    String[] field1 = new String[] {"col2"};
+    String[] field2 = new String[] {"col3"};
+    Literal<?> primaryPartition = Literals.dateLiteral(LocalDate.parse("2023-01-02"));
+    Literal<?> secondaryPartition = Literals.stringLiteral("gravitino_it_test2");
+    Partition identity =
+        Partitions.identity(
+            new String[][] {field1, field2},
+            new Literal<?>[] {primaryPartition, secondaryPartition});
+
+    Partition partition = table.supportPartitions().addPartition(identity);
+
+    org.apache.hadoop.hive.metastore.api.Partition partitionGot =
+        hiveClientPool.run(client -> client.getPartition(schemaName, tableName, partition.name()));
+
+    Assertions.assertEquals(
+        EXPECT_USER, hdfs.getFileStatus(new Path(partitionGot.getSd().getLocation())).getOwner());
+
+    Literal<?> anotherSecondaryPartition = Literals.stringLiteral("gravitino_it_test3");
+    Partition anotherIdentity =
+        Partitions.identity(
+            new String[][] {field1, field2},
+            new Literal<?>[] {primaryPartition, anotherSecondaryPartition});
+
+    // create partition with exception with system user
+    Exception e =
+        Assertions.assertThrows(
+            RuntimeException.class,
+            () ->
+                anotherCatalog
+                    .asTableCatalog()
+                    .loadTable(nameIdentifier)
+                    .supportPartitions()
+                    .addPartition(anotherIdentity));
+    Assertions.assertTrue(e.getMessage().contains("AccessControlException Permission denied"));
+  }
+
   private Column[] createColumns() {
     Column col1 = Column.of("col1", Types.ByteType.get(), "col_1_comment");
     Column col2 = Column.of("col2", Types.DateType.get(), "col_2_comment");
@@ -221,6 +294,13 @@ public class ProxyCatalogHiveIT extends AbstractIT {
     Assertions.assertEquals(createdMetalake, loadMetalake);
 
     metalake = loadMetalake;
+  }
+
+  private Map<String, String> createProperties() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("key1", "val1");
+    properties.put("key2", "val2");
+    return properties;
   }
 
   private static void createCatalog() {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Now, we only support catalog operations to impersonate. We should support it in the TableOperation.

### Why are the changes needed?
Better user experience.

Fix: #1830 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Add UT.