### PR TITLE
[#1974] fix(hive): Hive table listPartitions reduces HMS RPC calls

### DIFF
--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveTable.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveTable.java
@@ -223,7 +223,7 @@ public class HiveTable extends BaseTable {
     return parameters;
   }
 
-  private List<FieldSchema> buildPartitionKeys() {
+  public List<FieldSchema> buildPartitionKeys() {
     return Arrays.stream(partitioning)
         .map(p -> getPartitionKey(((Transforms.IdentityTransform) p).fieldName()))
         .collect(Collectors.toList());

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveTableOperations.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveTableOperations.java
@@ -41,7 +41,7 @@ public class TestHiveTableOperations extends MiniHiveMetastoreService {
   private static Partition existingPartition;
 
   @BeforeAll
-  private static void setup() {
+  public static void setup() {
     hiveCatalog = initHiveCatalog();
     hiveSchema = initHiveSchema(hiveCatalog);
     hiveTable = createPartitionedTable();


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use HMS's `listPartitions` RPC to replace the two RPC calls of `listPartitionNames` and `getPartitionsByNames`.

### Why are the changes needed?

Fix: #1974

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
exist UT