### PR TITLE
[#2187] Improvement: Remove redundant null check when using instanceof

### DIFF
--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveClientPool.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveClientPool.java
@@ -112,8 +112,7 @@ public class HiveClientPool extends ClientPoolImpl<IMetaStoreClient, TException>
   @Override
   protected boolean isConnectionException(Exception e) {
     return super.isConnectionException(e)
-        || (e != null
-            && e instanceof MetaException
+        || (e instanceof MetaException
             && e.getMessage()
                 .contains("Got exception: org.apache.thrift.transport.TTransportException"));
   }


### PR DESCRIPTION
<!--
1. Title: [#2187] Improvement: Remove redundant null checks when using instanceof
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Remove redundant null check when using `instanceof`.

### Why are the changes needed?

Fix: https://github.com/datastrato/gravitino/issues/2187
### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested with existing tests.