### PR TITLE
[#1944] fix(core): Make constructor of MetricsSource.java protected 

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/metrics/source/MetricsSource.java
+++ b/core/src/main/java/com/datastrato/gravitino/metrics/source/MetricsSource.java
@@ -25,7 +25,7 @@ public abstract class MetricsSource {
   private final MetricRegistry metricRegistry;
   private final String metricsSourceName;
 
-  public MetricsSource(String name) {
+  protected MetricsSource(String name) {
     this.metricsSourceName = name;
     metricRegistry = new MetricRegistry();
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
1.The constructor access specifier was changed to protected 

### Why are the changes needed?
fix: #1944 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

Existing tests