### PR TITLE
[#1865] fix: Transform AuthConstants.java into a final class with all constant fields declared as public static final

### DIFF
--- a/common/src/main/java/com/datastrato/gravitino/auth/AuthConstants.java
+++ b/common/src/main/java/com/datastrato/gravitino/auth/AuthConstants.java
@@ -6,33 +6,35 @@
 package com.datastrato.gravitino.auth;
 
 /** Constants used for authentication. */
-public interface AuthConstants {
+public final class AuthConstants {
+  private AuthConstants() {}
 
   /** The HTTP header used to pass the authentication token. */
-  String HTTP_HEADER_AUTHORIZATION = "Authorization";
+  public static final String HTTP_HEADER_AUTHORIZATION = "Authorization";
 
   /** The name of BEARER header used to pass the authentication token. */
-  String AUTHORIZATION_BEARER_HEADER = "Bearer ";
+  public static final String AUTHORIZATION_BEARER_HEADER = "Bearer ";
 
   /** The name of BASIC header used to pass the authentication token. */
-  String AUTHORIZATION_BASIC_HEADER = "Basic ";
+  public static final String AUTHORIZATION_BASIC_HEADER = "Basic ";
 
   /** The name of NEGOTIATE. */
-  String NEGOTIATE = "Negotiate";
+  public static final String NEGOTIATE = "Negotiate";
 
   /** The value of NEGOTIATE header used to pass the authentication token. */
-  String AUTHORIZATION_NEGOTIATE_HEADER = NEGOTIATE + " ";
+  public static final String AUTHORIZATION_NEGOTIATE_HEADER = NEGOTIATE + " ";
 
   /** The HTTP header used to pass the authentication token. */
-  String HTTP_CHALLENGE_HEADER = "WWW-Authenticate";
+  public static final String HTTP_CHALLENGE_HEADER = "WWW-Authenticate";
 
   /** The default username used for anonymous access. */
-  String ANONYMOUS_USER = "anonymous";
+  public static final String ANONYMOUS_USER = "anonymous";
 
   /**
    * The default name of the attribute that stores the authenticated principal in the request.
    *
    * <p>Refer to the style of `AuthenticationFilter#AuthenticatedRoleAttributeName` of Apache Pulsar
    */
-  String AUTHENTICATED_PRINCIPAL_ATTRIBUTE_NAME = AuthConstants.class.getName() + "-principal";
+  public static final String AUTHENTICATED_PRINCIPAL_ATTRIBUTE_NAME =
+      AuthConstants.class.getName() + "-principal";
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Transform AuthConstants.java into a final class with all constant fields declared as public static final.

### Why are the changes needed?

Fix: #1865

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
