### PR TITLE
[#1987] improvement(build): Take warning information as error when build java docs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -199,6 +199,14 @@ subprojects {
   tasks.withType<Javadoc> {
     options.encoding = "UTF-8"
     options.locale = "en_US"
+
+    val projectName = project.name
+    if (projectName == "common" || projectName == "api" || projectName == "client-java") {
+      options {
+        (this as CoreJavadocOptions).addStringOption("Xwerror", "-quiet")
+        isFailOnError = true
+      }
+    }
   }
 
   val sourcesJar by tasks.registering(Jar::class) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add check warning information in the JavaDoc task.

### Why are the changes needed?

Module `api`, `common`, and `client-java` will be exposed and used by users, we need to make it more standard. 

Fix: #1987 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Test locally.

![image](https://github.com/datastrato/gravitino/assets/15794564/4eecf869-ad87-4a13-a586-833c87dee19e)


