### PR TITLE
[#2042] improvement(doc): Unify the style of configuration options

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -146,11 +146,11 @@ You can follow the steps to set up an OAuth mode Gravitino server.
 6. You can refer to the [Configurations](gravitino-server-config.md) and append the configurations to the conf/gravitino.conf.
 
 ```text
-gravitino.authenticator oauth
-gravitino.authenticator.oauth.serviceAudience test
-gravitino.authenticator.oauth.defaultSignKey <the default signing key>
-gravitino.authenticator.oauth.tokenPath /oauth2/token
-gravitino.authenticator.oauth.serverUri http://localhost:8177
+gravitino.authenticator = oauth
+gravitino.authenticator.oauth.serviceAudience = test
+gravitino.authenticator.oauth.defaultSignKey = <the default signing key>
+gravitino.authenticator.oauth.tokenPath = /oauth2/token
+gravitino.authenticator.oauth.serverUri = http://localhost:8177
 ```
 
 7. Open [the URL of Gravitino server](http://localhost:8090) and login in with clientId `test`, clientSecret `test`, and scope `test`.
@@ -258,11 +258,11 @@ Configuration doesn't support resolving environment variables, so you should rep
 Then, You can start the Gravitino server.
 
 ```text
-gravitino.server.webserver.host localhost
-gravitino.server.webserver.enableHttps true
-gravitino.server.webserver.keyStorePath ${JAVA_HOME}/localhost.jks
-gravitino.server.webserver.keyStorePassword localhost
-gravitino.server.webserver.managerPassword localhost
+gravitino.server.webserver.host = localhost
+gravitino.server.webserver.enableHttps = true
+gravitino.server.webserver.keyStorePath = ${JAVA_HOME}/localhost.jks
+gravitino.server.webserver.keyStorePassword = localhost
+gravitino.server.webserver.managerPassword = localhost
 ```
 
 6. Request the Gravitino server


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Unify the style of configuration options

### Why are the changes needed?

Fix: #2042 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Just doc.