### PR TITLE
[#1268] improvement(build): clean bin directory when executing gradle…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -495,6 +495,9 @@ tasks {
   val cleanDistribution by registering(Delete::class) {
     group = "gravitino distribution"
     delete(outputDir)
+    subprojects.forEach {
+      delete(it.file("bin"))
+    }
   }
 
   register("copySubprojectDependencies", Copy::class) {


### PR DESCRIPTION

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

close #1268 

### Why are the changes needed?

Fix: #1268 

### Does this PR introduce _any_ user-facing change?

- no

### How was this patch tested?

- execute `./gradlew clean` on local compute machine, there will no `*.class` left.
