### PR TITLE
[#2035] fix(trino-connector): Fix type conversion about type `varhcar` and `char` for PG catalog

### DIFF
--- a/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-postgresql/00000_create_table.sql
+++ b/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-postgresql/00000_create_table.sql
@@ -5,6 +5,35 @@ CREATE TABLE "test.gt_postgresql".gt_db1.tb01 (
     salary int
 );
 
+show create table "test.gt_postgresql".gt_db1.tb01;
+
+CREATE TABLE "test.gt_postgresql".gt_db1.tb02 (
+    name varchar(100),
+    salary int
+);
+
+show create table "test.gt_postgresql".gt_db1.tb02;
+
+CREATE TABLE "test.gt_postgresql".gt_db1.tb03 (
+    name char(100),
+    salary int
+);
+
+show create table "test.gt_postgresql".gt_db1.tb03;
+
+CREATE TABLE "test.gt_postgresql".gt_db1.tb04 (
+    name char,
+    salary int
+);
+
+show create table "test.gt_postgresql".gt_db1.tb04;
+
 drop table "test.gt_postgresql".gt_db1.tb01;
+
+drop table "test.gt_postgresql".gt_db1.tb02;
+
+drop table "test.gt_postgresql".gt_db1.tb03;
+
+drop table "test.gt_postgresql".gt_db1.tb04;
 
 drop schema "test.gt_postgresql".gt_db1;

--- a/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-postgresql/00000_create_table.txt
+++ b/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-postgresql/00000_create_table.txt
@@ -2,6 +2,42 @@ CREATE SCHEMA
 
 CREATE TABLE
 
+"CREATE TABLE ""test.gt_postgresql"".gt_db1.tb01 (
+   name varchar(10485760),
+   salary integer
+)
+COMMENT ''"
+
+CREATE TABLE
+
+"CREATE TABLE ""test.gt_postgresql"".gt_db1.tb02 (
+   name varchar(100),
+   salary integer
+)
+COMMENT ''"
+
+CREATE TABLE
+
+"CREATE TABLE ""test.gt_postgresql"".gt_db1.tb03 (
+   name char(100),
+   salary integer
+)
+COMMENT ''"
+
+CREATE TABLE
+
+"CREATE TABLE ""test.gt_postgresql"".gt_db1.tb04 (
+   name char(1),
+   salary integer
+)
+COMMENT ''"
+
+DROP TABLE
+
+DROP TABLE
+
+DROP TABLE
+
 DROP TABLE
 
 DROP SCHEMA

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/jdbc/postgresql/PostgreSQLDataTypeTransformer.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/jdbc/postgresql/PostgreSQLDataTypeTransformer.java
@@ -6,19 +6,20 @@
 package com.datastrato.gravitino.trino.connector.catalog.jdbc.postgresql;
 
 import com.datastrato.gravitino.rel.types.Type;
-import com.datastrato.gravitino.rel.types.Type.Name;
 import com.datastrato.gravitino.rel.types.Types;
 import com.datastrato.gravitino.trino.connector.util.GeneralDataTypeTransformer;
 
 /** Type transformer between PostgreSQL and Trino */
 public class PostgreSQLDataTypeTransformer extends GeneralDataTypeTransformer {
 
+  private static final int MAX_VARCHAR_LENGTH_FOR_PG = 10485760;
+
   @Override
   public Type getGravitinoType(io.trino.spi.type.Type type) {
-    Type gravitinoType = super.getGravitinoType(type);
-    if (gravitinoType.name() == Name.VARCHAR || gravitinoType.name() == Name.FIXEDCHAR) {
-      return Types.StringType.get();
+    if (type.equals(io.trino.spi.type.VarcharType.VARCHAR)) {
+      return Types.VarCharType.of(MAX_VARCHAR_LENGTH_FOR_PG);
     }
-    return gravitinoType;
+
+    return super.getGravitinoType(type);
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove logic that convert `varchar` and `char` to type `string`. 

### Why are the changes needed?

Type conversion should be aligned with their definition. 

Fix: #2035 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

new IT cases in `trino-ci-testset`
