### PR TITLE
[#2052] fix(IT): improve the timeout handle of web driver

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/AbstractWebIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/AbstractWebIT.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
 public class AbstractWebIT extends AbstractIT {
   protected static final Logger LOG = LoggerFactory.getLogger(AbstractWebIT.class);
   protected static WebDriver driver;
-  protected static final long MAX_IMPLICIT_WAIT = 30;
+  protected static final long MAX_IMPLICIT_WAIT = 60;
 
   @BeforeAll
   public static void startUp() {

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/WebDriverManager.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/WebDriverManager.java
@@ -27,31 +27,19 @@ public class WebDriverManager {
     driver.get(url);
 
     // wait for webpage load compiled.
-    long start = System.currentTimeMillis();
-    boolean loaded = false;
-    while (System.currentTimeMillis() - start < 60 * 1000) {
-      try {
-        (new WebDriverWait(driver, 10))
-            .until(
-                new ExpectedCondition<Boolean>() {
-                  @Override
-                  public Boolean apply(WebDriver d) {
-                    String gravitinoVersion = d.findElement(By.id("gravitino_version")).getText();
-                    String projectVersion = System.getenv("PROJECT_VERSION");
-                    return projectVersion.equalsIgnoreCase(gravitinoVersion);
-                  }
-                });
-        loaded = true;
-        break;
-      } catch (TimeoutException e) {
-        LOG.info("Exception in WebDriverManager while WebDriverWait ", e);
-        driver.navigate().to(url);
-      }
+    try {
+      (new WebDriverWait(driver, AbstractWebIT.MAX_IMPLICIT_WAIT))
+          .until(
+              d -> {
+                String gravitinoVersion = d.findElement(By.id("gravitino_version")).getText();
+                String projectVersion = System.getenv("PROJECT_VERSION");
+                return projectVersion.equalsIgnoreCase(gravitinoVersion);
+              });
+    } catch (TimeoutException e) {
+      LOG.info("Exception in WebDriverManager while WebDriverWait ", e);
+      throw new RuntimeException(e);
     }
 
-    if (!loaded) {
-      throw new RuntimeException("Webpage not loaded in 60 seconds.");
-    }
     Dimension d = new Dimension(1440, 1080);
     driver.manage().window().setSize(d);
 

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/WebDriverManager.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/WebDriverManager.java
@@ -9,7 +9,6 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
### What changes were proposed in this pull request?
really wait 60s to load the web page

### Why are the changes needed?
in the form implement, if load failed in 10s, will try load again using `driver.navigate().to(url);`, seems unnecessary, we could wait 60s to load page.

```
while (System.currentTimeMillis() - start < 60 * 1000) {
      try {
        (new WebDriverWait(driver, 10))
            .until(
                new ExpectedCondition<Boolean>() {
                  @Override
                  public Boolean apply(WebDriver d) {
                    String gravitinoVersion = d.findElement(By.id("gravitino_version")).getText();
                    String projectVersion = System.getenv("PROJECT_VERSION");
                    return projectVersion.equalsIgnoreCase(gravitinoVersion);
                  }
                });
        loaded = true;
        break;
      } catch (TimeoutException e) {
        LOG.info("Exception in WebDriverManager while WebDriverWait ", e);
        driver.navigate().to(url);
      }
}

```


Fix: #2052 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

