### PR TITLE
[#2158] Improvement: Return the value after executing apply() in checkValueFormat()

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/catalog/PropertiesMetadata.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/PropertiesMetadata.java
@@ -39,9 +39,9 @@ public interface PropertiesMetadata {
     return propertyEntries().containsKey(propertyName);
   }
 
-  static <T> void checkValueFormat(String key, String value, Function<String, T> decoder) {
+  static <T> T checkValueFormat(String key, String value, Function<String, T> decoder) {
     try {
-      decoder.apply(value);
+      return decoder.apply(value);
     } catch (Exception e) {
       throw new IllegalArgumentException(
           String.format("Invalid value: '%s' for property: '%s'", value, key), e);


### PR DESCRIPTION
Return the value after executing apply() in checkValueFormat()

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Return the value after executing apply() in checkValueFormat()

### Why are the changes needed?

Address the linter issue in #2158

Fix: #2158

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Covered by existing tests
