### PR TITLE
[#2209] Swap order of assertEquals parameters to be correct

### DIFF
--- a/api/src/test/java/com/datastrato/gravitino/TestNameIdentifier.java
+++ b/api/src/test/java/com/datastrato/gravitino/TestNameIdentifier.java
@@ -88,8 +88,8 @@ public class TestNameIdentifier {
     NameIdentifier id1 = NameIdentifier.parse("a");
     NameIdentifier id2 = NameIdentifier.parse("a.b.c");
 
-    assertEquals(id1.toString(), "a");
-    assertEquals(id2.toString(), "a.b.c");
+    assertEquals("a", id1.toString());
+    assertEquals("a.b.c", id2.toString());
   }
 
   @Test

--- a/api/src/test/java/com/datastrato/gravitino/rel/TestLiteral.java
+++ b/api/src/test/java/com/datastrato/gravitino/rel/TestLiteral.java
@@ -33,53 +33,53 @@ public class TestLiteral {
   @Test
   public void testLiterals() {
     Literal<?> literal = booleanLiteral(Boolean.valueOf("true"));
-    Assertions.assertEquals(literal.value(), true);
-    Assertions.assertEquals(literal.dataType(), Types.BooleanType.get());
+    Assertions.assertEquals(true, literal.value());
+    Assertions.assertEquals(Types.BooleanType.get(), literal.dataType());
 
     literal = byteLiteral(Byte.valueOf("1"));
-    Assertions.assertEquals(literal.value(), (byte) 1);
-    Assertions.assertEquals(literal.dataType(), Types.ByteType.get());
+    Assertions.assertEquals((byte) 1, literal.value());
+    Assertions.assertEquals(Types.ByteType.get(), literal.dataType());
 
     literal = shortLiteral(Short.valueOf("1"));
-    Assertions.assertEquals(literal.value(), (short) 1);
-    Assertions.assertEquals(literal.dataType(), Types.ShortType.get());
+    Assertions.assertEquals((short) 1, literal.value());
+    Assertions.assertEquals(Types.ShortType.get(), literal.dataType());
 
     literal = integerLiteral(Integer.valueOf("1"));
-    Assertions.assertEquals(literal.value(), 1);
-    Assertions.assertEquals(literal.dataType(), Types.IntegerType.get());
+    Assertions.assertEquals(1, literal.value());
+    Assertions.assertEquals(Types.IntegerType.get(), literal.dataType());
 
     literal = longLiteral(Long.valueOf("1"));
-    Assertions.assertEquals(literal.value(), 1L);
-    Assertions.assertEquals(literal.dataType(), Types.LongType.get());
+    Assertions.assertEquals(1L, literal.value());
+    Assertions.assertEquals(Types.LongType.get(), literal.dataType());
 
     literal = floatLiteral(Float.valueOf("1.234"));
-    Assertions.assertEquals(literal.value(), 1.234f);
-    Assertions.assertEquals(literal.dataType(), Types.FloatType.get());
+    Assertions.assertEquals(1.234f, literal.value());
+    Assertions.assertEquals(Types.FloatType.get(), literal.dataType());
 
     literal = doubleLiteral(Double.valueOf("1.234"));
-    Assertions.assertEquals(literal.value(), 1.234d);
-    Assertions.assertEquals(literal.dataType(), Types.DoubleType.get());
+    Assertions.assertEquals(1.234d, literal.value());
+    Assertions.assertEquals(Types.DoubleType.get(), literal.dataType());
 
     literal = dateLiteral(LocalDate.parse("2020-01-01"));
-    Assertions.assertEquals(literal.value(), LocalDate.of(2020, 1, 1));
-    Assertions.assertEquals(literal.dataType(), Types.DateType.get());
+    Assertions.assertEquals(LocalDate.of(2020, 1, 1), literal.value());
+    Assertions.assertEquals(Types.DateType.get(), literal.dataType());
 
     literal = timeLiteral(LocalTime.parse("12:34:56"));
-    Assertions.assertEquals(literal.value(), LocalTime.of(12, 34, 56));
-    Assertions.assertEquals(literal.dataType(), Types.TimeType.get());
+    Assertions.assertEquals(LocalTime.of(12, 34, 56), literal.value());
+    Assertions.assertEquals(Types.TimeType.get(), literal.dataType());
 
     literal = timestampLiteral(LocalDateTime.parse("2020-01-01T12:34:56"));
-    Assertions.assertEquals(literal.value(), LocalDateTime.of(2020, 1, 1, 12, 34, 56));
-    Assertions.assertEquals(literal.dataType(), Types.TimestampType.withoutTimeZone());
+    Assertions.assertEquals(LocalDateTime.of(2020, 1, 1, 12, 34, 56), literal.value());
+    Assertions.assertEquals(Types.TimestampType.withoutTimeZone(), literal.dataType());
 
     literal = stringLiteral("hello");
-    Assertions.assertEquals(literal.value(), "hello");
-    Assertions.assertEquals(literal.dataType(), Types.StringType.get());
+    Assertions.assertEquals("hello", literal.value());
+    Assertions.assertEquals(Types.StringType.get(), literal.dataType());
 
-    Assertions.assertEquals(Literals.of(null, Types.NullType.get()), Literals.NULL);
+    Assertions.assertEquals(Literals.NULL, Literals.of(null, Types.NullType.get()));
 
     literal = decimalLiteral(Decimal.of("0.00"));
-    Assertions.assertEquals(literal.value(), Decimal.of(new BigDecimal("0.00")));
-    Assertions.assertEquals(literal.dataType(), Types.DecimalType.of(2, 2));
+    Assertions.assertEquals(Decimal.of(new BigDecimal("0.00")), literal.value());
+    Assertions.assertEquals(Types.DecimalType.of(2, 2), literal.dataType());
   }
 }

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveTable.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveTable.java
@@ -578,7 +578,7 @@ public class TestHiveTable extends MiniHiveMetastoreService {
 
     Assertions.assertEquals(HIVE_COMMENT + "_new", alteredTable.comment());
     Assertions.assertFalse(alteredTable.properties().containsKey("key1"));
-    Assertions.assertEquals(alteredTable.properties().get("key2"), "val2_new");
+    Assertions.assertEquals("val2_new", alteredTable.properties().get("key2"));
 
     Assertions.assertEquals(createdTable.auditInfo().creator(), alteredTable.auditInfo().creator());
     Assertions.assertNull(alteredTable.auditInfo().lastModifier());

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergTable.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergTable.java
@@ -481,7 +481,7 @@ public class TestIcebergTable {
 
     Assertions.assertEquals(ICEBERG_COMMENT + "_new", alteredTable.comment());
     Assertions.assertFalse(alteredTable.properties().containsKey("key1"));
-    Assertions.assertEquals(alteredTable.properties().get("key2"), "val2_new");
+    Assertions.assertEquals("val2_new", alteredTable.properties().get("key2"));
 
     Assertions.assertEquals(sortOrders.length, alteredTable.sortOrder().length);
 

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/TestConvertUtil.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/TestConvertUtil.java
@@ -150,13 +150,13 @@ public class TestConvertUtil extends TestBaseConvert {
         ConvertUtil.toIcebergType(
             true, com.datastrato.gravitino.rel.types.Types.DecimalType.of(9, 2));
     Assertions.assertTrue(decimalType instanceof Types.DecimalType);
-    Assertions.assertEquals(((Types.DecimalType) decimalType).precision(), 9);
-    Assertions.assertEquals(((Types.DecimalType) decimalType).scale(), 2);
+    Assertions.assertEquals(9, ((Types.DecimalType) decimalType).precision());
+    Assertions.assertEquals(2, ((Types.DecimalType) decimalType).scale());
 
     Type fixedCharType =
         ConvertUtil.toIcebergType(true, com.datastrato.gravitino.rel.types.Types.FixedType.of(9));
     Assertions.assertTrue(fixedCharType instanceof Types.FixedType);
-    Assertions.assertEquals(((Types.FixedType) fixedCharType).length(), 9);
+    Assertions.assertEquals(9, ((Types.FixedType) fixedCharType).length());
 
     com.datastrato.gravitino.rel.types.Type mapType =
         com.datastrato.gravitino.rel.types.Types.MapType.of(
@@ -219,15 +219,15 @@ public class TestConvertUtil extends TestBaseConvert {
     Assertions.assertTrue(
         decimalType instanceof com.datastrato.gravitino.rel.types.Types.DecimalType);
     Assertions.assertEquals(
-        ((com.datastrato.gravitino.rel.types.Types.DecimalType) decimalType).precision(), 9);
+        9, ((com.datastrato.gravitino.rel.types.Types.DecimalType) decimalType).precision());
     Assertions.assertEquals(
-        ((com.datastrato.gravitino.rel.types.Types.DecimalType) decimalType).scale(), 2);
+        2, ((com.datastrato.gravitino.rel.types.Types.DecimalType) decimalType).scale());
 
     com.datastrato.gravitino.rel.types.Type fixedType =
         ConvertUtil.formIcebergType(Types.FixedType.ofLength(2));
     Assertions.assertTrue(fixedType instanceof com.datastrato.gravitino.rel.types.Types.FixedType);
     Assertions.assertEquals(
-        ((com.datastrato.gravitino.rel.types.Types.FixedType) fixedType).length(), 2);
+        2, ((com.datastrato.gravitino.rel.types.Types.FixedType) fixedType).length());
 
     Types.MapType mapType =
         Types.MapType.ofOptional(1, 2, Types.StringType.get(), Types.IntegerType.get());

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/TestFromIcebergSortOrder.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/TestFromIcebergSortOrder.java
@@ -61,7 +61,7 @@ public class TestFromIcebergSortOrder extends TestBaseConvert {
         NullOrder.NULLS_FIRST);
     org.apache.iceberg.SortOrder icebergSortOrder = sortOrderBuilder.build();
     SortOrder[] sortOrders = FromIcebergSortOrder.fromSortOrder(sortOrderBuilder.build());
-    Assertions.assertEquals(sortOrders.length, 7);
+    Assertions.assertEquals(7, sortOrders.length);
 
     Map<String, SortOrder> sortOrderByName =
         Arrays.stream(sortOrders)

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/web/rest/TestIcebergConfig.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/web/rest/TestIcebergConfig.java
@@ -31,8 +31,8 @@ public class TestIcebergConfig extends IcebergTestBase {
     Assertions.assertEquals(MediaType.APPLICATION_JSON_TYPE, resp.getMediaType());
 
     ConfigResponse response = resp.readEntity(ConfigResponse.class);
-    Assertions.assertEquals(response.defaults().size(), 0);
-    Assertions.assertEquals(response.overrides().size(), 0);
+    Assertions.assertEquals(0, response.defaults().size());
+    Assertions.assertEquals(0, response.overrides().size());
   }
 
   @ParameterizedTest

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/web/rest/TestIcebergNamespaceOperations.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/web/rest/TestIcebergNamespaceOperations.java
@@ -192,9 +192,9 @@ public class TestIcebergNamespaceOperations extends IcebergTestBase {
 
     UpdateNamespacePropertiesResponse r =
         response.readEntity(UpdateNamespacePropertiesResponse.class);
-    Assertions.assertEquals(r.removed(), Arrays.asList("a"));
-    Assertions.assertEquals(r.missing(), Arrays.asList("a1"));
-    Assertions.assertEquals(r.updated(), Arrays.asList("b"));
+    Assertions.assertEquals(Arrays.asList("a"), r.removed());
+    Assertions.assertEquals(Arrays.asList("a1"), r.missing());
+    Assertions.assertEquals(Arrays.asList("b"), r.updated());
   }
 
   private void verifyUpdateNamespaceFail(int status, String name) {

--- a/common/src/test/java/com/datastrato/gravitino/dto/responses/TestResponses.java
+++ b/common/src/test/java/com/datastrato/gravitino/dto/responses/TestResponses.java
@@ -62,7 +62,7 @@ public class TestResponses {
     entityList.validate(); // No exception thrown
     NameIdentifier[] identsB = entityList.identifiers();
     assertEquals(1, identsB.length);
-    assertEquals(identsB[0].name(), "TableA");
+    assertEquals("TableA", identsB[0].name());
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Swap order of assertEquals parameters to be correct

### Why are the changes needed?

If the test fails the error message will be misleading.

Fix: #2209

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Built and run test locally all passed.
