### PR TITLE
[Minor] Force line endings to be LF not CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+text eol=lf

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ All files must have a license header and the build fails if any files are missin
 
 For any bugs or new code please add unit tests to provide coverage of the code. The project may not accept code without unit tests.
 
-All text files should use mocOS/unix style line endings (LF) not windows style line endings (CRLF).
+All text files should use macOS/unix style line endings (LF) not windows style line endings (CRLF).
 
 ## Community and communication
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,8 @@ All files must have a license header and the build fails if any files are missin
 
 For any bugs or new code please add unit tests to provide coverage of the code. The project may not accept code without unit tests.
 
+All text files should use mocOS/unix style line endings (LF) not windows style line endings (CRLF).
+
 ## Community and communication
 
 Join the [community discourse group](https://gravitino.discourse.group) to discuss ideas and seek help. You are also encouraged to use GitHub discussions and follow Datastrato on social media to stay updated on project news.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Force line endings to be LF not CRLF

### Why are the changes needed?

So users using windows don't get confused and submit PRs with CRLFs in them.

Fix: # N/A

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

I don't have a windows machine to test this on, but it's simple enough.