### PR TITLE
[#1987] improvement(build): Take warning information as error when build java docs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -204,22 +204,9 @@ subprojects {
 
     val projectName = project.name
     if (projectName == "common" || projectName == "api" || projectName == "client-java") {
-      val outputEvents = mutableListOf<String>()
-      val listener = StandardOutputListener { message -> outputEvents.add(message.toString()) }
-
-      doFirst {
-        logging.addStandardOutputListener(listener)
-        logging.addStandardErrorListener(listener)
-      }
-
-      doLast {
-        logging.removeStandardErrorListener(listener)
-        logging.removeStandardErrorListener(listener)
-        outputEvents.forEach { e ->
-          if (e.contains(" warning: ")) {
-            throw GradleException("Javadoc has warnings, please fix them!")
-          }
-        }
+      options {
+        (this as CoreJavadocOptions).addStringOption("Xwerror", "-quiet")
+        isFailOnError = true
       }
     }
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,8 +57,6 @@ project.extra["extraJvmArgs"] = if (extra["jdkVersion"] in listOf("8", "11")) {
   listOf()
 } else {
   listOf(
-    "-Duser.language=en",
-    "-Duser.country=US",
     "-XX:+IgnoreUnrecognizedVMOptions",
     "--add-opens", "java.base/java.io=ALL-UNNAMED",
     "--add-opens", "java.base/java.lang.invoke=ALL-UNNAMED",


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add check warning information in the JavaDoc task.

### Why are the changes needed?

Module `api`, `common`, and `client-java` will be exposed and used by users, we need to make it more standard. 

Fix: #1987 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Test locally.

![image](https://github.com/datastrato/gravitino/assets/15794564/4eecf869-ad87-4a13-a586-833c87dee19e)


