### PR TITLE
[#1969] Improvement: In all gradle files group dependancies by their destination

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
 
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
-  
+
   testRuntimeOnly(libs.junit.jupiter.engine)
 }
 

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
 
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
+  
   testRuntimeOnly(libs.junit.jupiter.engine)
 }
 

--- a/catalogs/catalog-hadoop/build.gradle.kts
+++ b/catalogs/catalog-hadoop/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
   testImplementation(libs.mockito.core)
-  
+
   testRuntimeOnly(libs.junit.jupiter.engine)
 }
 

--- a/catalogs/catalog-hadoop/build.gradle.kts
+++ b/catalogs/catalog-hadoop/build.gradle.kts
@@ -22,8 +22,9 @@ dependencies {
 
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
-  testRuntimeOnly(libs.junit.jupiter.engine)
   testImplementation(libs.mockito.core)
+  
+  testRuntimeOnly(libs.junit.jupiter.engine)
 }
 
 tasks {

--- a/catalogs/catalog-hive/build.gradle.kts
+++ b/catalogs/catalog-hive/build.gradle.kts
@@ -75,7 +75,7 @@ dependencies {
 
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.mockito.core)
-  
+
   testRuntimeOnly(libs.junit.jupiter.engine)
 }
 

--- a/catalogs/catalog-hive/build.gradle.kts
+++ b/catalogs/catalog-hive/build.gradle.kts
@@ -74,8 +74,9 @@ dependencies {
   implementation(libs.caffeine)
 
   testImplementation(libs.junit.jupiter.api)
-  testRuntimeOnly(libs.junit.jupiter.engine)
   testImplementation(libs.mockito.core)
+  
+  testRuntimeOnly(libs.junit.jupiter.engine)
 }
 
 tasks {

--- a/catalogs/catalog-jdbc-common/build.gradle.kts
+++ b/catalogs/catalog-jdbc-common/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
   testImplementation(libs.sqlite.jdbc)
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
-  
+
   testRuntimeOnly(libs.junit.jupiter.engine)
   compileOnly(libs.lombok)
   annotationProcessor(libs.lombok)

--- a/catalogs/catalog-jdbc-common/build.gradle.kts
+++ b/catalogs/catalog-jdbc-common/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
   testImplementation(libs.sqlite.jdbc)
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
+  
   testRuntimeOnly(libs.junit.jupiter.engine)
   compileOnly(libs.lombok)
   annotationProcessor(libs.lombok)

--- a/catalogs/catalog-jdbc-mysql/build.gradle.kts
+++ b/catalogs/catalog-jdbc-mysql/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
   testImplementation(libs.commons.lang3)
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
-  
+
   testRuntimeOnly(libs.junit.jupiter.engine)
 }
 

--- a/catalogs/catalog-jdbc-mysql/build.gradle.kts
+++ b/catalogs/catalog-jdbc-mysql/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
   testImplementation(libs.commons.lang3)
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
+  
   testRuntimeOnly(libs.junit.jupiter.engine)
 }
 

--- a/catalogs/catalog-jdbc-postgresql/build.gradle.kts
+++ b/catalogs/catalog-jdbc-postgresql/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
   testImplementation(libs.commons.lang3)
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
-  
+
   testRuntimeOnly(libs.junit.jupiter.engine)
 }
 

--- a/catalogs/catalog-jdbc-postgresql/build.gradle.kts
+++ b/catalogs/catalog-jdbc-postgresql/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
   testImplementation(libs.commons.lang3)
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
+  
   testRuntimeOnly(libs.junit.jupiter.engine)
 }
 

--- a/catalogs/catalog-lakehouse-iceberg/build.gradle.kts
+++ b/catalogs/catalog-lakehouse-iceberg/build.gradle.kts
@@ -73,7 +73,7 @@ dependencies {
   testImplementation(libs.jersey.test.framework.provider.jetty) {
     exclude(group = "org.junit.jupiter")
   }
-  
+
   testRuntimeOnly(libs.junit.jupiter.engine)
 }
 

--- a/catalogs/catalog-lakehouse-iceberg/build.gradle.kts
+++ b/catalogs/catalog-lakehouse-iceberg/build.gradle.kts
@@ -66,7 +66,6 @@ dependencies {
 
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
-  testRuntimeOnly(libs.junit.jupiter.engine)
   testImplementation(libs.mockito.core)
   testImplementation(libs.jersey.test.framework.core) {
     exclude(group = "org.junit.jupiter")
@@ -74,6 +73,8 @@ dependencies {
   testImplementation(libs.jersey.test.framework.provider.jetty) {
     exclude(group = "org.junit.jupiter")
   }
+  
+  testRuntimeOnly(libs.junit.jupiter.engine)
 }
 
 tasks {

--- a/clients/client-java/build.gradle.kts
+++ b/clients/client-java/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
   testImplementation(libs.mockserver.netty)
   testImplementation(libs.mockserver.client.java)
   testImplementation(libs.bundles.jwt)
-  
+
   testRuntimeOnly(libs.junit.jupiter.engine)
 }
 

--- a/clients/client-java/build.gradle.kts
+++ b/clients/client-java/build.gradle.kts
@@ -31,11 +31,12 @@ dependencies {
 
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
-  testRuntimeOnly(libs.junit.jupiter.engine)
   testImplementation(libs.mockito.core)
   testImplementation(libs.mockserver.netty)
   testImplementation(libs.mockserver.client.java)
   testImplementation(libs.bundles.jwt)
+  
+  testRuntimeOnly(libs.junit.jupiter.engine)
 }
 
 tasks.build {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -28,6 +28,6 @@ dependencies {
 
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
-  
+
   testRuntimeOnly(libs.junit.jupiter.engine)
 }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -28,5 +28,6 @@ dependencies {
 
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
+  
   testRuntimeOnly(libs.junit.jupiter.engine)
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -33,6 +33,6 @@ dependencies {
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
   testImplementation(libs.mockito.core)
-  
+
   testRuntimeOnly(libs.junit.jupiter.engine)
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
 
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
-  testRuntimeOnly(libs.junit.jupiter.engine)
   testImplementation(libs.mockito.core)
+  
+  testRuntimeOnly(libs.junit.jupiter.engine)
 }

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -126,9 +126,9 @@ dependencies {
   testImplementation(libs.minikdc) {
     exclude("org.apache.directory.api", "api-ldap-schema-data")
   }
-  
+
   implementation(libs.commons.cli)
-  
+
   testRuntimeOnly(libs.junit.jupiter.engine)
 }
 

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -126,6 +126,7 @@ dependencies {
   testImplementation(libs.minikdc) {
     exclude("org.apache.directory.api", "api-ldap-schema-data")
   }
+  
   implementation(libs.commons.cli)
   
   testRuntimeOnly(libs.junit.jupiter.engine)

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -94,7 +94,6 @@ dependencies {
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
   testImplementation(libs.httpclient5)
-  testRuntimeOnly(libs.junit.jupiter.engine)
   testImplementation(libs.mockito.core)
   testImplementation(libs.bundles.log4j)
   testImplementation(libs.iceberg.spark.runtime)
@@ -122,12 +121,14 @@ dependencies {
   testImplementation(libs.okhttp3.loginterceptor)
   testImplementation(libs.mysql.driver)
   testImplementation(libs.postgresql.driver)
-  implementation(libs.commons.cli)
   testImplementation(libs.selenium)
   testImplementation(libs.rauschig)
   testImplementation(libs.minikdc) {
     exclude("org.apache.directory.api", "api-ldap-schema-data")
   }
+  implementation(libs.commons.cli)
+  
+  testRuntimeOnly(libs.junit.jupiter.engine)
 }
 
 /* Optimizing integration test execution conditions */

--- a/server-common/build.gradle.kts
+++ b/server-common/build.gradle.kts
@@ -34,6 +34,6 @@ dependencies {
   testImplementation(libs.minikdc) {
     exclude("org.apache.directory.api", "api-ldap-schema-data")
   }
-  
+
   testRuntimeOnly(libs.junit.jupiter.engine)
 }

--- a/server-common/build.gradle.kts
+++ b/server-common/build.gradle.kts
@@ -29,10 +29,11 @@ dependencies {
 
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
-  testRuntimeOnly(libs.junit.jupiter.engine)
   testImplementation(libs.mockito.core)
   testImplementation(libs.commons.io)
   testImplementation(libs.minikdc) {
     exclude("org.apache.directory.api", "api-ldap-schema-data")
   }
+  
+  testRuntimeOnly(libs.junit.jupiter.engine)
 }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -47,7 +47,7 @@ dependencies {
   testImplementation(libs.jersey.test.framework.provider.jetty) {
     exclude(group = "org.junit.jupiter")
   }
-  
+
   testRuntimeOnly(libs.junit.jupiter.engine)
 }
 

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -39,15 +39,16 @@ dependencies {
 
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
-  testRuntimeOnly(libs.junit.jupiter.engine)
+  testImplementation(libs.mockito.core)
+  testImplementation(libs.commons.io)
   testImplementation(libs.jersey.test.framework.core) {
     exclude(group = "org.junit.jupiter")
   }
   testImplementation(libs.jersey.test.framework.provider.jetty) {
     exclude(group = "org.junit.jupiter")
   }
-  testImplementation(libs.mockito.core)
-  testImplementation(libs.commons.io)
+  
+  testRuntimeOnly(libs.junit.jupiter.engine)
 }
 
 fun getGitCommitId(): String {


### PR DESCRIPTION
…destination #1969

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Group dependencies by their destination.

### Why are the changes needed?

Change to group dependencies by their destination.

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?
