### PR TITLE
[#1857] improvement: Add an Iceberg REST service demo

### DIFF
--- a/docs/how-to-use-the-playground.md
+++ b/docs/how-to-use-the-playground.md
@@ -128,7 +128,19 @@ If you want to migrate your business from Hive to Iceberg. Some tables will use 
 Gravitino provides an Iceberg REST catalog service, too. You can will use Spark to access REST catalog to write the table data.
 Then, you can use Trino to read the data from the Hive table joining the Iceberg table.
 
+spark-defaults.conf is as follows (is already configured):
+
+```text
+spark.sql.extensions org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
+spark.sql.catalog.catalog_iceberg org.apache.iceberg.spark.SparkCatalog
+spark.sql.catalog.catalog_iceberg.type rest
+spark.sql.catalog.catalog_iceberg.uri http://gravitino:9001/iceberg/
+spark.locality.wait.node 0
+```
+
 1. Login Spark container and execute the steps.
+
+
 
 ```shell
 docker exec -it playground-spark bash
@@ -143,6 +155,7 @@ use catalog_iceberg;
 create database sales;
 use sales;
 create table customers (customer_id int, customer_name varchar(100), customer_email varchar(100));
+describe extended customers;    
 insert into customers (customer_id, customer_name, customer_email) values (11,'Rory Brown','rory@123.com');
 insert into customers (customer_id, customer_name, customer_email) values (12,'Jerry Washington','jerry@dt.com');
 ```

--- a/docs/how-to-use-the-playground.md
+++ b/docs/how-to-use-the-playground.md
@@ -122,7 +122,7 @@ WHERE e.employee_id = p.employee_id AND p.employee_id = s.employee_id
 GROUP BY e.employee_id,  given_name, family_name;
 ```
 
-### Lakehouse practice
+### Using Iceberg REST service
 
 If you want to migrate your business from Hive to Iceberg. Some tables will use Hive, and the other tables will use Iceberg.
 Gravitino provides an Iceberg REST catalog service, too. You can will use Spark to access REST catalog to write the table data.

--- a/docs/how-to-use-the-playground.md
+++ b/docs/how-to-use-the-playground.md
@@ -174,6 +174,3 @@ select * from "metalake_demo.catalog_hive".sales.customers
 union
 select * from "metalake_demo.catalog_iceberg".sales.customers;
 ```
-
-For the details, review the
-[playground example](./how-to-use-the-playground.md#lakehouse-practice).

--- a/docs/how-to-use-the-playground.md
+++ b/docs/how-to-use-the-playground.md
@@ -128,7 +128,7 @@ If you want to migrate your business from Hive to Iceberg. Some tables will use 
 Gravitino provides an Iceberg REST catalog service, too. You can will use Spark to access REST catalog to write the table data.
 Then, you can use Trino to read the data from the Hive table joining the Iceberg table.
 
-spark-defaults.conf is as follows (is already configured):
+`spark-defaults.conf` is as follows (It's already configured in the playground):
 
 ```text
 spark.sql.extensions org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions

--- a/docs/how-to-use-the-playground.md
+++ b/docs/how-to-use-the-playground.md
@@ -140,8 +140,6 @@ spark.locality.wait.node 0
 
 1. Login Spark container and execute the steps.
 
-
-
 ```shell
 docker exec -it playground-spark bash
 ```
@@ -176,3 +174,6 @@ select * from "metalake_demo.catalog_hive".sales.customers
 union
 select * from "metalake_demo.catalog_iceberg".sales.customers;
 ```
+
+For the details, review the
+[playground example](./how-to-use-the-playground.md#lakehouse-practice).

--- a/docs/iceberg-rest-service.md
+++ b/docs/iceberg-rest-service.md
@@ -159,3 +159,6 @@ DESCRIBE TABLE EXTENDED dml.test;
 INSERT INTO dml.test VALUES (1), (2);
 SELECT * FROM dml.test
 ```
+
+For the details, review the
+[playground example](./how-to-use-the-playground.md#lakehouse-practice).

--- a/docs/iceberg-rest-service.md
+++ b/docs/iceberg-rest-service.md
@@ -161,4 +161,4 @@ SELECT * FROM dml.test
 ```
 
 For the details, review the
-[playground example](./how-to-use-the-playground.md#lakehouse-practice).
+[playground example](./how-to-use-the-playground.md#using-iceberg-rest-service).

--- a/docs/iceberg-rest-service.md
+++ b/docs/iceberg-rest-service.md
@@ -160,5 +160,4 @@ INSERT INTO dml.test VALUES (1), (2);
 SELECT * FROM dml.test
 ```
 
-For the details, review the
-[playground example](./how-to-use-the-playground.md#using-iceberg-rest-service).
+You could try Spark with Gravitino REST catalog service in our [playground](./how-to-use-the-playground.md#using-iceberg-rest-service).


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add an Iceberg REST service demo in the playground.

This pr is related to https://github.com/datastrato/gravitino-playground/pull/26

### Why are the changes needed?

Fix: #1857 #1699 

### Does this PR introduce _any_ user-facing change?
No, just doc.

### How was this patch tested?
By hand.
