### PR TITLE
[#1988] improve(web): add the column headers `autoIncrement` and `comment` in the Table view

### DIFF
--- a/web/app/ui/MetalakeList.js
+++ b/web/app/ui/MetalakeList.js
@@ -143,7 +143,7 @@ const MetalakeList = () => {
       minWidth: 150,
       disableColumnMenu: true,
       field: 'createdBy',
-      headerName: 'Created By',
+      headerName: 'Created by',
       renderCell: ({ row }) => {
         return (
           <Typography noWrap sx={{ color: 'text.secondary' }}>
@@ -158,7 +158,7 @@ const MetalakeList = () => {
       disableColumnMenu: true,
       valueGetter: params => `${params.row.audit?.createTime}`,
       field: 'createdAt',
-      headerName: 'Created At',
+      headerName: 'Created at',
       renderCell: ({ row }) => {
         return (
           <Typography noWrap sx={{ color: 'text.secondary' }}>

--- a/web/app/ui/metalakes/TableView.js
+++ b/web/app/ui/metalakes/TableView.js
@@ -53,7 +53,8 @@ const TableView = props => {
       flex: 0.1,
       minWidth: 60,
       disableColumnMenu: true,
-      field: 'id',
+      type: 'string',
+      field: 'name',
       headerName: 'Name',
       renderCell: ({ row }) => {
         const { name, path } = row
@@ -89,7 +90,8 @@ const TableView = props => {
       flex: 0.1,
       minWidth: 60,
       disableColumnMenu: true,
-      field: 'id',
+      type: 'string',
+      field: 'name',
       headerName: 'Name',
       renderCell: ({ row }) => {
         const { name, path } = row
@@ -123,6 +125,7 @@ const TableView = props => {
       minWidth: 90,
       sortable: false,
       disableColumnMenu: true,
+      type: 'actions',
       field: 'actions',
       headerName: 'Actions',
       renderCell: ({ row }) => (
@@ -163,6 +166,7 @@ const TableView = props => {
       flex: 0.1,
       minWidth: 60,
       disableColumnMenu: true,
+      type: 'string',
       field: 'name',
       headerName: 'Name',
       renderCell: ({ row }) => {
@@ -188,6 +192,7 @@ const TableView = props => {
       flex: 0.1,
       minWidth: 60,
       disableColumnMenu: true,
+      type: 'string',
       field: 'type',
       headerName: 'Type',
       renderCell: ({ row }) => {
@@ -204,6 +209,7 @@ const TableView = props => {
       flex: 0.1,
       minWidth: 60,
       disableColumnMenu: true,
+      type: 'boolean',
       field: 'nullable',
       headerName: 'Nullable',
       renderCell: ({ row }) => {
@@ -221,6 +227,60 @@ const TableView = props => {
               }}
             >
               {typeof nullable !== 'undefined' && `${nullable}`}
+            </Typography>
+          </Box>
+        )
+      }
+    },
+    {
+      flex: 0.1,
+      minWidth: 60,
+      disableColumnMenu: true,
+      type: 'boolean',
+      field: 'autoIncrement',
+      headerName: 'AutoIncrement',
+      renderCell: ({ row }) => {
+        const { autoIncrement } = row
+
+        return (
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            <Typography
+              noWrap
+              variant='body2'
+              sx={{
+                fontWeight: 400,
+                color: 'text.secondary',
+                textDecoration: 'none'
+              }}
+            >
+              {typeof autoIncrement !== 'undefined' && `${autoIncrement}`}
+            </Typography>
+          </Box>
+        )
+      }
+    },
+    {
+      flex: 0.1,
+      minWidth: 60,
+      disableColumnMenu: true,
+      type: 'string',
+      field: 'comment',
+      headerName: 'Comment',
+      renderCell: ({ row }) => {
+        const { comment } = row
+
+        return (
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            <Typography
+              noWrap
+              variant='body2'
+              sx={{
+                fontWeight: 400,
+                color: 'text.secondary',
+                textDecoration: 'none'
+              }}
+            >
+              {typeof comment !== 'undefined' && `${comment}`}
             </Typography>
           </Box>
         )

--- a/web/app/ui/metalakes/TabsContent.js
+++ b/web/app/ui/metalakes/TabsContent.js
@@ -25,7 +25,7 @@ const CustomTab = props => {
       label={
         <Box sx={{ display: 'flex', alignItems: 'center' }}>
           <Icon icon={icon} />
-          <Typography sx={{ ml: 1 }} color={'inherit'}>
+          <Typography className={`twc-font-bold twc-ml-1 twc-normal-case`} color={'inherit'}>
             {label}
           </Typography>
         </Box>

--- a/web/lib/theme/mui.js
+++ b/web/lib/theme/mui.js
@@ -697,8 +697,7 @@ const createMuiTheme = (config = {}) => {
             columnHeaderTitle: {
               fontWeight: 600,
               fontSize: '0.75rem',
-              letterSpacing: '0.17px',
-              textTransform: 'uppercase'
+              letterSpacing: '0.17px'
             },
             columnSeparator: ({ theme }) => ({
               color: theme.palette.divider


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Add the column headers `autoIncrement` and `comment` in the Table
view.
2. Changed the style of Table column header and Tab label.

<img width="621" alt="image"
src="https://github.com/datastrato/gravitino/assets/17310559/cf2669fc-d067-4416-8f9d-52184c54412e">

### Why are the changes needed?

Fix: https://github.com/datastrato/gravitino/issues/1988

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A