### PR TITLE
[#2067] Fix the bugs that list tables in schema `pg_` will get all tables in schema starts with `pg`

### DIFF
--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/operation/JdbcTableOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/operation/JdbcTableOperations.java
@@ -106,7 +106,9 @@ public abstract class JdbcTableOperations implements TableOperation {
       final List<String> names = Lists.newArrayList();
       try (ResultSet tables = getTables(connection)) {
         while (tables.next()) {
-          names.add(tables.getString("TABLE_NAME"));
+          if (Objects.equals(tables.getString("TABLE_SCHEM"), databaseName)) {
+            names.add(tables.getString("TABLE_NAME"));
+          }
         }
       }
       LOG.info("Finished listing tables size {} for database name {} ", names.size(), databaseName);

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
@@ -1038,4 +1038,61 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     table = tableCatalog.loadTable(tableIdentifier2);
     Assertions.assertEquals("TABLENAME", table.name());
   }
+
+  @Test
+  void testPGListTable() {
+
+    String schemaPrefix = GravitinoITUtils.genRandomName("postgresql_it_schema");
+    String schemaName1 = schemaPrefix + "_";
+    String schemaName2 = schemaPrefix + "_a";
+    String schemaName3 = schemaPrefix + "1";
+    String schemaName4 = schemaPrefix + "1a";
+    String schemaName5 = schemaPrefix + "aaa";
+
+    String[] dbs = {schemaName1, schemaName2, schemaName3, schemaName4, schemaName5};
+
+    for (int i = 0; i < dbs.length; i++) {
+      catalog
+          .asSchemas()
+          .createSchema(
+              NameIdentifier.of(metalakeName, catalogName, dbs[i]), dbs[i], Maps.newHashMap());
+    }
+
+    String tableName1 = "table1";
+    String tableName2 = "table2";
+    String tableName3 = "table3";
+    String tableName4 = "table4";
+    String tableName5 = "table5";
+
+    Column col1 = Column.of("col_1", Types.LongType.get(), "id", false, false, null);
+    Column col2 = Column.of("col_2", Types.IntegerType.get(), "yes", false, false, null);
+    Column col3 = Column.of("col_3", Types.DateType.get(), "comment", false, false, null);
+    Column col4 = Column.of("col_4", Types.VarCharType.of(255), "code", false, false, null);
+    Column col5 = Column.of("col_5", Types.VarCharType.of(255), "config", false, false, null);
+    Column[] newColumns = new Column[] {col1, col2, col3, col4, col5};
+
+    String[] tables = {tableName1, tableName2, tableName3, tableName4, tableName5};
+
+    for (int i = 0; i < dbs.length; i++) {
+      catalog
+          .asTableCatalog()
+          .createTable(
+              NameIdentifier.of(metalakeName, catalogName, dbs[i], tables[i]),
+              newColumns,
+              dbs[i] + "." + tables[i],
+              Maps.newHashMap(),
+              Transforms.EMPTY_TRANSFORM,
+              Distributions.NONE,
+              new SortOrder[0],
+              new Index[0]);
+    }
+
+    // list table in schema1
+    for (int i = 0; i < 5; i++) {
+      NameIdentifier[] tableNames =
+          catalog.asTableCatalog().listTables(Namespace.of(metalakeName, catalogName, dbs[i]));
+      Assertions.assertEquals(1, tableNames.length);
+      Assertions.assertEquals(tables[i], tableNames[0].name());
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add logic to check the table schema when listing tables.

### Why are the changes needed?

Method `getTables` supports regex and if we use `pg_` as the database name, all tables in schemas that start with `pg` will
Retrieved. 

Fix: #2067 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Add IT `testPGListTable`