### PR TITLE
[MINOR] docs: Update the version of the OpenAPI document to 0.4.0

### DIFF
--- a/docs/open-api/openapi.yaml
+++ b/docs/open-api/openapi.yaml
@@ -10,7 +10,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.3.0
+  version: 0.4.0
   description: |
     Defines the specification for the first version of the Gravitino REST API.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update the version of the OpenAPI document to 0.4.0

### Why are the changes needed?

As the [OAS](https://spec.openapis.org/oas/latest.html#info-object) description, the version field in Info object should be:

> The version of the OpenAPI document (which is distinct from the [OpenAPI Specification version](https://spec.openapis.org/oas/latest.html#oasVersion) or the API implementation version).

So I update the version to 0.4.0


### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

no need
