### PR TITLE
[#2027] fix(trino-connector): Fix the bug that `format` configuration can't overwrite default `InputFormat` value.

### DIFF
--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/hive/HivePropertyMeta.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/hive/HivePropertyMeta.java
@@ -54,20 +54,11 @@ public class HivePropertyMeta implements HasPropertyMeta {
           stringProperty(HIVE_TABLE_LOCATION, "HDFS location for table storage", null, false),
           stringProperty(HIVE_TABLE_TYPE, "The type of Hive table", null, false),
           stringProperty(
-              HIVE_TABLE_INPUT_FORMAT,
-              "The input format class for the table",
-              "org.apache.hadoop.mapred.TextInputFormat",
-              false),
+              HIVE_TABLE_INPUT_FORMAT, "The input format class for the table", null, false),
           stringProperty(
-              HIVE_TABLE_OUTPUT_FORMAT,
-              "The output format class for the table",
-              "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
-              false),
+              HIVE_TABLE_OUTPUT_FORMAT, "The output format class for the table", null, false),
           stringProperty(
-              HIVE_TABLE_SERDE_LIB,
-              "The serde library class for the table",
-              "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
-              false),
+              HIVE_TABLE_SERDE_LIB, "The serde library class for the table", null, false),
           stringProperty(
               HIVE_TABLE_SERDE_NAME, "Name of the serde, table name by default", null, false),
           new PropertyMetadata<>(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove default values of `input_format`, `output_format` and `serde_lib` in Trino Hive connector.

### Why are the changes needed?

When we create hive table, format value can't overwrite the value of `serde_lib`, `input_format` and `output_fomat`

Fix: #2027 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Add some tests in `testHiveTableCreatedByGravitino`.
