### PR TITLE
[MINOR] docs: fix unparsed link

### DIFF
--- a/docs/how-to-install.md
+++ b/docs/how-to-install.md
@@ -99,7 +99,7 @@ After configuring the Gravitino server, start the Gravitino server by running:
 ./bin/gravitino.sh start
 ```
 
-You can access the Gravitino Web UI by typing <http://localhost:8090> in your browser. or you
+You can access the Gravitino Web UI by typing [http://localhost:8090](http://localhost:8090) in your browser. or you
 can run
 
 ```shell

--- a/docs/how-to-use-the-playground.md
+++ b/docs/how-to-use-the-playground.md
@@ -10,7 +10,7 @@ This software is licensed under the Apache License version 2."
 
 The playground is a complete Gravitino Docker runtime environment with `Hive`, `HDFS`, `Trino`, `MySQL`, `PostgreSQL`, and a `Gravitino` server.
 
-Depending on your network and computer, startup time may take 3-5 minutes. Once the playground environment has started, you can open <http://localhost:8090> in a browser to access the Gravitino Web UI.
+Depending on your network and computer, startup time may take 3-5 minutes. Once the playground environment has started, you can open [http://localhost:8090](http://localhost:8090) in a browser to access the Gravitino Web UI.
 
 ## Prerequisites
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

replace `<>` with `[]()` on link

### Why are the changes needed?

There is a rendering error for current md

<img width="1770" alt="image-20240206100149997" src="https://github.com/datastrato/gravitino/assets/24897598/0c2903ef-5d9c-4d08-bb67-386e728d890b">


### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

local tested
