### PR TITLE
[#1893] improvement(build): treat warnings as errors in lint OpenAPI

### DIFF
--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -8,7 +8,7 @@ import com.github.gradle.node.npm.task.NpxTask
 tasks {
   val lintOpenAPI by registering(NpxTask::class) {
     command.set("@redocly/cli@1.5.0")
-    args.set(listOf("lint", "${project.projectDir}/open-api/openapi.yaml"))
+    args.set(listOf("lint", "--extends=recommended-strict", "${project.projectDir}/open-api/openapi.yaml"))
   }
 
   build {


### PR DESCRIPTION
### What changes were proposed in this pull request?

treat warnings as errors in lint OpenAPI

### Why are the changes needed?

Fix: #1893

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?
about `recommended-strict`,  see [here](https://github.com/Redocly/redocly-cli/pull/1311)

before:

<img width="1417" alt="image" src="https://github.com/datastrato/gravitino/assets/24897598/e610696b-76ff-4d80-8c25-a13d11fdde8c">

after:

<img width="1415" alt="image" src="https://github.com/datastrato/gravitino/assets/24897598/b7f0aec8-70b6-48ab-9d3c-45dc74f52a9c">

