### PR TITLE
[#1838] feat(client): Add Java client support for fileset

### DIFF
--- a/api/src/main/java/com/datastrato/gravitino/Catalog.java
+++ b/api/src/main/java/com/datastrato/gravitino/Catalog.java
@@ -20,11 +20,11 @@ public interface Catalog extends Auditable {
     /** Catalog Type for Relational Data Structure, like db.table, catalog.db.table. */
     RELATIONAL,
 
-    /** Catalog Type for File System (including HDFS, S3, etc.), like path/to/file */
-    FILE,
+    /** Catalog Type for Fileset System (including HDFS, S3, etc.), like path/to/file */
+    FILESET,
 
     /** Catalog Type for Message Queue, like kafka://topic */
-    STREAM,
+    STREAM
   }
 
   /**

--- a/api/src/main/java/com/datastrato/gravitino/NameIdentifier.java
+++ b/api/src/main/java/com/datastrato/gravitino/NameIdentifier.java
@@ -160,6 +160,17 @@ public class NameIdentifier {
   }
 
   /**
+   * Check the given {@link NameIdentifier} is a fileset identifier. Throw an {@link
+   * IllegalNameIdentifierException} if it's not.
+   *
+   * @param ident The fileset {@link NameIdentifier} to check.
+   */
+  public static void checkFileset(NameIdentifier ident) {
+    check(ident != null, "Fileset identifier must not be null");
+    Namespace.checkFileset(ident.namespace);
+  }
+
+  /**
    * Create a {@link NameIdentifier} from the given identifier string.
    *
    * @param identifier The identifier string

--- a/api/src/main/java/com/datastrato/gravitino/Namespace.java
+++ b/api/src/main/java/com/datastrato/gravitino/Namespace.java
@@ -157,6 +157,20 @@ public class Namespace {
         namespace);
   }
 
+  /**
+   * Check if the given fileset namespace is legal, throw an {@link IllegalNamespaceException} if
+   * it's illegal.
+   *
+   * @param namespace The fileset namespace
+   */
+  public static void checkFileset(Namespace namespace) {
+    check(
+        namespace != null && namespace.length() == 3,
+        String.format(
+            "Fileset namespace must be non-null and have 3 levels, the input namespace is %s",
+            namespace));
+  }
+
   private Namespace(String[] levels) {
     this.levels = levels;
   }

--- a/api/src/main/java/com/datastrato/gravitino/Namespace.java
+++ b/api/src/main/java/com/datastrato/gravitino/Namespace.java
@@ -166,9 +166,8 @@ public class Namespace {
   public static void checkFileset(Namespace namespace) {
     check(
         namespace != null && namespace.length() == 3,
-        String.format(
-            "Fileset namespace must be non-null and have 3 levels, the input namespace is %s",
-            namespace));
+        "Fileset namespace must be non-null and have 3 levels, the input namespace is %s",
+        namespace);
   }
 
   private Namespace(String[] levels) {

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/BaseSchemaCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/BaseSchemaCatalog.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * common methods for managing schemas in a catalog. With {@link BaseSchemaCatalog}, users can list,
  * create, load, alter and drop a schema with specified identifier.
  */
-public abstract class BaseSchemaCatalog extends CatalogDTO implements SupportsSchemas {
+abstract class BaseSchemaCatalog extends CatalogDTO implements SupportsSchemas {
   private static final Logger LOG = LoggerFactory.getLogger(BaseSchemaCatalog.class);
 
   /** The REST client to send the requests. */

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/BaseSchemaCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/BaseSchemaCatalog.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.client;
+
+import com.datastrato.gravitino.NameIdentifier;
+import com.datastrato.gravitino.Namespace;
+import com.datastrato.gravitino.dto.AuditDTO;
+import com.datastrato.gravitino.dto.CatalogDTO;
+import com.datastrato.gravitino.dto.requests.SchemaCreateRequest;
+import com.datastrato.gravitino.dto.requests.SchemaUpdateRequest;
+import com.datastrato.gravitino.dto.requests.SchemaUpdatesRequest;
+import com.datastrato.gravitino.dto.responses.DropResponse;
+import com.datastrato.gravitino.dto.responses.EntityListResponse;
+import com.datastrato.gravitino.dto.responses.SchemaResponse;
+import com.datastrato.gravitino.exceptions.NoSuchCatalogException;
+import com.datastrato.gravitino.exceptions.NoSuchSchemaException;
+import com.datastrato.gravitino.exceptions.NonEmptySchemaException;
+import com.datastrato.gravitino.exceptions.SchemaAlreadyExistsException;
+import com.datastrato.gravitino.rel.Schema;
+import com.datastrato.gravitino.rel.SchemaChange;
+import com.datastrato.gravitino.rel.SupportsSchemas;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * BaseSchemaCatalog is the base abstract class for all the catalog with schema. It provides the
+ * common methods for managing schemas in a catalog. With {@link BaseSchemaCatalog}, users can list,
+ * create, load, alter and drop a schema with specified identifier.
+ */
+public abstract class BaseSchemaCatalog extends CatalogDTO implements SupportsSchemas {
+  private static final Logger LOG = LoggerFactory.getLogger(BaseSchemaCatalog.class);
+
+  /** The REST client to send the requests. */
+  protected final RESTClient restClient;
+
+  BaseSchemaCatalog(
+      String name,
+      Type type,
+      String provider,
+      String comment,
+      Map<String, String> properties,
+      AuditDTO auditDTO,
+      RESTClient restClient) {
+    super(name, type, provider, comment, properties, auditDTO);
+    this.restClient = restClient;
+  }
+
+  @Override
+  public SupportsSchemas asSchemas() throws UnsupportedOperationException {
+    return this;
+  }
+
+  /**
+   * List all the schemas under the given catalog namespace.
+   *
+   * @param namespace The namespace of the catalog.
+   * @return A list of {@link NameIdentifier} of the schemas under the given catalog namespace.
+   * @throws NoSuchCatalogException if the catalog with specified namespace does not exist.
+   */
+  @Override
+  public NameIdentifier[] listSchemas(Namespace namespace) throws NoSuchCatalogException {
+    Namespace.checkSchema(namespace);
+
+    EntityListResponse resp =
+        restClient.get(
+            formatSchemaRequestPath(namespace),
+            EntityListResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.schemaErrorHandler());
+    resp.validate();
+
+    return resp.identifiers();
+  }
+
+  /**
+   * Create a new schema with specified identifier, comment and metadata.
+   *
+   * @param ident The name identifier of the schema.
+   * @param comment The comment of the schema.
+   * @param properties The properties of the schema.
+   * @return The created {@link Schema}.
+   * @throws NoSuchCatalogException if the catalog with specified namespace does not exist.
+   * @throws SchemaAlreadyExistsException if the schema with specified identifier already exists.
+   */
+  @Override
+  public Schema createSchema(NameIdentifier ident, String comment, Map<String, String> properties)
+      throws NoSuchCatalogException, SchemaAlreadyExistsException {
+    NameIdentifier.checkSchema(ident);
+
+    SchemaCreateRequest req = new SchemaCreateRequest(ident.name(), comment, properties);
+    req.validate();
+
+    SchemaResponse resp =
+        restClient.post(
+            formatSchemaRequestPath(ident.namespace()),
+            req,
+            SchemaResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.schemaErrorHandler());
+    resp.validate();
+
+    return resp.getSchema();
+  }
+
+  /**
+   * Load the schema with specified identifier.
+   *
+   * @param ident The name identifier of the schema.
+   * @return The {@link Schema} with specified identifier.
+   * @throws NoSuchSchemaException if the schema with specified identifier does not exist.
+   */
+  @Override
+  public Schema loadSchema(NameIdentifier ident) throws NoSuchSchemaException {
+    NameIdentifier.checkSchema(ident);
+
+    SchemaResponse resp =
+        restClient.get(
+            formatSchemaRequestPath(ident.namespace()) + "/" + ident.name(),
+            SchemaResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.schemaErrorHandler());
+    resp.validate();
+
+    return resp.getSchema();
+  }
+
+  /**
+   * Alter the schema with specified identifier by applying the changes.
+   *
+   * @param ident The name identifier of the schema.
+   * @param changes The metadata changes to apply.
+   * @return The altered {@link Schema}.
+   * @throws NoSuchSchemaException if the schema with specified identifier does not exist.
+   */
+  @Override
+  public Schema alterSchema(NameIdentifier ident, SchemaChange... changes)
+      throws NoSuchSchemaException {
+    NameIdentifier.checkSchema(ident);
+
+    List<SchemaUpdateRequest> reqs =
+        Arrays.stream(changes)
+            .map(DTOConverters::toSchemaUpdateRequest)
+            .collect(Collectors.toList());
+    SchemaUpdatesRequest updatesRequest = new SchemaUpdatesRequest(reqs);
+    updatesRequest.validate();
+
+    SchemaResponse resp =
+        restClient.put(
+            formatSchemaRequestPath(ident.namespace()) + "/" + ident.name(),
+            updatesRequest,
+            SchemaResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.schemaErrorHandler());
+    resp.validate();
+
+    return resp.getSchema();
+  }
+
+  /**
+   * Drop the schema with specified identifier.
+   *
+   * @param ident The name identifier of the schema.
+   * @param cascade Whether to drop all the tables under the schema.
+   * @return true if the schema is dropped successfully, false otherwise.
+   * @throws NonEmptySchemaException if the schema is not empty and cascade is false.
+   */
+  @Override
+  public boolean dropSchema(NameIdentifier ident, boolean cascade) throws NonEmptySchemaException {
+    NameIdentifier.checkSchema(ident);
+
+    try {
+      DropResponse resp =
+          restClient.delete(
+              formatSchemaRequestPath(ident.namespace()) + "/" + ident.name(),
+              Collections.singletonMap("cascade", String.valueOf(cascade)),
+              DropResponse.class,
+              Collections.emptyMap(),
+              ErrorHandlers.schemaErrorHandler());
+      resp.validate();
+      return resp.dropped();
+
+    } catch (NonEmptySchemaException e) {
+      throw e;
+    } catch (Exception e) {
+      LOG.warn("Failed to drop schema {}", ident, e);
+      return false;
+    }
+  }
+
+  @VisibleForTesting
+  static String formatSchemaRequestPath(Namespace ns) {
+    return new StringBuilder()
+        .append("api/metalakes/")
+        .append(ns.level(0))
+        .append("/catalogs/")
+        .append(ns.level(1))
+        .append("/schemas")
+        .toString();
+  }
+}

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/ErrorHandlers.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/ErrorHandlers.java
@@ -369,6 +369,7 @@ public class ErrorHandlers {
   }
 
   /** Error handler specific to Fileset operations. */
+  @SuppressWarnings("FormatStringAnnotation")
   private static class FilesetErrorHandler extends RestErrorHandler {
 
     private static final FilesetErrorHandler INSTANCE = new FilesetErrorHandler();

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/ErrorHandlers.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/ErrorHandlers.java
@@ -9,8 +9,10 @@ import com.datastrato.gravitino.dto.responses.ErrorResponse;
 import com.datastrato.gravitino.dto.responses.OAuth2ErrorResponse;
 import com.datastrato.gravitino.exceptions.BadRequestException;
 import com.datastrato.gravitino.exceptions.CatalogAlreadyExistsException;
+import com.datastrato.gravitino.exceptions.FilesetAlreadyExistsException;
 import com.datastrato.gravitino.exceptions.MetalakeAlreadyExistsException;
 import com.datastrato.gravitino.exceptions.NoSuchCatalogException;
+import com.datastrato.gravitino.exceptions.NoSuchFilesetException;
 import com.datastrato.gravitino.exceptions.NoSuchMetalakeException;
 import com.datastrato.gravitino.exceptions.NoSuchPartitionException;
 import com.datastrato.gravitino.exceptions.NoSuchSchemaException;
@@ -99,6 +101,15 @@ public class ErrorHandlers {
    */
   public static Consumer<ErrorResponse> oauthErrorHandler() {
     return OAuthErrorHandler.INSTANCE;
+  }
+
+  /**
+   * Creates an error handler specific to Fileset operations.
+   *
+   * @return A Consumer representing the Fileset error handler.
+   */
+  public static Consumer<ErrorResponse> filesetErrorHandler() {
+    return FilesetErrorHandler.INSTANCE;
   }
 
   private ErrorHandlers() {}
@@ -353,6 +364,39 @@ public class ErrorHandlers {
                 "Malformed request: %s: %s", errorResponse.getType(), errorResponse.getMessage());
         }
       }
+      super.accept(errorResponse);
+    }
+  }
+
+  /** Error handler specific to Fileset operations. */
+  private static class FilesetErrorHandler extends RestErrorHandler {
+
+    private static final FilesetErrorHandler INSTANCE = new FilesetErrorHandler();
+
+    @Override
+    public void accept(ErrorResponse errorResponse) {
+      String errorMessage = formatErrorMessage(errorResponse);
+
+      switch (errorResponse.getCode()) {
+        case ErrorConstants.ILLEGAL_ARGUMENTS_CODE:
+          throw new IllegalArgumentException(errorMessage);
+
+        case ErrorConstants.NOT_FOUND_CODE:
+          if (errorResponse.getType().equals(NoSuchSchemaException.class.getSimpleName())) {
+            throw new NoSuchSchemaException(errorMessage);
+          } else if (errorResponse.getType().equals(NoSuchFilesetException.class.getSimpleName())) {
+            throw new NoSuchFilesetException(errorMessage);
+          } else {
+            throw new NotFoundException(errorMessage);
+          }
+
+        case ErrorConstants.ALREADY_EXISTS_CODE:
+          throw new FilesetAlreadyExistsException(errorMessage);
+
+        case ErrorConstants.INTERNAL_ERROR_CODE:
+          throw new RuntimeException(errorMessage);
+      }
+
       super.accept(errorResponse);
     }
   }

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/FilesetCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/FilesetCatalog.java
@@ -242,7 +242,7 @@ public class FilesetCatalog extends BaseSchemaCatalog
     @Override
     public FilesetCatalog build() {
       Preconditions.checkArgument(restClient != null, "restClient must be set");
-      Preconditions.checkArgument(StringUtils.isNotBlank(name), "name must not be null or empty");
+      Preconditions.checkArgument(StringUtils.isNotBlank(name), "name must not be blank");
       Preconditions.checkArgument(type != null, "type must not be null");
       Preconditions.checkArgument(
           StringUtils.isNotBlank(provider), "provider must not be null or empty");

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/FilesetCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/FilesetCatalog.java
@@ -244,8 +244,7 @@ public class FilesetCatalog extends BaseSchemaCatalog
       Preconditions.checkArgument(restClient != null, "restClient must be set");
       Preconditions.checkArgument(StringUtils.isNotBlank(name), "name must not be blank");
       Preconditions.checkArgument(type != null, "type must not be null");
-      Preconditions.checkArgument(
-          StringUtils.isNotBlank(provider), "provider must not be null or empty");
+      Preconditions.checkArgument(StringUtils.isNotBlank(provider), "provider must not be blank");
       Preconditions.checkArgument(audit != null, "audit must not be null");
 
       return new FilesetCatalog(name, type, provider, comment, properties, audit, restClient);

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/FilesetCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/FilesetCatalog.java
@@ -19,7 +19,6 @@ import com.datastrato.gravitino.exceptions.NoSuchFilesetException;
 import com.datastrato.gravitino.exceptions.NoSuchSchemaException;
 import com.datastrato.gravitino.file.Fileset;
 import com.datastrato.gravitino.file.FilesetChange;
-import com.datastrato.gravitino.rest.RESTUtils;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.util.Arrays;
@@ -89,9 +88,7 @@ public class FilesetCatalog extends BaseSchemaCatalog
 
     FilesetResponse resp =
         restClient.get(
-            formatFilesetRequestPath(ident.namespace())
-                + "/"
-                + RESTUtils.encodeString(ident.name()),
+            formatFilesetRequestPath(ident.namespace()) + "/" + ident.name(),
             FilesetResponse.class,
             Collections.emptyMap(),
             ErrorHandlers.filesetErrorHandler());
@@ -129,7 +126,7 @@ public class FilesetCatalog extends BaseSchemaCatalog
 
     FilesetCreateRequest req =
         FilesetCreateRequest.builder()
-            .name(RESTUtils.encodeString(ident.name()))
+            .name(ident.name())
             .comment(comment)
             .type(type)
             .storageLocation(storageLocation)
@@ -170,9 +167,7 @@ public class FilesetCatalog extends BaseSchemaCatalog
 
     FilesetResponse resp =
         restClient.put(
-            formatFilesetRequestPath(ident.namespace())
-                + "/"
-                + RESTUtils.encodeString(ident.name()),
+            formatFilesetRequestPath(ident.namespace()) + "/" + ident.name(),
             req,
             FilesetResponse.class,
             Collections.emptyMap(),
@@ -197,9 +192,7 @@ public class FilesetCatalog extends BaseSchemaCatalog
 
     DropResponse resp =
         restClient.delete(
-            formatFilesetRequestPath(ident.namespace())
-                + "/"
-                + RESTUtils.encodeString(ident.name()),
+            formatFilesetRequestPath(ident.namespace()) + "/" + ident.name(),
             DropResponse.class,
             Collections.emptyMap(),
             ErrorHandlers.filesetErrorHandler());

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/FilesetCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/FilesetCatalog.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.client;
+
+import com.datastrato.gravitino.NameIdentifier;
+import com.datastrato.gravitino.Namespace;
+import com.datastrato.gravitino.dto.AuditDTO;
+import com.datastrato.gravitino.dto.CatalogDTO;
+import com.datastrato.gravitino.dto.requests.FilesetCreateRequest;
+import com.datastrato.gravitino.dto.requests.FilesetUpdateRequest;
+import com.datastrato.gravitino.dto.requests.FilesetUpdatesRequest;
+import com.datastrato.gravitino.dto.responses.DropResponse;
+import com.datastrato.gravitino.dto.responses.EntityListResponse;
+import com.datastrato.gravitino.dto.responses.FilesetResponse;
+import com.datastrato.gravitino.exceptions.FilesetAlreadyExistsException;
+import com.datastrato.gravitino.exceptions.NoSuchFilesetException;
+import com.datastrato.gravitino.exceptions.NoSuchSchemaException;
+import com.datastrato.gravitino.file.Fileset;
+import com.datastrato.gravitino.file.FilesetChange;
+import com.datastrato.gravitino.rest.RESTUtils;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Fileset catalog is a catalog implementation that supports fileset like metadata operations, for
+ * example, schemas and filesets list, creation, update and deletion. A Fileset catalog is under the
+ * metalake.
+ */
+public class FilesetCatalog extends BaseSchemaCatalog
+    implements com.datastrato.gravitino.file.FilesetCatalog {
+
+  FilesetCatalog(
+      String name,
+      Type type,
+      String provider,
+      String comment,
+      Map<String, String> properties,
+      AuditDTO auditDTO,
+      RESTClient restClient) {
+    super(name, type, provider, comment, properties, auditDTO, restClient);
+  }
+
+  @Override
+  public com.datastrato.gravitino.file.FilesetCatalog asFilesetCatalog()
+      throws UnsupportedOperationException {
+    return this;
+  }
+
+  /**
+   * List the filesets in a schema namespace from the catalog.
+   *
+   * @param namespace A schema namespace.
+   * @return An array of fileset identifiers in the namespace.
+   * @throws NoSuchSchemaException If the schema does not exist.
+   */
+  @Override
+  public NameIdentifier[] listFilesets(Namespace namespace) throws NoSuchSchemaException {
+    Namespace.checkFileset(namespace);
+
+    EntityListResponse resp =
+        restClient.get(
+            formatFilesetRequestPath(namespace),
+            EntityListResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.filesetErrorHandler());
+    resp.validate();
+
+    return resp.identifiers();
+  }
+
+  /**
+   * Load fileset metadata by {@link NameIdentifier} from the catalog.
+   *
+   * @param ident A fileset identifier.
+   * @return The fileset metadata.
+   * @throws NoSuchFilesetException If the fileset does not exist.
+   */
+  @Override
+  public Fileset loadFileset(NameIdentifier ident) throws NoSuchFilesetException {
+    NameIdentifier.checkFileset(ident);
+
+    FilesetResponse resp =
+        restClient.get(
+            formatFilesetRequestPath(ident.namespace())
+                + "/"
+                + RESTUtils.encodeString(ident.name()),
+            FilesetResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.filesetErrorHandler());
+    resp.validate();
+
+    return resp.getFileset();
+  }
+
+  /**
+   * Create a fileset metadata in the catalog.
+   *
+   * <p>If the type of the fileset object is "MANAGED", the underlying storageLocation can be null,
+   * and Gravitino will manage the storage location based on the location of the schema.
+   *
+   * <p>If the type of the fileset object is "EXTERNAL", the underlying storageLocation must be set.
+   *
+   * @param ident A fileset identifier.
+   * @param comment The comment of the fileset.
+   * @param type The type of the fileset.
+   * @param storageLocation The storage location of the fileset.
+   * @param properties The properties of the fileset.
+   * @return The created fileset metadata
+   * @throws NoSuchSchemaException If the schema does not exist.
+   * @throws FilesetAlreadyExistsException If the fileset already exists.
+   */
+  @Override
+  public Fileset createFileset(
+      NameIdentifier ident,
+      String comment,
+      Fileset.Type type,
+      String storageLocation,
+      Map<String, String> properties)
+      throws NoSuchSchemaException, FilesetAlreadyExistsException {
+    NameIdentifier.checkFileset(ident);
+
+    FilesetCreateRequest req =
+        FilesetCreateRequest.builder()
+            .name(RESTUtils.encodeString(ident.name()))
+            .comment(comment)
+            .type(type)
+            .storageLocation(storageLocation)
+            .properties(properties)
+            .build();
+
+    FilesetResponse resp =
+        restClient.post(
+            formatFilesetRequestPath(ident.namespace()),
+            req,
+            FilesetResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.filesetErrorHandler());
+    resp.validate();
+
+    return resp.getFileset();
+  }
+
+  /**
+   * Update a fileset metadata in the catalog.
+   *
+   * @param ident A fileset identifier.
+   * @param changes The changes to apply to the fileset.
+   * @return The updated fileset metadata.
+   * @throws NoSuchFilesetException If the fileset does not exist.
+   * @throws IllegalArgumentException If the changes are invalid.
+   */
+  @Override
+  public Fileset alterFileset(NameIdentifier ident, FilesetChange... changes)
+      throws NoSuchFilesetException, IllegalArgumentException {
+    NameIdentifier.checkFileset(ident);
+
+    List<FilesetUpdateRequest> updates =
+        Arrays.stream(changes)
+            .map(DTOConverters::toFilesetUpdateRequest)
+            .collect(Collectors.toList());
+    FilesetUpdatesRequest req = new FilesetUpdatesRequest(updates);
+
+    FilesetResponse resp =
+        restClient.put(
+            formatFilesetRequestPath(ident.namespace())
+                + "/"
+                + RESTUtils.encodeString(ident.name()),
+            req,
+            FilesetResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.filesetErrorHandler());
+    resp.validate();
+
+    return resp.getFileset();
+  }
+
+  /**
+   * Drop a fileset from the catalog.
+   *
+   * <p>The underlying files will be deleted if this fileset type is managed, otherwise, only the
+   * metadata will be dropped.
+   *
+   * @param ident A fileset identifier.
+   * @return true If the fileset is dropped, false the fileset did not exist.
+   */
+  @Override
+  public boolean dropFileset(NameIdentifier ident) {
+    NameIdentifier.checkFileset(ident);
+
+    DropResponse resp =
+        restClient.delete(
+            formatFilesetRequestPath(ident.namespace())
+                + "/"
+                + RESTUtils.encodeString(ident.name()),
+            DropResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.filesetErrorHandler());
+    resp.validate();
+
+    return resp.dropped();
+  }
+
+  @VisibleForTesting
+  static String formatFilesetRequestPath(Namespace ns) {
+    Namespace schemaNs = Namespace.of(ns.level(0), ns.level(1));
+    return new StringBuilder()
+        .append(formatSchemaRequestPath(schemaNs))
+        .append("/")
+        .append(ns.level(2))
+        .append("/filesets")
+        .toString();
+  }
+
+  /**
+   * Create a new builder for the fileset catalog.
+   *
+   * @return A new builder for the fileset catalog.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  static class Builder extends CatalogDTO.Builder<Builder> {
+    /** The REST client to send the requests. */
+    private RESTClient restClient;
+
+    private Builder() {}
+
+    Builder withRestClient(RESTClient restClient) {
+      this.restClient = restClient;
+      return this;
+    }
+
+    @Override
+    public FilesetCatalog build() {
+      Preconditions.checkArgument(restClient != null, "restClient must be set");
+      Preconditions.checkArgument(StringUtils.isNotBlank(name), "name must not be null or empty");
+      Preconditions.checkArgument(type != null, "type must not be null");
+      Preconditions.checkArgument(
+          StringUtils.isNotBlank(provider), "provider must not be null or empty");
+      Preconditions.checkArgument(audit != null, "audit must not be null");
+
+      return new FilesetCatalog(name, type, provider, comment, properties, audit, restClient);
+    }
+  }
+}

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
@@ -11,26 +11,16 @@ import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.dto.AuditDTO;
 import com.datastrato.gravitino.dto.CatalogDTO;
-import com.datastrato.gravitino.dto.requests.SchemaCreateRequest;
-import com.datastrato.gravitino.dto.requests.SchemaUpdateRequest;
-import com.datastrato.gravitino.dto.requests.SchemaUpdatesRequest;
 import com.datastrato.gravitino.dto.requests.TableCreateRequest;
 import com.datastrato.gravitino.dto.requests.TableUpdateRequest;
 import com.datastrato.gravitino.dto.requests.TableUpdatesRequest;
 import com.datastrato.gravitino.dto.responses.DropResponse;
 import com.datastrato.gravitino.dto.responses.EntityListResponse;
-import com.datastrato.gravitino.dto.responses.SchemaResponse;
 import com.datastrato.gravitino.dto.responses.TableResponse;
-import com.datastrato.gravitino.exceptions.NoSuchCatalogException;
 import com.datastrato.gravitino.exceptions.NoSuchSchemaException;
 import com.datastrato.gravitino.exceptions.NoSuchTableException;
-import com.datastrato.gravitino.exceptions.NonEmptySchemaException;
-import com.datastrato.gravitino.exceptions.SchemaAlreadyExistsException;
 import com.datastrato.gravitino.exceptions.TableAlreadyExistsException;
 import com.datastrato.gravitino.rel.Column;
-import com.datastrato.gravitino.rel.Schema;
-import com.datastrato.gravitino.rel.SchemaChange;
-import com.datastrato.gravitino.rel.SupportsSchemas;
 import com.datastrato.gravitino.rel.Table;
 import com.datastrato.gravitino.rel.TableCatalog;
 import com.datastrato.gravitino.rel.TableChange;
@@ -55,11 +45,9 @@ import org.slf4j.LoggerFactory;
  * operations, for example, schemas and tables list, creation, update and deletion. A Relational
  * catalog is under the metalake.
  */
-public class RelationalCatalog extends CatalogDTO implements TableCatalog, SupportsSchemas {
+public class RelationalCatalog extends BaseSchemaCatalog implements TableCatalog {
 
   private static final Logger LOG = LoggerFactory.getLogger(RelationalCatalog.class);
-
-  private final RESTClient restClient;
 
   RelationalCatalog(
       String name,
@@ -69,13 +57,7 @@ public class RelationalCatalog extends CatalogDTO implements TableCatalog, Suppo
       Map<String, String> properties,
       AuditDTO auditDTO,
       RESTClient restClient) {
-    super(name, type, provider, comment, properties, auditDTO);
-    this.restClient = restClient;
-  }
-
-  @Override
-  public SupportsSchemas asSchemas() {
-    return this;
+    super(name, type, provider, comment, properties, auditDTO, restClient);
   }
 
   @Override
@@ -267,143 +249,6 @@ public class RelationalCatalog extends CatalogDTO implements TableCatalog, Suppo
     }
   }
 
-  /**
-   * List all the schemas under the given catalog namespace.
-   *
-   * @param namespace The namespace of the catalog.
-   * @return A list of {@link NameIdentifier} of the schemas under the given catalog namespace.
-   * @throws NoSuchCatalogException if the catalog with specified namespace does not exist.
-   */
-  @Override
-  public NameIdentifier[] listSchemas(Namespace namespace) throws NoSuchCatalogException {
-    Namespace.checkSchema(namespace);
-
-    EntityListResponse resp =
-        restClient.get(
-            formatSchemaRequestPath(namespace),
-            EntityListResponse.class,
-            Collections.emptyMap(),
-            ErrorHandlers.schemaErrorHandler());
-    resp.validate();
-
-    return resp.identifiers();
-  }
-
-  /**
-   * Create a new schema with specified identifier, comment and metadata.
-   *
-   * @param ident The name identifier of the schema.
-   * @param comment The comment of the schema.
-   * @param properties The properties of the schema.
-   * @return The created {@link Schema}.
-   * @throws NoSuchCatalogException if the catalog with specified namespace does not exist.
-   * @throws SchemaAlreadyExistsException if the schema with specified identifier already exists.
-   */
-  @Override
-  public Schema createSchema(NameIdentifier ident, String comment, Map<String, String> properties)
-      throws NoSuchCatalogException, SchemaAlreadyExistsException {
-    NameIdentifier.checkSchema(ident);
-
-    SchemaCreateRequest req = new SchemaCreateRequest(ident.name(), comment, properties);
-    req.validate();
-
-    SchemaResponse resp =
-        restClient.post(
-            formatSchemaRequestPath(ident.namespace()),
-            req,
-            SchemaResponse.class,
-            Collections.emptyMap(),
-            ErrorHandlers.schemaErrorHandler());
-    resp.validate();
-
-    return resp.getSchema();
-  }
-
-  /**
-   * Load the schema with specified identifier.
-   *
-   * @param ident The name identifier of the schema.
-   * @return The {@link Schema} with specified identifier.
-   * @throws NoSuchSchemaException if the schema with specified identifier does not exist.
-   */
-  @Override
-  public Schema loadSchema(NameIdentifier ident) throws NoSuchSchemaException {
-    NameIdentifier.checkSchema(ident);
-
-    SchemaResponse resp =
-        restClient.get(
-            formatSchemaRequestPath(ident.namespace()) + "/" + ident.name(),
-            SchemaResponse.class,
-            Collections.emptyMap(),
-            ErrorHandlers.schemaErrorHandler());
-    resp.validate();
-
-    return resp.getSchema();
-  }
-
-  /**
-   * Alter the schema with specified identifier by applying the changes.
-   *
-   * @param ident The name identifier of the schema.
-   * @param changes The metadata changes to apply.
-   * @return The altered {@link Schema}.
-   * @throws NoSuchSchemaException if the schema with specified identifier does not exist.
-   */
-  @Override
-  public Schema alterSchema(NameIdentifier ident, SchemaChange... changes)
-      throws NoSuchSchemaException {
-    NameIdentifier.checkSchema(ident);
-
-    List<SchemaUpdateRequest> reqs =
-        Arrays.stream(changes)
-            .map(DTOConverters::toSchemaUpdateRequest)
-            .collect(Collectors.toList());
-    SchemaUpdatesRequest updatesRequest = new SchemaUpdatesRequest(reqs);
-    updatesRequest.validate();
-
-    SchemaResponse resp =
-        restClient.put(
-            formatSchemaRequestPath(ident.namespace()) + "/" + ident.name(),
-            updatesRequest,
-            SchemaResponse.class,
-            Collections.emptyMap(),
-            ErrorHandlers.schemaErrorHandler());
-    resp.validate();
-
-    return resp.getSchema();
-  }
-
-  /**
-   * Drop the schema with specified identifier.
-   *
-   * @param ident The name identifier of the schema.
-   * @param cascade Whether to drop all the tables under the schema.
-   * @return true if the schema is dropped successfully, false otherwise.
-   * @throws NonEmptySchemaException if the schema is not empty and cascade is false.
-   */
-  @Override
-  public boolean dropSchema(NameIdentifier ident, boolean cascade) throws NonEmptySchemaException {
-    NameIdentifier.checkSchema(ident);
-
-    try {
-      DropResponse resp =
-          restClient.delete(
-              formatSchemaRequestPath(ident.namespace()) + "/" + ident.name(),
-              Collections.singletonMap("cascade", String.valueOf(cascade)),
-              DropResponse.class,
-              Collections.emptyMap(),
-              ErrorHandlers.schemaErrorHandler());
-      resp.validate();
-      return resp.dropped();
-
-    } catch (NonEmptySchemaException e) {
-      throw e;
-    } catch (Exception e) {
-      LOG.warn("Failed to drop schema {}", ident, e);
-      return false;
-    }
-  }
-
   @VisibleForTesting
   static String formatTableRequestPath(Namespace ns) {
     Namespace schemaNs = Namespace.of(ns.level(0), ns.level(1));
@@ -415,19 +260,20 @@ public class RelationalCatalog extends CatalogDTO implements TableCatalog, Suppo
         .toString();
   }
 
-  @VisibleForTesting
-  static String formatSchemaRequestPath(Namespace ns) {
-    return new StringBuilder()
-        .append("api/metalakes/")
-        .append(ns.level(0))
-        .append("/catalogs/")
-        .append(ns.level(1))
-        .append("/schemas")
-        .toString();
+  /**
+   * Create a new builder for the relational catalog.
+   *
+   * @return A new builder for the relational catalog.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 
   static class Builder extends CatalogDTO.Builder<Builder> {
+    /** The REST client to send the requests. */
     private RESTClient restClient;
+
+    private Builder() {}
 
     Builder withRestClient(RESTClient restClient) {
       this.restClient = restClient;

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
@@ -285,8 +285,7 @@ public class RelationalCatalog extends BaseSchemaCatalog implements TableCatalog
       Preconditions.checkArgument(restClient != null, "restClient must be set");
       Preconditions.checkArgument(StringUtils.isNotBlank(name), "name must not be blank");
       Preconditions.checkArgument(type != null, "type must not be null");
-      Preconditions.checkArgument(
-          StringUtils.isNotBlank(provider), "provider must not be blank");
+      Preconditions.checkArgument(StringUtils.isNotBlank(provider), "provider must not be blank");
       Preconditions.checkArgument(audit != null, "audit must not be null");
 
       return new RelationalCatalog(name, type, provider, comment, properties, audit, restClient);

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
@@ -283,10 +283,10 @@ public class RelationalCatalog extends BaseSchemaCatalog implements TableCatalog
     @Override
     public RelationalCatalog build() {
       Preconditions.checkArgument(restClient != null, "restClient must be set");
-      Preconditions.checkArgument(StringUtils.isNotBlank(name), "name must not be null or empty");
+      Preconditions.checkArgument(StringUtils.isNotBlank(name), "name must not be blank");
       Preconditions.checkArgument(type != null, "type must not be null");
       Preconditions.checkArgument(
-          StringUtils.isNotBlank(provider), "provider must not be null or empty");
+          StringUtils.isNotBlank(provider), "provider must not be blank");
       Preconditions.checkArgument(audit != null, "audit must not be null");
 
       return new RelationalCatalog(name, type, provider, comment, properties, audit, restClient);

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalTable.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalTable.java
@@ -24,8 +24,8 @@ import com.datastrato.gravitino.rel.expressions.sorts.SortOrder;
 import com.datastrato.gravitino.rel.expressions.transforms.Transform;
 import com.datastrato.gravitino.rel.indexes.Index;
 import com.datastrato.gravitino.rel.partitions.Partition;
+import com.datastrato.gravitino.rest.RESTUtils;
 import com.google.common.annotations.VisibleForTesting;
-import java.net.URLEncoder;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -247,6 +247,6 @@ public class RelationalTable implements Table, SupportsPartitions {
   @VisibleForTesting
   @SneakyThrows // Encode charset is fixed to UTF-8, so this is safe.
   protected static String formatPartitionRequestPath(String prefix, String partitionName) {
-    return prefix + "/" + URLEncoder.encode(partitionName, "UTF-8");
+    return prefix + "/" + RESTUtils.encodeString(partitionName);
   }
 }

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalTable.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalTable.java
@@ -24,8 +24,8 @@ import com.datastrato.gravitino.rel.expressions.sorts.SortOrder;
 import com.datastrato.gravitino.rel.expressions.transforms.Transform;
 import com.datastrato.gravitino.rel.indexes.Index;
 import com.datastrato.gravitino.rel.partitions.Partition;
-import com.datastrato.gravitino.rest.RESTUtils;
 import com.google.common.annotations.VisibleForTesting;
+import java.net.URLEncoder;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -247,6 +247,6 @@ public class RelationalTable implements Table, SupportsPartitions {
   @VisibleForTesting
   @SneakyThrows // Encode charset is fixed to UTF-8, so this is safe.
   protected static String formatPartitionRequestPath(String prefix, String partitionName) {
-    return prefix + "/" + RESTUtils.encodeString(partitionName);
+    return prefix + "/" + URLEncoder.encode(partitionName, "UTF-8");
   }
 }

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestBase.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestBase.java
@@ -77,4 +77,8 @@ public abstract class TestBase {
       throws JsonProcessingException {
     buildMockResource(method, path, Collections.emptyMap(), reqBody, respBody, statusCode);
   }
+
+  protected static String withSlash(String path) {
+    return "/" + path;
+  }
 }

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestFilesetCatalog.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestFilesetCatalog.java
@@ -1,0 +1,383 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.client;
+
+import static org.apache.hc.core5.http.HttpStatus.SC_CONFLICT;
+import static org.apache.hc.core5.http.HttpStatus.SC_NOT_FOUND;
+import static org.apache.hc.core5.http.HttpStatus.SC_OK;
+import static org.apache.hc.core5.http.HttpStatus.SC_SERVER_ERROR;
+
+import com.datastrato.gravitino.Catalog;
+import com.datastrato.gravitino.NameIdentifier;
+import com.datastrato.gravitino.dto.AuditDTO;
+import com.datastrato.gravitino.dto.CatalogDTO;
+import com.datastrato.gravitino.dto.file.FilesetDTO;
+import com.datastrato.gravitino.dto.requests.CatalogCreateRequest;
+import com.datastrato.gravitino.dto.requests.FilesetCreateRequest;
+import com.datastrato.gravitino.dto.requests.FilesetUpdateRequest;
+import com.datastrato.gravitino.dto.requests.FilesetUpdatesRequest;
+import com.datastrato.gravitino.dto.responses.CatalogResponse;
+import com.datastrato.gravitino.dto.responses.DropResponse;
+import com.datastrato.gravitino.dto.responses.EntityListResponse;
+import com.datastrato.gravitino.dto.responses.ErrorResponse;
+import com.datastrato.gravitino.dto.responses.FilesetResponse;
+import com.datastrato.gravitino.exceptions.AlreadyExistsException;
+import com.datastrato.gravitino.exceptions.FilesetAlreadyExistsException;
+import com.datastrato.gravitino.exceptions.NoSuchFilesetException;
+import com.datastrato.gravitino.exceptions.NoSuchSchemaException;
+import com.datastrato.gravitino.exceptions.NotFoundException;
+import com.datastrato.gravitino.file.Fileset;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.nio.file.NoSuchFileException;
+import java.time.Instant;
+import java.util.Map;
+import org.apache.hc.core5.http.Method;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class TestFilesetCatalog extends TestBase {
+
+  protected static Catalog catalog;
+
+  private static GravitinoMetaLake metalake;
+
+  protected static final String metalakeName = "testMetalake";
+
+  protected static final String catalogName = "testCatalog";
+
+  private static final String provider = "test";
+
+  @BeforeAll
+  public static void setUp() throws Exception {
+    TestBase.setUp();
+
+    metalake = TestGravitinoMetalake.createMetalake(client, metalakeName);
+
+    CatalogDTO mockCatalog =
+        new CatalogDTO.Builder()
+            .withName(catalogName)
+            .withType(CatalogDTO.Type.FILESET)
+            .withProvider(provider)
+            .withComment("comment")
+            .withProperties(ImmutableMap.of("k1", "k2"))
+            .withAudit(
+                new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
+            .build();
+
+    CatalogCreateRequest catalogCreateRequest =
+        new CatalogCreateRequest(
+            catalogName, CatalogDTO.Type.FILESET, provider, "comment", ImmutableMap.of("k1", "k2"));
+    CatalogResponse catalogResponse = new CatalogResponse(mockCatalog);
+    buildMockResource(
+        Method.POST,
+        "/api/metalakes/" + metalakeName + "/catalogs",
+        catalogCreateRequest,
+        catalogResponse,
+        SC_OK);
+
+    catalog =
+        metalake.createCatalog(
+            NameIdentifier.of(metalakeName, catalogName),
+            CatalogDTO.Type.FILESET,
+            provider,
+            "comment",
+            ImmutableMap.of("k1", "k2"));
+  }
+
+  @Test
+  public void testListFileset() throws JsonProcessingException {
+    NameIdentifier fileset1 = NameIdentifier.of(metalakeName, catalogName, "schema1", "fileset1");
+    NameIdentifier fileset2 = NameIdentifier.of(metalakeName, catalogName, "schema1", "fileset2");
+    String filesetPath = withSlash(FilesetCatalog.formatFilesetRequestPath(fileset1.namespace()));
+
+    EntityListResponse resp = new EntityListResponse(new NameIdentifier[] {fileset1, fileset2});
+    buildMockResource(Method.GET, filesetPath, null, resp, SC_OK);
+    NameIdentifier[] filesets = catalog.asFilesetCatalog().listFilesets(fileset1.namespace());
+
+    Assertions.assertEquals(2, filesets.length);
+    Assertions.assertEquals(fileset1, filesets[0]);
+    Assertions.assertEquals(fileset2, filesets[1]);
+
+    // Throw schema not found exception
+    ErrorResponse errResp =
+        ErrorResponse.notFound(NoSuchSchemaException.class.getSimpleName(), "schema not found");
+    buildMockResource(Method.GET, filesetPath, null, errResp, SC_NOT_FOUND);
+    Assertions.assertThrows(
+        NoSuchSchemaException.class,
+        () -> catalog.asFilesetCatalog().listFilesets(fileset1.namespace()),
+        "schema not found");
+
+    // Throw fileset not found exception
+    ErrorResponse errResp1 =
+        ErrorResponse.notFound(NoSuchFileException.class.getSimpleName(), "fileset not found");
+    buildMockResource(Method.GET, filesetPath, null, errResp1, SC_NOT_FOUND);
+    Assertions.assertThrows(
+        NotFoundException.class,
+        () -> catalog.asFilesetCatalog().listFilesets(fileset1.namespace()),
+        "fileset not found");
+
+    // Throw Runtime exception
+    ErrorResponse errResp2 = ErrorResponse.internalError("internal error");
+    buildMockResource(Method.GET, filesetPath, null, errResp2, SC_SERVER_ERROR);
+    Assertions.assertThrows(
+        RuntimeException.class,
+        () -> catalog.asFilesetCatalog().listFilesets(fileset1.namespace()),
+        "internal error");
+  }
+
+  @Test
+  public void testLoadFileset() throws JsonProcessingException {
+    NameIdentifier fileset = NameIdentifier.of(metalakeName, catalogName, "schema1", "fileset1");
+    String filesetPath =
+        withSlash(FilesetCatalog.formatFilesetRequestPath(fileset.namespace()) + "/fileset1");
+
+    FilesetDTO mockFileset =
+        mockFilesetDTO(
+            fileset.name(),
+            Fileset.Type.MANAGED,
+            "mock comment",
+            "mock location",
+            ImmutableMap.of("k1", "v1"));
+    FilesetResponse resp = new FilesetResponse(mockFileset);
+    buildMockResource(Method.GET, filesetPath, null, resp, SC_OK);
+    Fileset loadedFileset = catalog.asFilesetCatalog().loadFileset(fileset);
+    Assertions.assertNotNull(loadedFileset);
+    assertFileset(mockFileset, loadedFileset);
+
+    // Throw schema not found exception
+    ErrorResponse errResp =
+        ErrorResponse.notFound(NoSuchSchemaException.class.getSimpleName(), "schema not found");
+    buildMockResource(Method.GET, filesetPath, null, errResp, SC_NOT_FOUND);
+    Assertions.assertThrows(
+        NoSuchSchemaException.class,
+        () -> catalog.asFilesetCatalog().loadFileset(fileset),
+        "schema not found");
+
+    ErrorResponse errResp1 =
+        ErrorResponse.notFound(NotFoundException.class.getSimpleName(), "fileset not found");
+    buildMockResource(Method.GET, filesetPath, null, errResp1, SC_NOT_FOUND);
+    Assertions.assertThrows(
+        NotFoundException.class,
+        () -> catalog.asFilesetCatalog().loadFileset(fileset),
+        "fileset not found");
+
+    ErrorResponse errResp2 = ErrorResponse.internalError("internal error");
+    buildMockResource(Method.GET, filesetPath, null, errResp2, SC_SERVER_ERROR);
+    Assertions.assertThrows(
+        RuntimeException.class,
+        () -> catalog.asFilesetCatalog().loadFileset(fileset),
+        "internal error");
+  }
+
+  @Test
+  public void testCreateFileset() throws JsonProcessingException {
+    NameIdentifier fileset = NameIdentifier.of(metalakeName, catalogName, "schema1", "fileset1");
+    String filesetPath = withSlash(FilesetCatalog.formatFilesetRequestPath(fileset.namespace()));
+
+    FilesetDTO mockFileset =
+        mockFilesetDTO(
+            fileset.name(),
+            Fileset.Type.MANAGED,
+            "mock comment",
+            "mock location",
+            ImmutableMap.of("k1", "v1"));
+    FilesetCreateRequest req =
+        FilesetCreateRequest.builder()
+            .name(fileset.name())
+            .type(Fileset.Type.MANAGED)
+            .comment("mock comment")
+            .storageLocation("mock location")
+            .properties(ImmutableMap.of("k1", "v1"))
+            .build();
+    FilesetResponse resp = new FilesetResponse(mockFileset);
+    buildMockResource(Method.POST, filesetPath, req, resp, SC_OK);
+    Fileset loadedFileset =
+        catalog
+            .asFilesetCatalog()
+            .createFileset(
+                fileset,
+                "mock comment",
+                Fileset.Type.MANAGED,
+                "mock location",
+                ImmutableMap.of("k1", "v1"));
+    Assertions.assertNotNull(loadedFileset);
+    assertFileset(mockFileset, loadedFileset);
+
+    // Test FilesetAlreadyExistsException
+    ErrorResponse errResp =
+        ErrorResponse.alreadyExists(
+            FilesetAlreadyExistsException.class.getSimpleName(), "fileset already exists");
+    buildMockResource(Method.POST, filesetPath, req, errResp, SC_CONFLICT);
+    Assertions.assertThrows(
+        AlreadyExistsException.class,
+        () ->
+            catalog
+                .asFilesetCatalog()
+                .createFileset(
+                    fileset,
+                    "mock comment",
+                    Fileset.Type.MANAGED,
+                    "mock location",
+                    ImmutableMap.of("k1", "v1")),
+        "fileset already exists");
+
+    // Test RuntimeException
+    ErrorResponse errResp1 = ErrorResponse.internalError("internal error");
+    buildMockResource(Method.POST, filesetPath, req, errResp1, SC_CONFLICT);
+    Assertions.assertThrows(
+        RuntimeException.class,
+        () ->
+            catalog
+                .asFilesetCatalog()
+                .createFileset(
+                    fileset,
+                    "mock comment",
+                    Fileset.Type.MANAGED,
+                    "mock location",
+                    ImmutableMap.of("k1", "v1")),
+        "internal error");
+  }
+
+  @Test
+  public void testDropFileset() throws JsonProcessingException {
+    NameIdentifier fileset = NameIdentifier.of(metalakeName, catalogName, "schema1", "fileset1");
+    String filesetPath =
+        withSlash(FilesetCatalog.formatFilesetRequestPath(fileset.namespace()) + "/fileset1");
+
+    DropResponse resp = new DropResponse(true);
+    buildMockResource(Method.DELETE, filesetPath, null, resp, SC_OK);
+    boolean dropped = catalog.asFilesetCatalog().dropFileset(fileset);
+    Assertions.assertTrue(dropped);
+
+    DropResponse resp1 = new DropResponse(false);
+    buildMockResource(Method.DELETE, filesetPath, null, resp1, SC_OK);
+    boolean dropped1 = catalog.asFilesetCatalog().dropFileset(fileset);
+    Assertions.assertFalse(dropped1);
+
+    // Test RuntimeException
+    ErrorResponse errResp = ErrorResponse.internalError("internal error");
+    buildMockResource(Method.DELETE, filesetPath, null, errResp, SC_SERVER_ERROR);
+    Assertions.assertThrows(
+        RuntimeException.class,
+        () -> catalog.asFilesetCatalog().dropFileset(fileset),
+        "internal error");
+  }
+
+  @Test
+  public void testAlterFileset() throws JsonProcessingException {
+    NameIdentifier fileset = NameIdentifier.of(metalakeName, catalogName, "schema1", "fileset1");
+    String filesetPath =
+        withSlash(FilesetCatalog.formatFilesetRequestPath(fileset.namespace()) + "/fileset1");
+
+    // Test alter fileset name
+    FilesetUpdateRequest req = new FilesetUpdateRequest.RenameFilesetRequest("new name");
+    FilesetDTO mockFileset =
+        mockFilesetDTO(
+            "new name",
+            Fileset.Type.MANAGED,
+            "mock comment",
+            "mock location",
+            ImmutableMap.of("k1", "v1"));
+    FilesetResponse resp = new FilesetResponse(mockFileset);
+    buildMockResource(
+        Method.PUT, filesetPath, new FilesetUpdatesRequest(ImmutableList.of(req)), resp, SC_OK);
+    Fileset res = catalog.asFilesetCatalog().alterFileset(fileset, req.filesetChange());
+    assertFileset(mockFileset, res);
+
+    // Test alter fileset comment
+    FilesetUpdateRequest req1 = new FilesetUpdateRequest.UpdateFilesetCommentRequest("new comment");
+    FilesetDTO mockFileset1 =
+        mockFilesetDTO(
+            "new name",
+            Fileset.Type.MANAGED,
+            "new comment",
+            "mock location",
+            ImmutableMap.of("k1", "v1"));
+    FilesetResponse resp1 = new FilesetResponse(mockFileset1);
+    buildMockResource(
+        Method.PUT, filesetPath, new FilesetUpdatesRequest(ImmutableList.of(req1)), resp1, SC_OK);
+    Fileset res1 = catalog.asFilesetCatalog().alterFileset(fileset, req1.filesetChange());
+    assertFileset(mockFileset1, res1);
+
+    // Test set fileset properties
+    FilesetUpdateRequest req2 = new FilesetUpdateRequest.SetFilesetPropertiesRequest("k2", "v2");
+    FilesetDTO mockFileset2 =
+        mockFilesetDTO(
+            "new name",
+            Fileset.Type.MANAGED,
+            "mock comment",
+            "mock location",
+            ImmutableMap.of("k1", "v1", "k2", "v2"));
+    FilesetResponse resp2 = new FilesetResponse(mockFileset2);
+    buildMockResource(
+        Method.PUT, filesetPath, new FilesetUpdatesRequest(ImmutableList.of(req2)), resp2, SC_OK);
+    Fileset res2 = catalog.asFilesetCatalog().alterFileset(fileset, req2.filesetChange());
+    assertFileset(mockFileset2, res2);
+
+    // Test remove fileset properties
+    FilesetUpdateRequest req3 = new FilesetUpdateRequest.RemoveFilesetPropertiesRequest("k1");
+    FilesetDTO mockFileset3 =
+        mockFilesetDTO(
+            "new name", Fileset.Type.MANAGED, "mock comment", "mock location", ImmutableMap.of());
+    FilesetResponse resp3 = new FilesetResponse(mockFileset3);
+    buildMockResource(
+        Method.PUT, filesetPath, new FilesetUpdatesRequest(ImmutableList.of(req3)), resp3, SC_OK);
+    Fileset res3 = catalog.asFilesetCatalog().alterFileset(fileset, req3.filesetChange());
+    assertFileset(mockFileset3, res3);
+
+    // Test NoSuchFilesetException
+    ErrorResponse errResp =
+        ErrorResponse.notFound(NoSuchFilesetException.class.getSimpleName(), "fileset not found");
+    buildMockResource(
+        Method.PUT,
+        filesetPath,
+        new FilesetUpdatesRequest(ImmutableList.of(req)),
+        errResp,
+        SC_NOT_FOUND);
+    Assertions.assertThrows(
+        NoSuchFilesetException.class,
+        () -> catalog.asFilesetCatalog().alterFileset(fileset, req.filesetChange()),
+        "fileset not found");
+
+    // Test RuntimeException
+    ErrorResponse errResp1 = ErrorResponse.internalError("internal error");
+    buildMockResource(
+        Method.PUT,
+        filesetPath,
+        new FilesetUpdatesRequest(ImmutableList.of(req)),
+        errResp1,
+        SC_SERVER_ERROR);
+    Assertions.assertThrows(
+        RuntimeException.class,
+        () -> catalog.asFilesetCatalog().alterFileset(fileset, req.filesetChange()),
+        "internal error");
+  }
+
+  private FilesetDTO mockFilesetDTO(
+      String name,
+      Fileset.Type type,
+      String comment,
+      String location,
+      Map<String, String> properties) {
+    return FilesetDTO.builder()
+        .name(name)
+        .type(type)
+        .comment(comment)
+        .storageLocation(location)
+        .properties(properties)
+        .audit(new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
+        .build();
+  }
+
+  private void assertFileset(FilesetDTO expected, Fileset actual) {
+    Assertions.assertEquals(expected.name(), actual.name());
+    Assertions.assertEquals(expected.comment(), actual.comment());
+    Assertions.assertEquals(expected.type(), actual.type());
+    Assertions.assertEquals(expected.properties(), actual.properties());
+  }
+}

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestGravitinoMetalake.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestGravitinoMetalake.java
@@ -126,7 +126,7 @@ public class TestGravitinoMetalake extends TestBase {
         new CatalogDTO.Builder()
             .withName("mock")
             .withComment("comment")
-            .withType(Catalog.Type.FILE)
+            .withType(Catalog.Type.STREAM)
             .withProvider("test")
             .withAudit(
                 new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
@@ -191,14 +191,14 @@ public class TestGravitinoMetalake extends TestBase {
         new CatalogDTO.Builder()
             .withName("mock")
             .withComment("comment")
-            .withType(Catalog.Type.FILE)
+            .withType(Catalog.Type.STREAM)
             .withProvider("test")
             .withAudit(
                 new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
             .build();
     CatalogCreateRequest req1 =
         new CatalogCreateRequest(
-            catalogName, Catalog.Type.FILE, provider, "comment", Collections.emptyMap());
+            catalogName, Catalog.Type.STREAM, provider, "comment", Collections.emptyMap());
     CatalogResponse resp1 = new CatalogResponse(mockCatalog1);
     buildMockResource(Method.POST, path, req1, resp1, HttpStatus.SC_OK);
     Assertions.assertThrows(
@@ -206,7 +206,7 @@ public class TestGravitinoMetalake extends TestBase {
         () ->
             metalake.createCatalog(
                 NameIdentifier.of(metalakeName, catalogName),
-                Catalog.Type.FILE,
+                Catalog.Type.STREAM,
                 provider,
                 "comment",
                 Collections.emptyMap()));

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalCatalog.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalCatalog.java
@@ -1121,10 +1121,6 @@ public class TestRelationalCatalog extends TestBase {
     Assertions.assertEquals(updatedSchema.properties(), alteredSchema.properties());
   }
 
-  protected static String withSlash(String path) {
-    return "/" + path;
-  }
-
   protected static SchemaDTO createMockSchema(
       String name, String comment, Map<String, String> props) {
     return new SchemaDTO.Builder()


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Add Java client support for fileset


### Why are the changes needed?

Fix: #1838 

### Does this PR introduce _any_ user-facing change?
- Add Java client support for fileset

### How was this patch tested?

add ut. `com.datastrato.gravitino.client.TestFilesetCatalog`
