### PR TITLE
[MINOR] docs: Condense the summary to fit the Docusaurus open api plugin

### DIFF
--- a/docs/open-api/catalogs.yaml
+++ b/docs/open-api/catalogs.yaml
@@ -13,7 +13,7 @@ paths:
     get:
       tags:
         - catalog
-      summary: List all catalogs in the specified metalake
+      summary: List catalogs
       operationId: listCatalogs
       responses:
         "200":
@@ -26,7 +26,7 @@ paths:
     post:
       tags:
         - catalog
-      summary: Create a new catalog in the specified metalake
+      summary: Create catalog
       operationId: createCatalog
       requestBody:
         content:
@@ -60,7 +60,7 @@ paths:
     get:
       tags:
         - catalog
-      summary: Get the specified catalog in the specified metalake
+      summary: Get catalog
       operationId: loadCatalog
       description: Returns the specified catalog information in the specified metalake
       responses:
@@ -83,7 +83,7 @@ paths:
     put:
       tags:
         - catalog
-      summary: Update the specified catalog in the specified metalake
+      summary: Update catalog
       operationId: alterCatalog
       description: Alters the specified catalog information in the specified metalake
       requestBody:
@@ -120,7 +120,7 @@ paths:
     delete:
       tags:
         - catalog
-      summary: Drop the specified catalog in the specified metalake
+      summary: Drop catalog
       operationId: dropCatalog
       responses:
         "200":

--- a/docs/open-api/metalakes.yaml
+++ b/docs/open-api/metalakes.yaml
@@ -12,7 +12,7 @@ paths:
     get:
       tags:
         - metalake
-      summary: List all metalakes
+      summary: List metalakes
       operationId: listMetalakes
       description: Returns a list of all metalakes.
       responses:
@@ -26,7 +26,7 @@ paths:
     post:
       tags:
         - metalake
-      summary: Create a new metalake
+      summary: Create metalake
       operationId: createMetalake
       description: Creates a new metalake
       requestBody:
@@ -64,7 +64,7 @@ paths:
     get:
       tags:
         - metalake
-      summary: Load a metalake from the Gravitino store
+      summary: Get metalake
       operationId: loadMetalake
       description: Returns a metalake information by given metalake name
       responses:
@@ -85,7 +85,7 @@ paths:
     put:
       tags:
         - metalake
-      summary: Alter a metalake by name
+      summary: Update metalake
       operationId: alterMetalake
       description: Alters a specified metalake
       requestBody:
@@ -126,7 +126,7 @@ paths:
     delete:
       tags:
         - metalake
-      summary: Drop a metalake by name
+      summary: Drop metalake
       operationId: dropMetalake
       description: Drops a specified metalake
       responses:

--- a/docs/open-api/partitions.yaml
+++ b/docs/open-api/partitions.yaml
@@ -17,7 +17,7 @@ paths:
     get:
       tags:
         - partition
-      summary: List all partitions/partition names in a table
+      summary: List partitions (names)
       operationId: listPartitions
       parameters:
         - $ref: "#/components/parameters/details"
@@ -43,7 +43,7 @@ paths:
     post:
       tags:
         - partition
-      summary: Add partitions to a table
+      summary: Add partitions
       operationId: addPartitions
       requestBody:
         content:
@@ -79,7 +79,7 @@ paths:
     get:
       tags:
         - partition
-      summary: Get a partition by name
+      summary: Get partition by name
       operationId: getPartition
       description: Returns the specified partition
       responses:

--- a/docs/open-api/schemas.yaml
+++ b/docs/open-api/schemas.yaml
@@ -15,7 +15,7 @@ paths:
     get:
       tags:
         - schema
-      summary: List all schemas in a catalog
+      summary: List schemas
       operationId: listSchemas
       responses:
         "200":
@@ -28,7 +28,7 @@ paths:
     post:
       tags:
         - schema
-      summary: Create a new schema in a catalog
+      summary: Create schema
       operationId: createSchema
       requestBody:
         content:
@@ -63,7 +63,7 @@ paths:
     get:
       tags:
         - schema
-      summary: Get the specified schema in the specified catalog and metalake
+      summary: Get schema
       operationId: loadSchema
       description: Returns the specified schema in the specified catalog and metalake
       responses:
@@ -88,7 +88,7 @@ paths:
     put:
       tags:
         - schema
-      summary: Update the specified schema in the specified catalog and metalake
+      summary: Update schema
       operationId: alterSchema
       description: Updates the specified schema in the specified catalog and metalake
       requestBody:
@@ -127,7 +127,7 @@ paths:
     delete:
       tags:
         - schema
-      summary: Drop the specified schema in the specified catalog and metalake
+      summary: Drop schema
       operationId: dropSchema
       responses:
         "200":

--- a/docs/open-api/tables.yaml
+++ b/docs/open-api/tables.yaml
@@ -16,7 +16,7 @@ paths:
     get:
       tags:
         - table
-      summary: List all tables in a schema
+      summary: List tables
       operationId: listTables
       responses:
         "200":
@@ -29,7 +29,7 @@ paths:
     post:
       tags:
         - table
-      summary: Create a new table in a schema
+      summary: Create table
       operationId: createTable
       requestBody:
         content:
@@ -69,7 +69,7 @@ paths:
     get:
       tags:
         - table
-      summary: Get the specified table in a schema
+      summary: Get table
       operationId: loadTable
       description: Returns the specified table object
       responses:
@@ -96,7 +96,7 @@ paths:
     put:
       tags:
         - table
-      summary: Update the specified table in a schema
+      summary: Update table
       operationId: alterTable
       description: Updates the specified table in a schema
       requestBody:
@@ -139,7 +139,7 @@ paths:
     delete:
       tags:
         - table
-      summary: Delete the specified table in a schema
+      summary: Drop table
       operationId: dropTable
       responses:
         "200":


### PR DESCRIPTION
### What changes were proposed in this pull request?

Condense the summary to fit the Docusaurus open api plugin
### Why are the changes needed?

Docusaurus open api plugin generate the sidebar tag value by the API summary, so we need to condense the summary to make the sidebar more cleaner

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

locally tested:

<img width="281" alt="image" src="https://github.com/datastrato/gravitino/assets/24897598/9b24df97-bff3-4280-9f56-a71aaa38f563">

