### PR TITLE
[#2161] Improvement: Fix JavaDoc in KerberosServerUtils.java

### DIFF
--- a/server-common/src/main/java/com/datastrato/gravitino/server/auth/KerberosServerUtils.java
+++ b/server-common/src/main/java/com/datastrato/gravitino/server/auth/KerberosServerUtils.java
@@ -1,13 +1,13 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
  * agreements. See the NOTICE file distributed with this work for additional information regarding
  * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
  *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * Unless required by applicable law or agreed to in writing, software distributed under the
  * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
@@ -77,22 +77,21 @@ public class KerberosServerUtils {
     }
   }
 
-  /*
-   * For a Service Host Principal specification, map the host's domain
-   * to kerberos realm, as specified by krb5.conf [domain_realm] mappings.
-   * Unfortunately the mapping routines are private to the security.krb5
-   * package, so have to construct a PrincipalName instance to derive the realm.
+  /**
+   * For a Service Host Principal specification, map the host's domain to kerberos realm, as
+   * specified by krb5.conf [domain_realm] mappings. Unfortunately the mapping routines are private
+   * to the security.krb5 package, so have to construct a PrincipalName instance to derive the
+   * realm.
    *
-   * Many things can go wrong with Kerberos configuration, and this is not
-   * the place to be throwing exceptions to help debug them.  Nor do we choose
-   * to make potentially voluminous logs on every call to a communications API.
-   * So we simply swallow all exceptions from the underlying libraries and
-   * return null if we can't get a good value for the realmString.
+   * <p>Many things can go wrong with Kerberos configuration, and this is not the place to be
+   * throwing exceptions to help debug them. Nor do we choose to make potentially voluminous logs on
+   * every call to a communications API. So we simply swallow all exceptions from the underlying
+   * libraries and return null if we can't get a good value for the realmString.
    *
    * @param shortprinc A service principal name with host fqdn as instance, e.g.
    *     "HTTP/myhost.mydomain"
-   * @return String value of Kerberos realm, mapped from host fqdn
-   *     May be default realm, or may be null.
+   * @return String value of Kerberos realm, mapped from host fqdn May be default realm, or may be
+   *     null.
    */
   public static String getDomainRealm(String shortprinc) {
     Class<?> classRef;


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
- Convert L80-94 into javadoc
- Follow conventions in other class, convert license comment into block comment

### Why are the changes needed?
Fix https://github.com/datastrato/gravitino/issues/2161

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Update comments only.

