### PR TITLE
[#1841] fix(client):  Fix Kerberos client to retrieve the credential form TGT cache.

### DIFF
--- a/common/src/main/java/com/datastrato/gravitino/auth/KerberosUtils.java
+++ b/common/src/main/java/com/datastrato/gravitino/auth/KerberosUtils.java
@@ -97,10 +97,10 @@ public class KerberosUtils {
       if (keyTabFile != null) {
         options.put("useKeyTab", "true");
         options.put("keyTab", keyTabFile);
+        options.put("storeKey", "true");
       }
 
       options.put("principal", principal);
-      options.put("storeKey", "true");
       options.put("doNotPrompt", "true");
       options.put("useTicketCache", "true");
       options.put("renewTGT", "true");


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix Kerberos client retrieve the credential form TGT cache.

### Why are the changes needed?

Fix: #1841

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By hand.