### PR TITLE
[#2187] Improvement: Remove redundant null checks when using instanceof

### DIFF
--- a/api/src/main/java/com/datastrato/gravitino/NameIdentifier.java
+++ b/api/src/main/java/com/datastrato/gravitino/NameIdentifier.java
@@ -208,7 +208,7 @@ public class NameIdentifier {
 
   @Override
   public boolean equals(Object other) {
-    if (other == null || !(other instanceof NameIdentifier)) {
+    if (!(other instanceof NameIdentifier)) {
       return false;
     }
 

--- a/api/src/main/java/com/datastrato/gravitino/Namespace.java
+++ b/api/src/main/java/com/datastrato/gravitino/Namespace.java
@@ -202,7 +202,7 @@ public class Namespace {
 
   @Override
   public boolean equals(Object other) {
-    if (other == null || !(other instanceof Namespace)) {
+    if (!(other instanceof Namespace)) {
       return false;
     }
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Remove redundant `null` checks when using `instanceof`.

### Why are the changes needed?

Simplify the code logic.

Fix: #2187

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Covered by existing tests
