### PR TITLE
[#1357] improvement(common): add `toSequence` support for configuration builder

### DIFF
--- a/common/src/main/java/com/datastrato/gravitino/config/ConfigEntry.java
+++ b/common/src/main/java/com/datastrato/gravitino/config/ConfigEntry.java
@@ -262,6 +262,7 @@ public class ConfigEntry<T> {
         throw new NoSuchElementException("No configuration found for key " + key);
       }
     }
+
     T convertedValue = valueConverter.apply(value);
     if (validator != null) {
       validator.accept(convertedValue);

--- a/common/src/main/java/com/datastrato/gravitino/config/ConfigEntry.java
+++ b/common/src/main/java/com/datastrato/gravitino/config/ConfigEntry.java
@@ -27,7 +27,6 @@ public class ConfigEntry<T> {
   @Getter private List<String> alternatives;
 
   @Getter private T defaultValue;
-  @Getter private List<T> defaultValueList;
 
   private Function<String, T> valueConverter;
 
@@ -98,15 +97,6 @@ public class ConfigEntry<T> {
    */
   void setDefaultValue(T t) {
     this.defaultValue = t;
-  }
-
-  /**
-   * Sets the default value list for this configuration.
-   *
-   * @param tl The default value list to be used when no value is provided.
-   */
-  void setDefaultValueList(List<T> tl) {
-    this.defaultValueList = tl;
   }
 
   /**
@@ -198,23 +188,6 @@ public class ConfigEntry<T> {
     conf.setValueConverter(valueConverter);
     conf.setStringConverter(stringConverter);
     conf.setDefaultValue(t);
-    conf.setValidator(validator);
-
-    return conf;
-  }
-
-  /**
-   * Creates a new ConfigEntry instance based on this configuration entry with a default value list.
-   *
-   * @param tl The default value list to be used when no value is provided.
-   * @return A new ConfigEntry instance with the specified default value list.
-   */
-  public ConfigEntry<T> createWithDefault(List<T> tl) {
-    ConfigEntry<T> conf =
-        new ConfigEntry<>(key, version, doc, alternatives, isPublic, isDeprecated);
-    conf.setValueConverter(valueConverter);
-    conf.setStringConverter(stringConverter);
-    conf.setDefaultValueList(tl);
     conf.setValidator(validator);
 
     return conf;

--- a/common/src/main/java/com/datastrato/gravitino/config/ConfigEntry.java
+++ b/common/src/main/java/com/datastrato/gravitino/config/ConfigEntry.java
@@ -27,6 +27,7 @@ public class ConfigEntry<T> {
   @Getter private List<String> alternatives;
 
   @Getter private T defaultValue;
+  @Getter private List<T> defaultValueList;
 
   private Function<String, T> valueConverter;
 
@@ -97,6 +98,15 @@ public class ConfigEntry<T> {
    */
   void setDefaultValue(T t) {
     this.defaultValue = t;
+  }
+
+  /**
+   * Sets the default value list for this configuration.
+   *
+   * @param tl The default value list to be used when no value is provided.
+   */
+  void setDefaultValueList(List<T> tl) {
+    this.defaultValueList = tl;
   }
 
   /**
@@ -188,6 +198,23 @@ public class ConfigEntry<T> {
     conf.setValueConverter(valueConverter);
     conf.setStringConverter(stringConverter);
     conf.setDefaultValue(t);
+    conf.setValidator(validator);
+
+    return conf;
+  }
+
+  /**
+   * Creates a new ConfigEntry instance based on this configuration entry with a default value list.
+   *
+   * @param tl The default value list to be used when no value is provided.
+   * @return A new ConfigEntry instance with the specified default value list.
+   */
+  public ConfigEntry<T> createWithDefault(List<T> tl) {
+    ConfigEntry<T> conf =
+        new ConfigEntry<>(key, version, doc, alternatives, isPublic, isDeprecated);
+    conf.setValueConverter(valueConverter);
+    conf.setStringConverter(stringConverter);
+    conf.setDefaultValueList(tl);
     conf.setValidator(validator);
 
     return conf;

--- a/common/src/main/java/com/datastrato/gravitino/config/ConfigEntry.java
+++ b/common/src/main/java/com/datastrato/gravitino/config/ConfigEntry.java
@@ -4,12 +4,14 @@
  */
 package com.datastrato.gravitino.config;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.Getter;
 import org.slf4j.Logger;
@@ -135,6 +137,46 @@ public class ConfigEntry<T> {
   }
 
   /**
+   * Split the string to a list, then map each string element to its converted form.
+   *
+   * @param str The string form of the value list from the conf entry.
+   * @param converter The orignal ConfigEntry valueConverter.
+   * @return The list of converted type.
+   */
+  public List<T> strToSeq(String str, Function<String, T> converter) {
+    List<String> strList = Arrays.asList(str.split(","));
+    List<T> valList = strList.stream().map(converter).collect(Collectors.toList());
+
+    return valList;
+  }
+
+  /**
+   * Reduce the values then join them as a string.
+   *
+   * @param seq The sequence of the value list from the conf entry.
+   * @param converter The orignal ConfigEntry stringConverter.
+   * @return The converted string.
+   */
+  public String seqToStr(List<T> seq, Function<T, String> converter) {
+    List<String> valList = seq.stream().map(converter).collect(Collectors.toList());
+    String str = String.join(",", valList);
+    return str;
+  }
+
+  /**
+   * Converts the configuration value to value list.
+   *
+   * @return The ConfigEntry instance.
+   */
+  public ConfigEntry<List<T>> toSequence() {
+    ConfigEntry<List<T>> conf =
+        new ConfigEntry<>(key, version, doc, alternatives, isPublic, isDeprecated);
+    conf.setValueConverter((String str) -> strToSeq(str, valueConverter));
+    conf.setStringConverter((List<T> val) -> seqToStr(val, stringConverter));
+    return conf;
+  }
+
+  /**
    * Creates a new ConfigEntry instance based on this configuration entry with a default value.
    *
    * @param t The default value to be used when no value is provided.
@@ -220,7 +262,6 @@ public class ConfigEntry<T> {
         throw new NoSuchElementException("No configuration found for key " + key);
       }
     }
-
     T convertedValue = valueConverter.apply(value);
     if (validator != null) {
       validator.accept(convertedValue);

--- a/common/src/test/java/com/datastrato/gravitino/config/TestConfigEntry.java
+++ b/common/src/test/java/com/datastrato/gravitino/config/TestConfigEntry.java
@@ -5,7 +5,6 @@
 package com.datastrato.gravitino.config;
 
 import com.google.common.collect.Lists;
-import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
@@ -25,102 +24,11 @@ public class TestConfigEntry {
     configMap.put("gravitino.test.string", "test-string");
     configMap.put("gravitino.test.string.alt1", "test-string1");
     configMap.put("gravitino.test.string.alt2", "test-string2");
-    configMap.put("gravitino.test.stringList", "test-string1,test-string2,test-string3");
-    configMap.put("gravitino.test.integerList", "1,2,3");
-    configMap.put("gravitino.test.integerList.invalid", "1,xxx,3");
   }
 
   @AfterEach
   public void clearConfigMap() {
     configMap.clear();
-  }
-
-  @Test
-  public void testStrConfValueList() {
-    ConfigEntry<List<String>> testConf =
-        new ConfigBuilder("gravitino.test.stringList")
-            .doc("test")
-            .internal()
-            .stringConf()
-            .toSequence()
-            .checkValue(
-                valueList ->
-                    (!Objects.equals(valueList.get(0), "test-string0")
-                        && !Objects.equals(valueList.get(1), "test-string0")
-                        && !Objects.equals(valueList.get(2), "test-string0")),
-                "error")
-            .checkValue(
-                valueList ->
-                    (Objects.equals(valueList.get(0), "test-string1")
-                        && Objects.equals(valueList.get(1), "test-string2")
-                        && Objects.equals(valueList.get(2), "test-string3")),
-                "error")
-            .create();
-
-    List<String> valueList = testConf.readFrom(configMap);
-    Assertions.assertEquals("test-string1", valueList.get(0));
-    Assertions.assertEquals("test-string2", valueList.get(1));
-    Assertions.assertEquals("test-string3", valueList.get(2));
-
-    valueList.set(0, "test-string4");
-    valueList.set(1, "test-string5");
-    valueList.set(2, "test-string6");
-    testConf.writeTo(configMap, valueList);
-    Assertions.assertEquals(
-        "test-string4,test-string5,test-string6", configMap.get("gravitino.test.stringList"));
-  }
-
-  @Test
-  public void testIntConfValueList() {
-    ConfigEntry<List<Integer>> testConf =
-        new ConfigBuilder("gravitino.test.integerList")
-            .doc("test")
-            .internal()
-            .intConf()
-            .toSequence()
-            .checkValue(
-                valueList ->
-                    (!Objects.equals(valueList.get(0), 4)
-                        && !Objects.equals(valueList.get(1), 5)
-                        && !Objects.equals(valueList.get(2), 6)),
-                "error")
-            .checkValue(
-                valueList ->
-                    (Objects.equals(valueList.get(0), 1)
-                        && Objects.equals(valueList.get(1), 2)
-                        && Objects.equals(valueList.get(2), 3)),
-                "error")
-            .create();
-
-    List<Integer> valueList = testConf.readFrom(configMap);
-    Assertions.assertEquals(1, valueList.get(0));
-    Assertions.assertEquals(2, valueList.get(1));
-    Assertions.assertEquals(3, valueList.get(2));
-
-    valueList.set(0, 4);
-    valueList.set(1, 5);
-    valueList.set(2, 6);
-    testConf.writeTo(configMap, valueList);
-    Assertions.assertEquals("4,5,6", configMap.get("gravitino.test.integerList"));
-  }
-
-  @Test
-  public void testIntConfInvalidValueList() {
-    ConfigEntry<List<Integer>> testConf =
-        new ConfigBuilder("gravitino.test.integerList.invalid")
-            .doc("test")
-            .internal()
-            .intConf()
-            .toSequence()
-            .create();
-    Assertions.assertThrows(
-        NumberFormatException.class,
-        () -> {
-          List<Integer> valueList = testConf.readFrom(configMap);
-          Assertions.assertEquals(1, valueList.get(0));
-          Assertions.assertEquals("xxx", valueList.get(1));
-          Assertions.assertEquals(3, valueList.get(2));
-        });
   }
 
   @Test

--- a/common/src/test/java/com/datastrato/gravitino/config/TestConfigEntry.java
+++ b/common/src/test/java/com/datastrato/gravitino/config/TestConfigEntry.java
@@ -5,6 +5,7 @@
 package com.datastrato.gravitino.config;
 
 import com.google.common.collect.Lists;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
@@ -24,11 +25,58 @@ public class TestConfigEntry {
     configMap.put("gravitino.test.string", "test-string");
     configMap.put("gravitino.test.string.alt1", "test-string1");
     configMap.put("gravitino.test.string.alt2", "test-string2");
+    configMap.put("gravitino.test.stringList", "test-string1,test-string2,test-string3");
+    configMap.put("gravitino.test.integerList", "1,2,3");
   }
 
   @AfterEach
   public void clearConfigMap() {
     configMap.clear();
+  }
+
+  @Test
+  public void testStrConfValueList() {
+    ConfigEntry<List<String>> testConf =
+        new ConfigBuilder("gravitino.test.stringList")
+            .doc("test")
+            .internal()
+            .stringConf()
+            .toSequence()
+            .create();
+
+    List<String> valueList = testConf.readFrom(configMap);
+    Assertions.assertEquals("test-string1", valueList.get(0));
+    Assertions.assertEquals("test-string2", valueList.get(1));
+    Assertions.assertEquals("test-string3", valueList.get(2));
+
+    valueList.set(0, "test-string4");
+    valueList.set(1, "test-string5");
+    valueList.set(2, "test-string6");
+    testConf.writeTo(configMap, valueList);
+    Assertions.assertEquals(
+        "test-string4,test-string5,test-string6", configMap.get("gravitino.test.stringList"));
+  }
+
+  @Test
+  public void testIntConfValueList() {
+    ConfigEntry<List<Integer>> testConf =
+        new ConfigBuilder("gravitino.test.integerList")
+            .doc("test")
+            .internal()
+            .intConf()
+            .toSequence()
+            .create();
+
+    List<Integer> valueList = testConf.readFrom(configMap);
+    Assertions.assertEquals(1, valueList.get(0));
+    Assertions.assertEquals(2, valueList.get(1));
+    Assertions.assertEquals(3, valueList.get(2));
+
+    valueList.set(0, 4);
+    valueList.set(1, 5);
+    valueList.set(2, 6);
+    testConf.writeTo(configMap, valueList);
+    Assertions.assertEquals("4,5,6", configMap.get("gravitino.test.integerList"));
   }
 
   @Test

--- a/common/src/test/java/com/datastrato/gravitino/config/TestConfigEntryList.java
+++ b/common/src/test/java/com/datastrato/gravitino/config/TestConfigEntryList.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2023 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.config;
+
+import com.google.common.collect.Lists;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TestConfigEntryList {
+
+  private final ConcurrentMap<String, String> configMap = new ConcurrentHashMap<>();
+
+  @BeforeEach
+  public void initializeConfigMap() {
+    configMap.put("gravitino.test.string.list", "test-string-1,test-string-2,test-string-3");
+  }
+
+  @AfterEach
+  public void clearConfigMap() {
+    configMap.clear();
+  }
+
+  @Test
+  public void testConfWithDefaultValue() {
+    ConfigEntry<List<String>> testConf1 =
+        new ConfigBuilder("gravitino.test.list")
+            .doc("test")
+            .internal()
+            .stringConf()
+            .checkValue(value -> value == "test-string-1,test-string-2,test-string-3", "error")
+            .toSequence()
+            .createWithDefault(Lists.newArrayList("test-string-0"));
+
+    ConfigEntry<List<String>> testConf2 =
+        new ConfigBuilder("gravitino.test.string.list")
+            .doc("test")
+            .internal()
+            .stringConf()
+            .toSequence()
+            .create();
+    List<String> valueList2 = testConf2.readFrom(configMap);
+    Assertions.assertEquals("test-string-1", valueList2.get(0));
+    Assertions.assertEquals("test-string-2", valueList2.get(1));
+    Assertions.assertEquals("test-string-3", valueList2.get(2));
+
+    ConfigEntry<List<Integer>> testConf3 =
+        new ConfigBuilder("gravitino.test.int.list")
+            .doc("test")
+            .version("1.0")
+            .intConf()
+            .toSequence()
+            .createWithDefault(Lists.newArrayList(10));
+    List<Integer> valueList3 = testConf3.readFrom(configMap);
+    Assertions.assertEquals(10, valueList3.get(0));
+
+    ConfigEntry<List<Boolean>> testConf4 =
+        new ConfigBuilder("gravitino.test.boolean.list")
+            .booleanConf()
+            .toSequence()
+            .createWithDefault(Lists.newArrayList(true, false));
+    List<Boolean> valueList4 = testConf4.readFrom(configMap);
+    Assertions.assertTrue(valueList4.get(0));
+    Assertions.assertFalse(valueList4.get(1));
+  }
+
+  @Test
+  public void testConfWithoutDefaultValue() {
+    ConfigEntry<List<String>> testConf =
+        new ConfigBuilder("gravitino.test.string.list")
+            .doc("test")
+            .internal()
+            .stringConf()
+            .toSequence();
+    List<String> valueList = testConf.readFrom(configMap);
+    Assertions.assertEquals("test-string-1", valueList.get(0));
+    Assertions.assertEquals("test-string-2", valueList.get(1));
+    Assertions.assertEquals("test-string-3", valueList.get(2));
+
+    ConfigEntry<List<Integer>> testConf1 =
+        new ConfigBuilder("gravitino.test.int.no-exist").intConf().toSequence();
+    Throwable exception =
+        Assertions.assertThrows(NoSuchElementException.class, () -> testConf1.readFrom(configMap));
+    Assertions.assertEquals(
+        "No configuration found for key gravitino.test.int.no-exist", exception.getMessage());
+  }
+
+  @Test
+  public void testSetConf() {
+    ConfigEntry<List<Integer>> testConf =
+        new ConfigBuilder("gravitino.test.int.list")
+            .intConf()
+            .toSequence()
+            .createWithDefault(Lists.newArrayList(1));
+
+    testConf.writeTo(configMap, Lists.newArrayList(10));
+    Assertions.assertEquals("10", configMap.get("gravitino.test.int.list"));
+
+    ConfigEntry<Optional<List<Integer>>> testConf1 =
+        new ConfigBuilder("gravitino.test.int1.list").intConf().toSequence().createWithOptional();
+
+    testConf1.writeTo(configMap, Optional.of(Lists.newArrayList(11)));
+    Assertions.assertEquals("11", configMap.get("gravitino.test.int1.list"));
+
+    testConf1.writeTo(configMap, Optional.empty());
+    Assertions.assertEquals("11", configMap.get("gravitino.test.int1.list"));
+  }
+
+  @Test
+  public void testCheckValue() {
+    ConfigEntry<List<Integer>> testConfDefault =
+        new ConfigBuilder("gravitino.test.default")
+            .intConf()
+            .toSequence()
+            .checkValue(valueList -> valueList.stream().allMatch(element -> element > 0), "error")
+            .createWithDefault(Lists.newArrayList(1, 2));
+    testConfDefault.writeTo(configMap, Lists.newArrayList(-10, 2));
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> testConfDefault.readFrom(configMap));
+    ConfigEntry<List<String>> testConfNoDefault =
+        new ConfigBuilder("gravitino.test.no.default")
+            .stringConf()
+            .toSequence()
+            .checkValue(Objects::nonNull, "error")
+            .create();
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `toSequence()` support while dealing with a list of values in one conf entry.

### Why are the changes needed?

Fix #1357 

Just like Spark [does](https://github.com/apache/spark/blob/e8dfcd3081abe16b2115bb2944a2b1cb547eca8e/core/src/main/scala/org/apache/spark/internal/config/ConfigBuilder.scala#L126) and can be indeed useful for Gravitino.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Run `./gradlew test -PskipITs` should pass all.

