### PR TITLE
[#1694] improve: optimized Github issue template file

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -2,8 +2,6 @@ name: Bug Report
 title: "[Bug report] "
 description: A bug report issue
 labels: [ "bug" ]
-projects: [ "datastrato/1" ]
-
 body:
 
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -2,8 +2,6 @@ name: Epic
 title: "[EPIC] "
 description: An epic issue with multiple sub-tasks
 labels: [ "epic" ]
-projects: [ "datastrato/1" ]
-
 body:
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -2,7 +2,6 @@ name: Feature Request
 title: "[FEATURE] "
 description: Suggest an idea for Gravitino
 labels: [ "feature" ]
-projects: [ "datastrato/1" ]
 body:
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -4,7 +4,6 @@ name: Improvement
 title: "[Improvement] "
 description: Suggest an improvement on performance, code quality, user experience, etc
 labels: [ "improvement" ]
-projects: [ "datastrato/1" ]
 body:
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/subtask.yml
+++ b/.github/ISSUE_TEMPLATE/subtask.yml
@@ -2,8 +2,6 @@ name: Subtask
 title: "[Subtask] "
 description: A subtask issue
 labels: [ "subtask" ]
-projects: [ "datastrato/1" ]
-
 body:
 
   - type: textarea

--- a/.github/workflows/add-to-project.yml 
+++ b/.github/workflows/add-to-project.yml 
@@ -1,0 +1,16 @@
+name: Add issue to project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/datastrato/projects/1
+          github-token: ${{ secrets.ADD_ISSUE_TO_PROJECT }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Revert `github/workflows/add-to-project.yml` Action.

### Why are the changes needed?

Currently, only issues created by Datastrato organization members can automatically add project(`Gravitino`).

Fix: #2106

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

CI
