### PR TITLE
[#1979] fix(test): add timeout and retry when downloading chrome

### DIFF
--- a/integration-test/src/main/java/com/datastrato/gravitino/integration/test/util/ITUtils.java
+++ b/integration-test/src/main/java/com/datastrato/gravitino/integration/test/util/ITUtils.java
@@ -22,7 +22,7 @@ public class ITUtils {
   }
 
   public static String[] splitPath(String path) {
-    return File.separator.split(path);
+    return path.split(File.separator);
   }
 
   public static void rewriteConfigFile(

--- a/integration-test/src/main/java/com/datastrato/gravitino/integration/test/util/ITUtils.java
+++ b/integration-test/src/main/java/com/datastrato/gravitino/integration/test/util/ITUtils.java
@@ -21,6 +21,10 @@ public class ITUtils {
     return String.join(File.separator, dirs);
   }
 
+  public static String[] splitPath(String path) {
+    return File.separator.split(path);
+  }
+
   public static void rewriteConfigFile(
       String configTempFileName, String configFileName, Map<String, String> configMap)
       throws IOException {

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/ChromeWebDriverProvider.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/ChromeWebDriverProvider.java
@@ -127,9 +127,10 @@ public class ChromeWebDriverProvider implements WebDriverProvider {
         Archiver archiver = ArchiverFactory.createArchiver(ArchiveFormat.ZIP);
         archiver.extract(chromeDriverZip, new File(downLoadTmpDir));
 
+        // fileName contains directory path, there's an assumption that the zip file is extracted to
+        // `ITUtils.splitPath(fileName)[0]`
         File unzipFile = new File(downLoadTmpDir, ITUtils.splitPath(fileName)[0]);
-        LOG.info(
-            "Move file from " + unzipFile.getAbsolutePath() + " to " + targetFile.getParentFile());
+        LOG.info("Move file from " + unzipFile.getAbsolutePath() + " to " + downLoadDir);
         FileUtils.moveToDirectory(unzipFile, new File(downLoadDir), true);
         LOG.info("Download the zip file from " + url + " to " + downLoadDir + " successfully.");
         return;

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/ChromeWebDriverProvider.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/ChromeWebDriverProvider.java
@@ -104,7 +104,7 @@ public class ChromeWebDriverProvider implements WebDriverProvider {
       return;
     }
 
-    Instant limit = Instant.now().plusSeconds(60);
+    Instant limit = Instant.now().plusSeconds(120);
     int retryNum = 0;
     IOException last = null;
 

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/ChromeWebDriverProvider.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/ChromeWebDriverProvider.java
@@ -127,11 +127,15 @@ public class ChromeWebDriverProvider implements WebDriverProvider {
         Archiver archiver = ArchiverFactory.createArchiver(ArchiveFormat.ZIP);
         archiver.extract(chromeDriverZip, new File(downLoadTmpDir));
 
-        // fileName contains directory path, there's an assumption that the zip file is extracted to
-        // `ITUtils.splitPath(fileName)[0]`
-        File unzipFile = new File(downLoadTmpDir, ITUtils.splitPath(fileName)[0]);
-        LOG.info("Move file from " + unzipFile.getAbsolutePath() + " to " + downLoadDir);
-        FileUtils.moveToDirectory(unzipFile, new File(downLoadDir), true);
+        // fileName contains directory path like "chrome-linux/chrome", there's an assumption
+        // that the zip file is extracted to the firstPath "chrome-linux"
+        String firstPath = ITUtils.splitPath(fileName)[0];
+        LOG.info("filename:{}, firstPath:{}, {}", fileName, firstPath, ITUtils.splitPath(fileName));
+        File unzipFile = new File(downLoadTmpDir, firstPath);
+        File dstFile = new File(downLoadDir);
+        LOG.info(
+            "Move file from " + unzipFile.getAbsolutePath() + " to " + dstFile.getAbsolutePath());
+        FileUtils.moveToDirectory(unzipFile, dstFile, true);
         LOG.info("Download the zip file from " + url + " to " + downLoadDir + " successfully.");
         return;
       } catch (IOException e) {

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/ChromeWebDriverProvider.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/ChromeWebDriverProvider.java
@@ -127,20 +127,19 @@ public class ChromeWebDriverProvider implements WebDriverProvider {
         Archiver archiver = ArchiverFactory.createArchiver(ArchiveFormat.ZIP);
         archiver.extract(chromeDriverZip, new File(downLoadTmpDir));
 
-        File unzipFile = new File(downLoadTmpDir, fileName);
+        File unzipFile = new File(downLoadTmpDir, ITUtils.splitPath(fileName)[0]);
         LOG.info(
             "Move file from " + unzipFile.getAbsolutePath() + " to " + targetFile.getParentFile());
-        FileUtils.moveToDirectory(unzipFile, targetFile.getParentFile(), true);
+        FileUtils.moveToDirectory(unzipFile, new File(downLoadDir), true);
         LOG.info("Download the zip file from " + url + " to " + downLoadDir + " successfully.");
         return;
       } catch (IOException e) {
-        LOG.error(
-            "Download of: " + url + ", failed in path " + ChromeWebDriverProvider.downLoadDir, e);
+        LOG.error("Download of: " + url + ", failed in path " + downLoadDir, e);
         retryNum += 1;
         last = e;
       } finally {
         LOG.info("Remove temp directory: " + downLoadTmpDir);
-        // FileUtils.deleteQuietly(new File(downLoadTmpDir));
+        FileUtils.deleteQuietly(new File(downLoadTmpDir));
       }
     }
     throw new RuntimeException(last);

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/ChromeWebDriverProvider.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/ChromeWebDriverProvider.java
@@ -140,7 +140,7 @@ public class ChromeWebDriverProvider implements WebDriverProvider {
         last = e;
       } finally {
         LOG.info("Remove temp directory: " + downLoadTmpDir);
-        //FileUtils.deleteQuietly(new File(downLoadTmpDir));
+        // FileUtils.deleteQuietly(new File(downLoadTmpDir));
       }
     }
     throw new RuntimeException(last);

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/ChromeWebDriverProvider.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/ChromeWebDriverProvider.java
@@ -140,7 +140,7 @@ public class ChromeWebDriverProvider implements WebDriverProvider {
         last = e;
       } finally {
         LOG.info("Remove temp directory: " + downLoadTmpDir);
-        FileUtils.deleteQuietly(new File(downLoadTmpDir));
+        //FileUtils.deleteQuietly(new File(downLoadTmpDir));
       }
     }
     throw new RuntimeException(last);


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. set connect and read timeout 30s when downloading chrome
2. add error retry 

### Why are the changes needed?
Fix: #1979 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
could run web IT
