### PR TITLE
[#2117] improvement(api): Type adds UNPARSED column data type to handle an unresolvable type from the catalog

### DIFF
--- a/api/src/main/java/com/datastrato/gravitino/rel/types/Type.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/types/Type.java
@@ -73,7 +73,10 @@ public interface Type {
     UNION,
 
     /** The null type. A null type represents a value that is null. */
-    NULL
+    NULL,
+
+    /** The unparsed type. An unparsed type represents an unresolvable type. */
+    UNPARSED
   }
 
   /** The base type of all primitive types. */

--- a/api/src/main/java/com/datastrato/gravitino/rel/types/Types.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/types/Types.java
@@ -1018,6 +1018,61 @@ public class Types {
   }
 
   /**
+   * Represents a type that is not parsed yet. The parsed type is represented by other types of
+   * {@link Types}.
+   */
+  public static class UnparsedType implements Type {
+
+    /**
+     * Creates a new {@link UnparsedType} with the given unparsed type.
+     *
+     * @param unparsedType The unparsed type.
+     * @return A new {@link UnparsedType} with the given unparsed type.
+     */
+    public static UnparsedType of(String unparsedType) {
+      return new UnparsedType(unparsedType);
+    }
+
+    private final String unparsedType;
+
+    private UnparsedType(String unparsedType) {
+      this.unparsedType = unparsedType;
+    }
+
+    /** @return The unparsed type as a string. */
+    public String unparsedType() {
+      return unparsedType;
+    }
+
+    @Override
+    public Name name() {
+      return Name.UNPARSED;
+    }
+
+    @Override
+    public String simpleString() {
+      return String.format("unparsed(%s)", unparsedType);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      UnparsedType that = (UnparsedType) o;
+      return Objects.equals(unparsedType, that.unparsedType);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(unparsedType);
+    }
+  }
+
+  /**
    * @param dataType The data type to check.
    * @return True if the given data type is allowed to be an auto-increment column.
    */

--- a/api/src/test/java/com/datastrato/gravitino/rel/TestTypes.java
+++ b/api/src/test/java/com/datastrato/gravitino/rel/TestTypes.java
@@ -179,4 +179,13 @@ public class TestTypes {
     Assertions.assertEquals("union<integer,string,boolean>", unionType.simpleString());
     Assertions.assertEquals(unionType, Types.UnionType.of(unionType.types()));
   }
+
+  @Test
+  public void testUnparsedType() {
+    Types.UnparsedType unparsedType = Types.UnparsedType.of("bit");
+    Assertions.assertEquals(Type.Name.UNPARSED, unparsedType.name());
+    Assertions.assertEquals("unparsed(bit)", unparsedType.simpleString());
+    Assertions.assertEquals("bit", unparsedType.unparsedType());
+    Assertions.assertEquals(unparsedType, Types.UnparsedType.of("bit"));
+  }
 }

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/converter/FromHiveType.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/converter/FromHiveType.java
@@ -21,6 +21,7 @@ import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils.getTypeInfoFr
 
 import com.datastrato.gravitino.rel.types.Type;
 import com.datastrato.gravitino.rel.types.Types;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.stream.IntStream;
 import org.apache.hadoop.hive.serde2.typeinfo.CharTypeInfo;
@@ -40,9 +41,8 @@ public class FromHiveType {
    *
    * @param hiveType The Hive data type string to convert.
    * @return The equivalent Gravitino data type.
-   * @throws IllegalArgumentException If the Hive data type is unknown or unsupported.
    */
-  public static Type convert(String hiveType) throws IllegalArgumentException {
+  public static Type convert(String hiveType) {
     TypeInfo hiveTypeInfo = getTypeInfoFromTypeString(hiveType);
     return toGravitinoType(hiveTypeInfo);
   }
@@ -52,9 +52,9 @@ public class FromHiveType {
    *
    * @param hiveTypeInfo The Hive TypeInfo object to convert.
    * @return The equivalent Gravitino Type.
-   * @throws IllegalArgumentException if the Hive data type category is unknown or unsupported.
    */
-  private static Type toGravitinoType(TypeInfo hiveTypeInfo) throws IllegalArgumentException {
+  @VisibleForTesting
+  public static Type toGravitinoType(TypeInfo hiveTypeInfo) {
     switch (hiveTypeInfo.getCategory()) {
       case PRIMITIVE:
         switch (hiveTypeInfo.getTypeName()) {
@@ -98,8 +98,7 @@ public class FromHiveType {
               return Types.DecimalType.of(decimalTypeInfo.precision(), decimalTypeInfo.scale());
             }
 
-            throw new IllegalArgumentException(
-                "Unknown Hive type: " + hiveTypeInfo.getQualifiedName());
+            return Types.UnparsedType.of(hiveTypeInfo.getQualifiedName());
         }
       case LIST:
         return Types.ListType.nullable(
@@ -128,8 +127,7 @@ public class FromHiveType {
                 .map(FromHiveType::toGravitinoType)
                 .toArray(Type[]::new));
       default:
-        throw new IllegalArgumentException(
-            "Unknown category of Hive type: " + hiveTypeInfo.getCategory());
+        return Types.UnparsedType.of(hiveTypeInfo.getQualifiedName());
     }
   }
 

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/converter/TestTypeConverter.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/converter/TestTypeConverter.java
@@ -29,12 +29,17 @@ import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils.getTypeInfoFr
 
 import com.datastrato.gravitino.catalog.hive.converter.FromHiveType;
 import com.datastrato.gravitino.catalog.hive.converter.ToHiveType;
+import com.datastrato.gravitino.rel.types.Types;
 import java.util.Arrays;
+import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestTypeConverter {
+
+  private static final String USER_DEFINED_TYPE = "user-defined";
+
   @Test
   public void testTypeConverter() {
     testConverter(BOOLEAN_TYPE_NAME);
@@ -69,11 +74,24 @@ public class TestTypeConverter {
                 Arrays.asList(
                     getPrimitiveTypeInfo(STRING_TYPE_NAME), getPrimitiveTypeInfo(INT_TYPE_NAME)))
             .getTypeName());
+    Assertions.assertEquals(
+        Types.UnparsedType.of(USER_DEFINED_TYPE),
+        FromHiveType.toGravitinoType(new UserDefinedTypeInfo()));
+    Assertions.assertThrows(
+        UnsupportedOperationException.class,
+        () -> ToHiveType.convert(Types.UnparsedType.of(USER_DEFINED_TYPE)));
   }
 
   private void testConverter(String typeName) {
     TypeInfo hiveType = getTypeInfoFromTypeString(typeName);
     TypeInfo convertedType = ToHiveType.convert(FromHiveType.convert(hiveType.getTypeName()));
     Assertions.assertEquals(hiveType, convertedType);
+  }
+
+  static class UserDefinedTypeInfo extends PrimitiveTypeInfo {
+    @Override
+    public String getTypeName() {
+      return USER_DEFINED_TYPE;
+    }
   }
 }

--- a/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/converter/MysqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/converter/MysqlTypeConverter.java
@@ -55,7 +55,7 @@ public class MysqlTypeConverter extends JdbcTypeConverter<String> {
       case BINARY:
         return Types.BinaryType.get();
       default:
-        throw new IllegalArgumentException("Not a supported type: " + typeBean.getTypeName());
+        return Types.UnparsedType.of(typeBean.getTypeName());
     }
   }
 
@@ -90,6 +90,7 @@ public class MysqlTypeConverter extends JdbcTypeConverter<String> {
     } else if (type instanceof Types.BinaryType) {
       return type.simpleString();
     }
-    throw new IllegalArgumentException("Not a supported type: " + type.toString());
+    throw new IllegalArgumentException(
+        String.format("Couldn't convert Gravitino type %s to MySQL type", type.simpleString()));
   }
 }

--- a/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/converter/TestMysqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/converter/TestMysqlTypeConverter.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 public class TestMysqlTypeConverter {
 
   private static final MysqlTypeConverter MYSQL_TYPE_CONVERTER = new MysqlTypeConverter();
+  private static final String USER_DEFINED_TYPE = "user-defined";
 
   @Test
   public void testToGravitinoType() {
@@ -44,6 +45,8 @@ public class TestMysqlTypeConverter {
     checkJdbcTypeToGravitinoType(Types.FixedCharType.of(20), CHAR, "20", null);
     checkJdbcTypeToGravitinoType(Types.StringType.get(), TEXT, null, null);
     checkJdbcTypeToGravitinoType(Types.BinaryType.get(), BINARY, null, null);
+    checkJdbcTypeToGravitinoType(
+        Types.UnparsedType.of(USER_DEFINED_TYPE), USER_DEFINED_TYPE, null, null);
   }
 
   @Test
@@ -61,6 +64,9 @@ public class TestMysqlTypeConverter {
     checkGravitinoTypeToJdbcType(CHAR + "(20)", Types.FixedCharType.of(20));
     checkGravitinoTypeToJdbcType(TEXT, Types.StringType.get());
     checkGravitinoTypeToJdbcType(BINARY, Types.BinaryType.get());
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> MYSQL_TYPE_CONVERTER.fromGravitinoType(Types.UnparsedType.of(USER_DEFINED_TYPE)));
   }
 
   protected void checkGravitinoTypeToJdbcType(String jdbcTypeName, Type gravitinoType) {

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/converter/PostgreSqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/converter/PostgreSqlTypeConverter.java
@@ -59,7 +59,7 @@ public class PostgreSqlTypeConverter extends JdbcTypeConverter<String> {
       case BYTEA:
         return Types.BinaryType.get();
       default:
-        throw new IllegalArgumentException("Not a supported type: " + typeBean);
+        return Types.UnparsedType.of(typeBean.getTypeName());
     }
   }
 
@@ -102,6 +102,7 @@ public class PostgreSqlTypeConverter extends JdbcTypeConverter<String> {
       return BYTEA;
     }
     throw new IllegalArgumentException(
-        String.format("Couldn't convert PostgreSQL type %s to Gravitino type", type.toString()));
+        String.format(
+            "Couldn't convert Gravitino type %s to PostgreSQL type", type.simpleString()));
   }
 }

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/converter/TestPostgreSqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/converter/TestPostgreSqlTypeConverter.java
@@ -30,6 +30,7 @@ public class TestPostgreSqlTypeConverter {
 
   private static final PostgreSqlTypeConverter POSTGRE_SQL_TYPE_CONVERTER =
       new PostgreSqlTypeConverter();
+  private static final String USER_DEFINED_TYPE = "user-defined";
 
   @Test
   public void testToGravitinoType() {
@@ -47,6 +48,8 @@ public class TestPostgreSqlTypeConverter {
     checkJdbcTypeToGravitinoType(Types.FixedCharType.of(20), BPCHAR, "20", null);
     checkJdbcTypeToGravitinoType(Types.StringType.get(), TEXT, null, null);
     checkJdbcTypeToGravitinoType(Types.BinaryType.get(), BYTEA, null, null);
+    checkJdbcTypeToGravitinoType(
+        Types.UnparsedType.of(USER_DEFINED_TYPE), USER_DEFINED_TYPE, null, null);
   }
 
   @Test
@@ -65,6 +68,10 @@ public class TestPostgreSqlTypeConverter {
     checkGravitinoTypeToJdbcType(BPCHAR + "(20)", Types.FixedCharType.of(20));
     checkGravitinoTypeToJdbcType(TEXT, Types.StringType.get());
     checkGravitinoTypeToJdbcType(BYTEA, Types.BinaryType.get());
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            POSTGRE_SQL_TYPE_CONVERTER.fromGravitinoType(Types.UnparsedType.of(USER_DEFINED_TYPE)));
   }
 
   protected void checkGravitinoTypeToJdbcType(String jdbcTypeName, Type gravitinoType) {

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/FromIcebergType.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/FromIcebergType.java
@@ -98,8 +98,7 @@ public class FromIcebergType extends TypeUtil.SchemaVisitor<Type> {
         return com.datastrato.gravitino.rel.types.Types.DecimalType.of(
             decimal.precision(), decimal.scale());
       default:
-        throw new UnsupportedOperationException(
-            "Cannot convert unknown type to Gravitino: " + primitive);
+        return com.datastrato.gravitino.rel.types.Types.UnparsedType.of(primitive.typeId().name());
     }
   }
 }

--- a/common/src/test/java/com/datastrato/gravitino/json/TestJsonUtils.java
+++ b/common/src/test/java/com/datastrato/gravitino/json/TestJsonUtils.java
@@ -154,6 +154,12 @@ public class TestJsonUtils {
             + "    ]\n"
             + "}";
     Assertions.assertEquals(objectMapper.readTree(expected), objectMapper.readTree(jsonValue));
+
+    type = Types.UnparsedType.of("user-defined");
+    jsonValue = JsonUtils.objectMapper().writeValueAsString(type);
+    expected =
+        "{\n" + "    \"type\": \"unparsed\",\n" + "    \"unparsedType\": \"user-defined\"\n" + "}";
+    Assertions.assertEquals(objectMapper.readTree(expected), objectMapper.readTree(jsonValue));
   }
 
   @Test

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/CatalogMysqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/CatalogMysqlIT.java
@@ -1289,4 +1289,16 @@ public class CatalogMysqlIT extends AbstractIT {
               .anyMatch(n -> n.equals(tableName)));
     }
   }
+
+  @Test
+  void testUnparsedTypeConverter() {
+    String tableName = GravitinoITUtils.genRandomName("test_unparsed_type");
+    mysqlService.executeQuery(
+        String.format("CREATE TABLE %s.%s (bit_col bit);", schemaName, tableName));
+    Table loadedTable =
+        catalog
+            .asTableCatalog()
+            .loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, tableName));
+    Assertions.assertEquals(Types.UnparsedType.of("BIT"), loadedTable.columns()[0].dataType());
+  }
 }

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/MysqlTableOperationsIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/MysqlTableOperationsIT.java
@@ -605,7 +605,9 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
       Assertions.assertTrue(
           illegalArgumentException
               .getMessage()
-              .contains("Not a supported type: " + type.toString()));
+              .contains(
+                  String.format(
+                      "Couldn't convert Gravitino type %s to MySQL type", type.simpleString())));
     }
   }
 

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
@@ -1181,4 +1181,16 @@ public class CatalogPostgreSqlIT extends AbstractIT {
               .anyMatch(n -> n.equals(tableName)));
     }
   }
+
+  @Test
+  void testUnparsedTypeConverter() {
+    String tableName = GravitinoITUtils.genRandomName("test_unparsed_type");
+    postgreSqlService.executeQuery(
+        String.format("CREATE TABLE %s.%s (bit_col bit);", schemaName, tableName));
+    Table loadedTable =
+        catalog
+            .asTableCatalog()
+            .loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, tableName));
+    Assertions.assertEquals(Types.UnparsedType.of("bit"), loadedTable.columns()[0].dataType());
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`Type` adds `UNPARSED` column data type to handle an unresolvable type from the catalog.

### Why are the changes needed?

If a column data type in the catalog does not have a mapping in Gravitino, an exception will be thrown. We should map all data types from a catalog to Gravitino. However, in practical situations, loading exceptions may occur due to the addition of new data types or insufficient mapping support. Introduce `UnparsedType` to represent the unparsed data type.

Fix: #2117 

### Does this PR introduce _any_ user-facing change?

`Type` adds `UNKNOWN` column data type that represents an unresolvable type.

### How was this patch tested?

- `TestJsonUtils#testTypeSerDe`
- `TestTypes#testUnparsedType`
- `TestTypeConverter#testTypeConverter`
- `TestMysqlTypeConverter#testToGravitinoType`
- `TestPostgreSqlTypeConverter#testToGravitinoType`
- `CatalogMysqlIT#testUnparsedTypeConverter`
- `CatalogPostgreSqlIT#testUnparsedTypeConverter`