### PR TITLE
[#2159] Improvement:  Replace String.split("@") with Splitter.on('@').splitToList()

### DIFF
--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
@@ -45,6 +45,7 @@ import com.datastrato.gravitino.rel.expressions.transforms.Transforms;
 import com.datastrato.gravitino.rel.indexes.Index;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -202,10 +203,11 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
         String catalogPrincipal = (String) catalogPropertiesMetadata.getOrDefault(conf, PRINCIPAL);
         Preconditions.checkArgument(
             StringUtils.isNotBlank(catalogPrincipal), "The principal can't be blank");
-        String[] principalComponents = catalogPrincipal.split("@");
+        @SuppressWarnings("null")
+        List<String> principalComponents = Splitter.on('@').splitToList(catalogPrincipal);
         Preconditions.checkArgument(
-            principalComponents.length == 2, "The principal has the wrong format");
-        this.kerberosRealm = principalComponents[1];
+            principalComponents.size() == 2, "The principal has the wrong format");
+        this.kerberosRealm = principalComponents.get(1);
 
         checkTgtExecutor =
             new ScheduledThreadPoolExecutor(

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/KerberosTokenProvider.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/KerberosTokenProvider.java
@@ -8,10 +8,12 @@ package com.datastrato.gravitino.client;
 import com.datastrato.gravitino.auth.AuthConstants;
 import com.datastrato.gravitino.auth.KerberosUtils;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import javax.security.auth.kerberos.KerberosTicket;
@@ -64,11 +66,11 @@ public final class KerberosTokenProvider implements AuthDataProvider {
   }
 
   private byte[] getTokenInternal() throws Exception {
-
-    String[] principalComponents = clientPrincipal.split("@");
+    @SuppressWarnings("null")
+    List<String> principalComponents = Splitter.on('@').splitToList(clientPrincipal);
     // Gravitino server's principal must start with HTTP. This restriction follows
     // the style of Apache Hadoop.
-    String serverPrincipal = "HTTP/" + host + "@" + principalComponents[1];
+    String serverPrincipal = "HTTP/" + host + "@" + principalComponents.get(1);
 
     synchronized (this) {
       if (loginContext == null) {
@@ -179,6 +181,7 @@ public final class KerberosTokenProvider implements AuthDataProvider {
      *
      * @return The built KerberosTokenProvider instance.
      */
+    @SuppressWarnings("null")
     public KerberosTokenProvider build() {
       KerberosTokenProvider provider = new KerberosTokenProvider();
 
@@ -186,7 +189,8 @@ public final class KerberosTokenProvider implements AuthDataProvider {
           StringUtils.isNotBlank(clientPrincipal),
           "KerberosTokenProvider must set clientPrincipal");
       Preconditions.checkArgument(
-          clientPrincipal.split("@").length == 2, "Principal has the wrong format");
+          Splitter.on('@').splitToList(clientPrincipal).size() == 2,
+          "Principal has the wrong format");
       provider.clientPrincipal = clientPrincipal;
 
       if (keyTabFile != null) {

--- a/server-common/src/main/java/com/datastrato/gravitino/server/auth/KerberosAuthenticator.java
+++ b/server-common/src/main/java/com/datastrato/gravitino/server/auth/KerberosAuthenticator.java
@@ -16,11 +16,13 @@ import com.datastrato.gravitino.UserPrincipal;
 import com.datastrato.gravitino.auth.AuthConstants;
 import com.datastrato.gravitino.auth.KerberosUtils;
 import com.datastrato.gravitino.exceptions.UnauthorizedException;
+import com.google.common.base.Splitter;
 import java.io.File;
 import java.security.Principal;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Base64;
+import java.util.List;
 import javax.security.auth.Subject;
 import javax.security.auth.kerberos.KerberosPrincipal;
 import javax.security.auth.kerberos.KeyTab;
@@ -161,12 +163,13 @@ public class KerberosAuthenticator implements Authenticator {
       }
 
       // Usually principal names are in the form 'user/instance@REALM' or 'user@REALM'.
-      String[] principalComponents = gssContext.getSrcName().toString().split("@");
-      if (principalComponents.length != 2) {
+      List<String> principalComponents =
+          Splitter.on('@').splitToList(gssContext.getSrcName().toString());
+      if (principalComponents.size() != 2) {
         throw new UnauthorizedException("Principal has wrong format", AuthConstants.NEGOTIATE);
       }
 
-      String user = principalComponents[0];
+      String user = principalComponents.get(0);
       // TODO: We will have KerberosUserPrincipal in the future.
       //  We can put more information of Kerberos to the KerberosUserPrincipal
       // For example, we can put the token into the KerberosUserPrincipal,


### PR DESCRIPTION


 Due to the linter warning "Null type safety: The expression of type
 'String' needs unchecked conversion to conform to '@Nonnull
 CharSequence'", @SuppressWarnings("null") is added to suppress the
 warning

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Replace String.split("@") with Splitter.on('@').splitToList()

### Why are the changes needed?

Address linter issue mentioned in #2159

Fix: #2159

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Covered by existing tests
