### PR TITLE
[#1817] improvement(all): Remove warning informations when building with JDK17 

### DIFF
--- a/common/src/main/java/com/datastrato/gravitino/Config.java
+++ b/common/src/main/java/com/datastrato/gravitino/Config.java
@@ -132,6 +132,11 @@ public abstract class Config {
     return MapUtils.getPrefixMap(configMap, prefix);
   }
 
+  /**
+   * Retrieves a map containing all configuration entries.
+   *
+   * @return An unmodifiable map containing all configuration entries.
+   */
   public Map<String, String> getAllConfig() {
     return MapUtils.unmodifiableMap(configMap);
   }

--- a/common/src/main/java/com/datastrato/gravitino/auth/AuthConstants.java
+++ b/common/src/main/java/com/datastrato/gravitino/auth/AuthConstants.java
@@ -5,20 +5,34 @@
 
 package com.datastrato.gravitino.auth;
 
+/** Constants used for authentication. */
 public interface AuthConstants {
+
+  /** The HTTP header used to pass the authentication token. */
   String HTTP_HEADER_AUTHORIZATION = "Authorization";
 
+  /** The name of BEARER header used to pass the authentication token. */
   String AUTHORIZATION_BEARER_HEADER = "Bearer ";
 
+  /** The name of BASIC header used to pass the authentication token. */
   String AUTHORIZATION_BASIC_HEADER = "Basic ";
 
+  /** The name of NEGOTIATE. */
   String NEGOTIATE = "Negotiate";
+
+  /** The value of NEGOTIATE header used to pass the authentication token. */
   String AUTHORIZATION_NEGOTIATE_HEADER = NEGOTIATE + " ";
 
+  /** The HTTP header used to pass the authentication token. */
   String HTTP_CHALLENGE_HEADER = "WWW-Authenticate";
 
+  /** The default username used for anonymous access. */
   String ANONYMOUS_USER = "anonymous";
 
-  // Refer to the style of `AuthenticationFilter#AuthenticatedRoleAttributeName` of Apache Pulsar
+  /**
+   * The default name of the attribute that stores the authenticated principal in the request.
+   *
+   * <p>Refer to the style of `AuthenticationFilter#AuthenticatedRoleAttributeName` of Apache Pulsar
+   */
   String AUTHENTICATED_PRINCIPAL_ATTRIBUTE_NAME = AuthConstants.class.getName() + "-principal";
 }

--- a/common/src/main/java/com/datastrato/gravitino/auth/AuthenticatorType.java
+++ b/common/src/main/java/com/datastrato/gravitino/auth/AuthenticatorType.java
@@ -5,9 +5,17 @@
 
 package com.datastrato.gravitino.auth;
 
+/** The type of authenticator for http/https request. */
 public enum AuthenticatorType {
+  /** No authentication. */
   NONE,
+
+  /** Simple authentication. */
   SIMPLE,
+
+  /** Authentication that uses OAuth. */
   OAUTH,
+
+  /** Authentication that uses Kerberos. */
   KERBEROS
 }

--- a/common/src/main/java/com/datastrato/gravitino/config/ConfigBuilder.java
+++ b/common/src/main/java/com/datastrato/gravitino/config/ConfigBuilder.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
+/** Builder class for creating configuration entries. */
 public class ConfigBuilder {
 
   private String key;

--- a/common/src/main/java/com/datastrato/gravitino/config/ConfigConstants.java
+++ b/common/src/main/java/com/datastrato/gravitino/config/ConfigConstants.java
@@ -5,10 +5,17 @@
 
 package com.datastrato.gravitino.config;
 
+/** Constants used for configuration. */
 public interface ConfigConstants {
+
+  /** The value of messages used to indicate that the configuration is not set. */
   String NOT_BLANK_ERROR_MSG = "The value can't be blank";
 
+  /** The value of messages used to indicate that the configuration should be a positive number. */
   String POSITIVE_NUMBER_ERROR_MSG = "The value must be a positive number";
 
+  /**
+   * The value of messages used to indicate that the configuration should be a non-negative number.
+   */
   String NON_NEGATIVE_NUMBER_ERROR_MSG = "The value must be a non-negative number";
 }

--- a/common/src/main/java/com/datastrato/gravitino/dto/AuditDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/AuditDTO.java
@@ -72,11 +72,20 @@ public class AuditDTO implements Audit {
    * @param <S> The type of the builder instance.
    */
   public static class Builder<S extends Builder> {
+
+    /** The creator of the audit. */
     protected String creator;
+
+    /** The create time for the audit. */
     protected Instant createTime;
+
+    /** The last modifier of the audit. */
     protected String lastModifier;
+
+    /** The last modified time for the audit. */
     protected Instant lastModifiedTime;
 
+    /** * Default constructor for the builder. */
     public Builder() {}
 
     /**

--- a/common/src/main/java/com/datastrato/gravitino/dto/CatalogDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/CatalogDTO.java
@@ -39,8 +39,19 @@ public class CatalogDTO implements Catalog {
   @JsonProperty("audit")
   private AuditDTO audit;
 
+  /** Default constructor for Jackson. */
   protected CatalogDTO() {}
 
+  /**
+   * Constructor for the catalog.
+   *
+   * @param name The name of the catalog.
+   * @param type The type of the catalog.
+   * @param provider The provider of the catalog.
+   * @param comment The comment of the catalog.
+   * @param properties The properties of the catalog.
+   * @param audit The audit information of the catalog.
+   */
   protected CatalogDTO(
       String name,
       Type type,
@@ -56,31 +67,61 @@ public class CatalogDTO implements Catalog {
     this.audit = audit;
   }
 
+  /**
+   * Get the name of the catalog.
+   *
+   * @return The name of the catalog.
+   */
   @Override
   public String name() {
     return name;
   }
 
+  /**
+   * Get the type of the catalog.
+   *
+   * @return The type of the catalog.
+   */
   @Override
   public Type type() {
     return type;
   }
 
+  /**
+   * Get the provider of the catalog.
+   *
+   * @return The provider of the catalog.
+   */
   @Override
   public String provider() {
     return provider;
   }
 
+  /**
+   * Get the comment of the catalog.
+   *
+   * @return The comment of the catalog.
+   */
   @Override
   public String comment() {
     return comment;
   }
 
+  /**
+   * Get the properties of the catalog.
+   *
+   * @return The properties of the catalog.
+   */
   @Override
   public Map<String, String> properties() {
     return properties;
   }
 
+  /**
+   * Get the audit information of the catalog.
+   *
+   * @return The audit information of the catalog.
+   */
   @Override
   public Audit auditInfo() {
     return audit;
@@ -92,11 +133,23 @@ public class CatalogDTO implements Catalog {
    * @param <S> The type of the builder instance.
    */
   public static class Builder<S extends Builder> {
+
+    /** The name of the catalog. */
     protected String name;
+
+    /** The type of the catalog. */
     protected Type type;
+
+    /** The provider of the catalog. */
     protected String provider;
+
+    /** The comment of the catalog. */
     protected String comment;
+
+    /** The properties of the catalog. */
     protected Map<String, String> properties;
+
+    /** The audit information of the catalog. */
     protected AuditDTO audit;
 
     public Builder() {}

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/ColumnDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/ColumnDTO.java
@@ -121,11 +121,22 @@ public class ColumnDTO implements Column {
    */
   public static class Builder<S extends Builder> {
 
+    /** The name of the column. */
     protected String name;
+
+    /** The data type of the column. */
     protected Type dataType;
+
+    /** The comment associated with the column. */
     protected String comment;
+
+    /** * Whether the column value can be null. */
     protected boolean nullable = true;
+
+    /** Whether the column is an auto-increment column. */
     protected boolean autoIncrement = false;
+
+    /** The default value of the column. */
     protected Expression defaultValue;
 
     public Builder() {}

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/DistributionDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/DistributionDTO.java
@@ -17,10 +17,12 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Preconditions;
 import java.util.Arrays;
 
+/** Data transfer object representing distribution information. */
 @JsonSerialize(using = JsonUtils.DistributionSerializer.class)
 @JsonDeserialize(using = JsonUtils.DistributionDeserializer.class)
 public class DistributionDTO implements Distribution {
 
+  /** A DistributionDTO instance that represents no distribution. */
   public static final DistributionDTO NONE =
       builder().withStrategy(Strategy.NONE).withNumber(0).withArgs(EMPTY_ARGS).build();
 
@@ -65,6 +67,7 @@ public class DistributionDTO implements Distribution {
     Arrays.stream(args).forEach(expression -> expression.validate(columns));
   }
 
+  /** Builder for {@link DistributionDTO}. */
   public static class Builder {
     private FunctionArg[] args;
     private int number = 0;

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/BucketPartitioningDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/BucketPartitioningDTO.java
@@ -12,9 +12,17 @@ import com.datastrato.gravitino.rel.expressions.Expression;
 import java.util.Arrays;
 import lombok.EqualsAndHashCode;
 
+/** Data transfer object representing bucket partitioning. */
 @EqualsAndHashCode
 public final class BucketPartitioningDTO implements Partitioning {
 
+  /**
+   * Creates a new instance of {@link BucketPartitioningDTO}.
+   *
+   * @param numBuckets The number of buckets.
+   * @param fieldNames The field names.
+   * @return The new instance.
+   */
   public static BucketPartitioningDTO of(int numBuckets, String[]... fieldNames) {
     return new BucketPartitioningDTO(numBuckets, fieldNames);
   }
@@ -27,10 +35,20 @@ public final class BucketPartitioningDTO implements Partitioning {
     this.fieldNames = fieldNames;
   }
 
+  /**
+   * Returns the number of buckets.
+   *
+   * @return The number of buckets.
+   */
   public int numBuckets() {
     return numBuckets;
   }
 
+  /**
+   * Returns the field names.
+   *
+   * @return The field names.
+   */
   public String[][] fieldNames() {
     return fieldNames;
   }

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/DayPartitioningDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/DayPartitioningDTO.java
@@ -8,9 +8,16 @@ import com.google.common.base.Preconditions;
 import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.ArrayUtils;
 
+/** Data transfer object representing day partitioning. */
 @EqualsAndHashCode(callSuper = true)
 public final class DayPartitioningDTO extends Partitioning.SingleFieldPartitioning {
 
+  /**
+   * Creates a new instance of {@link DayPartitioningDTO}.
+   *
+   * @param fieldName The field name.
+   * @return The new instance.
+   */
   public static DayPartitioningDTO of(String... fieldName) {
     return new DayPartitioningDTO(fieldName);
   }

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/Partitioning.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/Partitioning.java
@@ -22,9 +22,19 @@ public interface Partitioning extends Transform {
 
   Partitioning[] EMPTY_PARTITIONING = new Partitioning[0];
 
+  /**
+   * Returns the name of the partitioning strategy.
+   *
+   * @return The name of the partitioning strategy.
+   */
   Strategy strategy();
 
-  // columns of table
+  /**
+   * Validates the partitioning columns.
+   *
+   * @param columns The columns to be validated.
+   * @throws IllegalArgumentException If the columns are invalid, this exception is thrown.
+   */
   void validate(ColumnDTO[] columns) throws IllegalArgumentException;
 
   enum Strategy {

--- a/common/src/main/java/com/datastrato/gravitino/dto/requests/AddPartitionsRequest.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/requests/AddPartitionsRequest.java
@@ -14,6 +14,7 @@ import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.jackson.Jacksonized;
 
+/** Request to add partitions to a table. */
 @Getter
 @EqualsAndHashCode
 @ToString
@@ -24,10 +25,16 @@ public class AddPartitionsRequest implements RESTRequest {
   @JsonProperty("partitions")
   private final PartitionDTO[] partitions;
 
+  /** Default constructor for Jackson. */
   public AddPartitionsRequest() {
     this(null);
   }
 
+  /**
+   * Constructor for the request.
+   *
+   * @param partitions The partitions to add.
+   */
   public AddPartitionsRequest(PartitionDTO[] partitions) {
     this.partitions = partitions;
   }

--- a/common/src/main/java/com/datastrato/gravitino/dto/requests/CatalogUpdateRequest.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/requests/CatalogUpdateRequest.java
@@ -40,6 +40,7 @@ public interface CatalogUpdateRequest extends RESTRequest {
    */
   CatalogChange catalogChange();
 
+  /** Request to rename a catalog. */
   @EqualsAndHashCode
   @ToString
   class RenameCatalogRequest implements CatalogUpdateRequest {
@@ -79,6 +80,7 @@ public interface CatalogUpdateRequest extends RESTRequest {
     }
   }
 
+  /** Request to update the comment of a catalog. */
   @EqualsAndHashCode
   @ToString
   class UpdateCatalogCommentRequest implements CatalogUpdateRequest {
@@ -119,6 +121,7 @@ public interface CatalogUpdateRequest extends RESTRequest {
     }
   }
 
+  /** Request to set a property on a catalog. */
   @EqualsAndHashCode
   @ToString
   class SetCatalogPropertyRequest implements CatalogUpdateRequest {
@@ -166,6 +169,7 @@ public interface CatalogUpdateRequest extends RESTRequest {
     }
   }
 
+  /** Request to remove a property from a catalog. */
   @EqualsAndHashCode
   @ToString
   class RemoveCatalogPropertyRequest implements CatalogUpdateRequest {


### PR DESCRIPTION

### What changes were proposed in this pull request?

Add Java docs for module `client`, `api` and `common`.

### Why are the changes needed?

It's necessary for the user API. 

Fix: #1817 

### Does this PR introduce _any_ user-facing change?

No, we are only adding Java docs.

### How was this patch tested?

Test locally using MacOS.