### PR TITLE
[MINOR] docs: Adjust the position of the example to fit the Docusaurus OpenAPI plugin

### DIFF
--- a/docs/open-api/partitions.yaml
+++ b/docs/open-api/partitions.yaml
@@ -30,6 +30,11 @@ paths:
                 oneOf:
                   - $ref: "#/components/schemas/PartitionNameListResponse"
                   - $ref: "#/components/schemas/PartitionListResponse"
+              examples:
+                PartitionNameListResponse:
+                  $ref: "#/components/examples/PartitionNameListResponse"
+                PartitionListResponse:
+                  $ref: "#/components/examples/PartitionListResponse"
         "400":
           $ref: "./openapi.yaml#/components/responses/BadRequestErrorResponse"
         "5xx":
@@ -159,9 +164,6 @@ components:
           description: A list of partition names
           items:
             type: string
-      example:
-        PartitionNameListResponse:
-          $ref: "#/components/examples/PartitionNameListResponse"
 
     PartitionListResponse:
       type: object
@@ -178,9 +180,6 @@ components:
           description: A list of partitions
           items:
             $ref: "#/components/schemas/PartitionSpec"
-      example:
-        PartitionListResponse:
-          $ref: "#/components/examples/PartitionListResponse"
 
 
     Properties:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adjust the position of the example to fit the Docusaurus OpenAPI plugin

### Why are the changes needed?

There seems a bug with Docusaurus OpenAPI plugin:

<img width="1421" alt="image" src="https://github.com/datastrato/gravitino/assets/24897598/fc272445-0ef1-40d9-a3ee-b67eb16aa1e7">


### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

locally tested
