### PR TITLE
[#1274] docs: Add complex data type example to `HiveTableCreate`

### DIFF
--- a/docs/open-api/tables.yaml
+++ b/docs/open-api/tables.yaml
@@ -745,6 +745,43 @@ components:
             "nullable": true
           },
           {
+            "name": "info",
+            "type": {
+              "type": "struct",
+              "fields": [
+                {
+                  "name": "position",
+                  "type": "string",
+                  "nullable": true,
+                  "comment": "position field comment"
+                },
+                {
+                  "name": "contact",
+                  "type": {
+                    "type": "list",
+                    "elementType": "integer",
+                    "containsNull": false
+                  },
+                  "nullable": true,
+                  "comment": "contact field comment"
+                },
+                {
+                  "name": "rating",
+                  "type": {
+                    "type": "map",
+                    "keyType": "string",
+                    "valueType": "integer",
+                    "valueContainsNull": false
+                  },
+                  "nullable": true,
+                  "comment": "rating field comment"
+                }
+              ]
+            },
+            "comment": "info column comment",
+            "nullable": true
+          },
+          {
             "name": "dt",
             "type": "date",
             "comment": "dt column comment",


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add complex data type example to `HiveTableCreate`

### Why are the changes needed?

The example of complex data type schema does work with Docusaura open API plugin, So I add complex type example to `HiveTableCreate`

Fix: #1274 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

local tested:

<img width="1841" alt="image" src="https://github.com/datastrato/gravitino/assets/24897598/751af357-7a43-4f35-b839-acac0f872928">

