### PR TITLE
[#2037] fix(mysql-catalog): Fix MySQL/PG wild card and case sensitive issues in table name

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/CatalogMysqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/CatalogMysqlIT.java
@@ -51,6 +51,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang.math.RandomUtils;
@@ -1071,5 +1072,140 @@ public class CatalogMysqlIT extends AbstractIT {
                 }));
 
     Assertions.assertDoesNotThrow(() -> tableCatalog.dropTable(tableIdentifier));
+  }
+
+  @Test
+  void testMySQLSpecialTableName() {
+    // Test create many indexes with name success.
+    Map<String, String> properties = createProperties();
+    TableCatalog tableCatalog = catalog.asTableCatalog();
+
+    String tableName = "t112";
+    Column col1 = Column.of(tableName, Types.LongType.get(), "id", false, false, null);
+    Column[] columns = {col1};
+
+    NameIdentifier tableIdentifier =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, tableName);
+    tableCatalog.createTable(
+        tableIdentifier,
+        columns,
+        table_comment,
+        properties,
+        Transforms.EMPTY_TRANSFORM,
+        Distributions.NONE,
+        new SortOrder[0]);
+
+    tableName = "t212";
+    col1 = Column.of(tableName, Types.LongType.get(), "id", false, false, null);
+    columns = new Column[] {col1};
+    tableIdentifier = NameIdentifier.of(metalakeName, catalogName, schemaName, tableName);
+    tableCatalog.createTable(
+        tableIdentifier,
+        columns,
+        table_comment,
+        properties,
+        Transforms.EMPTY_TRANSFORM,
+        Distributions.NONE,
+        new SortOrder[0]);
+
+    tableName = "t_12";
+    col1 = Column.of(tableName, Types.LongType.get(), "id", false, false, null);
+    columns = new Column[] {col1};
+    tableIdentifier = NameIdentifier.of(metalakeName, catalogName, schemaName, tableName);
+    tableCatalog.createTable(
+        tableIdentifier,
+        columns,
+        table_comment,
+        properties,
+        Transforms.EMPTY_TRANSFORM,
+        Distributions.NONE,
+        new SortOrder[0]);
+
+    tableName = "_1__";
+    col1 = Column.of(tableName, Types.LongType.get(), "id", false, false, null);
+    columns = new Column[] {col1};
+    tableIdentifier = NameIdentifier.of(metalakeName, catalogName, schemaName, tableName);
+    tableCatalog.createTable(
+        tableIdentifier,
+        columns,
+        table_comment,
+        properties,
+        Transforms.EMPTY_TRANSFORM,
+        Distributions.NONE,
+        new SortOrder[0]);
+
+    Table t1 =
+        tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, "t112"));
+    Arrays.stream(t1.columns()).anyMatch(c -> Objects.equals(c.name(), "t112"));
+
+    Table t2 =
+        tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, "t212"));
+    Arrays.stream(t2.columns()).anyMatch(c -> Objects.equals(c.name(), "t212"));
+
+    Table t3 =
+        tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, "t_12"));
+    Arrays.stream(t3.columns()).anyMatch(c -> Objects.equals(c.name(), "t_12"));
+
+    Table t4 =
+        tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, "_1__"));
+    Arrays.stream(t4.columns()).anyMatch(c -> Objects.equals(c.name(), "_1__"));
+  }
+
+  @Test
+  void testMySQLTableNameCaseSensitive() {
+    Column col1 = Column.of("col_1", Types.LongType.get(), "id", false, false, null);
+    Column col2 = Column.of("col_2", Types.ByteType.get(), "yes", false, false, null);
+    Column col3 = Column.of("col_3", Types.DateType.get(), "comment", false, false, null);
+    Column col4 = Column.of("col_4", Types.VarCharType.of(255), "code", false, false, null);
+    Column col5 = Column.of("col_5", Types.VarCharType.of(255), "config", false, false, null);
+    Column[] newColumns = new Column[] {col1, col2, col3, col4, col5};
+
+    Index[] indexes =
+        new Index[] {
+          Indexes.createMysqlPrimaryKey(new String[][] {{"col_1"}, {"col_2"}}),
+          Indexes.unique("u1_key", new String[][] {{"col_2"}, {"col_3"}})
+        };
+
+    NameIdentifier tableIdentifier =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, "tableName");
+    Map<String, String> properties = createProperties();
+    TableCatalog tableCatalog = catalog.asTableCatalog();
+    Table createdTable =
+        tableCatalog.createTable(
+            tableIdentifier,
+            newColumns,
+            table_comment,
+            properties,
+            Transforms.EMPTY_TRANSFORM,
+            Distributions.NONE,
+            new SortOrder[0],
+            indexes);
+    assertionsTableInfo(
+        "tableName", table_comment, Arrays.asList(newColumns), properties, indexes, createdTable);
+    Table table = tableCatalog.loadTable(tableIdentifier);
+    assertionsTableInfo(
+        "tableName", table_comment, Arrays.asList(newColumns), properties, indexes, table);
+
+    // Test create table with same name but different case
+    NameIdentifier tableIdentifier2 =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, "TABLENAME");
+
+    Table tableAgain =
+        Assertions.assertDoesNotThrow(
+            () ->
+                tableCatalog.createTable(
+                    tableIdentifier2,
+                    newColumns,
+                    table_comment,
+                    properties,
+                    Transforms.EMPTY_TRANSFORM,
+                    Distributions.NONE,
+                    new SortOrder[0],
+                    indexes));
+    Assertions.assertEquals("TABLENAME", tableAgain.name());
+
+    table = tableCatalog.loadTable(tableIdentifier2);
+    assertionsTableInfo(
+        "TABLENAME", table_comment, Arrays.asList(newColumns), properties, indexes, table);
   }
 }

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
@@ -51,6 +51,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -901,5 +902,140 @@ public class CatalogPostgreSqlIT extends AbstractIT {
           Assertions.fail("Unexpected column name: " + column.name());
       }
     }
+  }
+
+  @Test
+  void testPGSpecialTableName() {
+    // Test create many indexes with name success.
+    Map<String, String> properties = createProperties();
+    TableCatalog tableCatalog = catalog.asTableCatalog();
+
+    String tableName = "t112";
+    Column col1 = Column.of(tableName, Types.LongType.get(), "id", false, false, null);
+    Column[] columns = {col1};
+
+    NameIdentifier tableIdentifier =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, tableName);
+    tableCatalog.createTable(
+        tableIdentifier,
+        columns,
+        table_comment,
+        properties,
+        Transforms.EMPTY_TRANSFORM,
+        Distributions.NONE,
+        new SortOrder[0]);
+
+    tableName = "t212";
+    col1 = Column.of(tableName, Types.LongType.get(), "id", false, false, null);
+    columns = new Column[] {col1};
+    tableIdentifier = NameIdentifier.of(metalakeName, catalogName, schemaName, tableName);
+    tableCatalog.createTable(
+        tableIdentifier,
+        columns,
+        table_comment,
+        properties,
+        Transforms.EMPTY_TRANSFORM,
+        Distributions.NONE,
+        new SortOrder[0]);
+
+    tableName = "t_12";
+    col1 = Column.of(tableName, Types.LongType.get(), "id", false, false, null);
+    columns = new Column[] {col1};
+    tableIdentifier = NameIdentifier.of(metalakeName, catalogName, schemaName, tableName);
+    tableCatalog.createTable(
+        tableIdentifier,
+        columns,
+        table_comment,
+        properties,
+        Transforms.EMPTY_TRANSFORM,
+        Distributions.NONE,
+        new SortOrder[0]);
+
+    tableName = "_1__";
+    col1 = Column.of(tableName, Types.LongType.get(), "id", false, false, null);
+    columns = new Column[] {col1};
+    tableIdentifier = NameIdentifier.of(metalakeName, catalogName, schemaName, tableName);
+    tableCatalog.createTable(
+        tableIdentifier,
+        columns,
+        table_comment,
+        properties,
+        Transforms.EMPTY_TRANSFORM,
+        Distributions.NONE,
+        new SortOrder[0]);
+
+    Table t1 =
+        tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, "t112"));
+    Arrays.stream(t1.columns()).anyMatch(c -> Objects.equals(c.name(), "t112"));
+
+    Table t2 =
+        tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, "t212"));
+    Arrays.stream(t2.columns()).anyMatch(c -> Objects.equals(c.name(), "t212"));
+
+    Table t3 =
+        tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, "t_12"));
+    Arrays.stream(t3.columns()).anyMatch(c -> Objects.equals(c.name(), "t_12"));
+
+    Table t4 =
+        tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, "_1__"));
+    Arrays.stream(t4.columns()).anyMatch(c -> Objects.equals(c.name(), "_1__"));
+  }
+
+  @Test
+  void testPGTableNameCaseSensitive() {
+    Column col1 = Column.of("col_1", Types.LongType.get(), "id", false, false, null);
+    Column col2 = Column.of("col_2", Types.IntegerType.get(), "yes", false, false, null);
+    Column col3 = Column.of("col_3", Types.DateType.get(), "comment", false, false, null);
+    Column col4 = Column.of("col_4", Types.VarCharType.of(255), "code", false, false, null);
+    Column col5 = Column.of("col_5", Types.VarCharType.of(255), "config", false, false, null);
+    Column[] newColumns = new Column[] {col1, col2, col3, col4, col5};
+
+    Index[] indexes = new Index[0];
+    NameIdentifier tableIdentifier =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, "tablename");
+    Map<String, String> properties = createProperties();
+    TableCatalog tableCatalog = catalog.asTableCatalog();
+    Table createdTable =
+        tableCatalog.createTable(
+            tableIdentifier,
+            newColumns,
+            "low case table name",
+            properties,
+            Transforms.EMPTY_TRANSFORM,
+            Distributions.NONE,
+            new SortOrder[0],
+            indexes);
+    assertionsTableInfo(
+        "tablename",
+        "low case table name",
+        Arrays.asList(newColumns),
+        properties,
+        indexes,
+        createdTable);
+    Table table = tableCatalog.loadTable(tableIdentifier);
+    assertionsTableInfo(
+        "tablename", "low case table name", Arrays.asList(newColumns), properties, indexes, table);
+
+    // Test create table with same name but different case
+    NameIdentifier tableIdentifier2 =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, "TABLENAME");
+
+    Column[] upperTableColumns = new Column[] {col1, col4, col5};
+    Table tableAgain =
+        Assertions.assertDoesNotThrow(
+            () ->
+                tableCatalog.createTable(
+                    tableIdentifier2,
+                    upperTableColumns,
+                    "upper case table name",
+                    properties,
+                    Transforms.EMPTY_TRANSFORM,
+                    Distributions.NONE,
+                    new SortOrder[0],
+                    indexes));
+    Assertions.assertEquals("TABLENAME", tableAgain.name());
+
+    table = tableCatalog.loadTable(tableIdentifier2);
+    Assertions.assertEquals("TABLENAME", table.name());
   }
 }

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoConnectorIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoConnectorIT.java
@@ -1333,6 +1333,64 @@ public class TrinoConnectorIT extends AbstractIT {
     data = containerSuite.getTrinoContainer().executeQuerySQL(sql).get(0).get(0);
     Assertions.assertTrue(data.contains("age integer NOT NULL"));
     Assertions.assertTrue(data.contains("address varchar(20) NOT NULL"));
+
+    // Test special characters in table name
+    String tableName1 = "t112";
+    sql =
+        String.format(
+            "create table \"%s.%s\".%s.%s (id int, t1name varchar)",
+            metalakeName, catalogName, schemaName, tableName1);
+    containerSuite.getTrinoContainer().executeUpdateSQL(sql);
+
+    String tableName2 = "t212";
+    sql =
+        String.format(
+            "create table \"%s.%s\".%s.%s (id int, t2name varchar)",
+            metalakeName, catalogName, schemaName, tableName2);
+    containerSuite.getTrinoContainer().executeUpdateSQL(sql);
+
+    String tableName3 = "t_12";
+    sql =
+        String.format(
+            "create table \"%s.%s\".%s.%s (id int, t3name varchar)",
+            metalakeName, catalogName, schemaName, tableName3);
+
+    containerSuite.getTrinoContainer().executeUpdateSQL(sql);
+
+    String tableName4 = "_1__";
+    sql =
+        String.format(
+            "create table \"%s.%s\".%s.%s (id int, t4name varchar)",
+            metalakeName, catalogName, schemaName, tableName4);
+    containerSuite.getTrinoContainer().executeUpdateSQL(sql);
+
+    // Get table tableName1
+    sql =
+        String.format(
+            "show create table \"%s.%s\".%s.%s", metalakeName, catalogName, schemaName, tableName1);
+    data = containerSuite.getTrinoContainer().executeQuerySQL(sql).get(0).get(0);
+    data.contains("t1name varchar");
+
+    // Get table tableName2
+    sql =
+        String.format(
+            "show create table \"%s.%s\".%s.%s", metalakeName, catalogName, schemaName, tableName2);
+    data = containerSuite.getTrinoContainer().executeQuerySQL(sql).get(0).get(0);
+    data.contains("t2name varchar");
+
+    // Get table tableName3
+    sql =
+        String.format(
+            "show create table \"%s.%s\".%s.%s", metalakeName, catalogName, schemaName, tableName3);
+    data = containerSuite.getTrinoContainer().executeQuerySQL(sql).get(0).get(0);
+    data.contains("t3name varchar");
+
+    // Get table tableName4
+    sql =
+        String.format(
+            "show create table \"%s.%s\".%s.%s", metalakeName, catalogName, schemaName, tableName4);
+    data = containerSuite.getTrinoContainer().executeQuerySQL(sql).get(0).get(0);
+    data.contains("t4name varchar");
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Changes table name matching when query metadata of MySQL table.

### Why are the changes needed?

We need to consider some corner cases like wildcard character and case sensitivity issues. 

Fix: #2037 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Add some test cases in `testMySQLTableCreatedByTrino` and test `testMySQLTableNameCaseSensitive`.
