### PR TITLE
[#1843] fix(postgresql-doc): PostgreSQL does not support the Byte type of Gravetino and needs to be removed from the document

### DIFF
--- a/docs/jdbc-postgresql-catalog.md
+++ b/docs/jdbc-postgresql-catalog.md
@@ -84,7 +84,6 @@ Please refer to [Manage Metadata Using Gravitino](./manage-metadata-using-gravit
 | Gravitino Type | PostgreSQL Type               |
 |----------------|-------------------------------|
 | `Boolean`      | `boolean`                     |
-| `Byte`         | `Tinyint`                     |
 | `Short`        | `Smallint`                    |
 | `Integer`      | `Integer`                     |
 | `Long`         | `Bigint`                      |


### PR DESCRIPTION
### What changes were proposed in this pull request?
PostgreSQL does not support the Byte type of Gravetino and needs to be removed from the document

### Why are the changes needed?
Fix: #1843 

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
NO
