### PR TITLE
[#2135] improvement(integration-test): TrinoQueryITBase removes unusual static call

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoQueryITBase.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoQueryITBase.java
@@ -60,7 +60,7 @@ public class TrinoQueryITBase {
       gravitinoClient = AbstractIT.getGravitinoClient();
       gravitinoUri = String.format("http://127.0.0.1:%d", AbstractIT.getGravitinoServerPort());
 
-      trinoITContainers = ContainerSuite.getInstance().getTrinoITContainers();
+      trinoITContainers = ContainerSuite.getTrinoITContainers();
       trinoITContainers.launch(AbstractIT.getGravitinoServerPort());
 
       trinoUri = trinoITContainers.getTrinoUri();


### PR DESCRIPTION
### What changes were proposed in this pull request?

TrinoQueryITBase removes unusual static call (`ContainerSuite.getInstance().getTrinoITContainers()`).

### Why are the changes needed?

There are unusual static call (`ContainerSuite.getInstance().getTrinoITContainers()`) in `TrinoQueryITBase`, which could remove from `TrinoQueryITBase`.

Fix: #2135

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`TrinoQueryITBase`