### PR TITLE
[Minor] Improve assert throws tests

### DIFF
--- a/api/src/test/java/com/datastrato/gravitino/TestNameIdentifier.java
+++ b/api/src/test/java/com/datastrato/gravitino/TestNameIdentifier.java
@@ -41,9 +41,10 @@ public class TestNameIdentifier {
     assertThrows(IllegalArgumentException.class, () -> NameIdentifier.of("a", null));
     assertThrows(IllegalArgumentException.class, () -> NameIdentifier.of("a", ""));
 
+    Namespace empty = Namespace.empty();
     assertThrows(IllegalArgumentException.class, () -> NameIdentifier.of(null, "a"));
-    assertThrows(IllegalArgumentException.class, () -> NameIdentifier.of(Namespace.empty(), null));
-    assertThrows(IllegalArgumentException.class, () -> NameIdentifier.of(Namespace.empty(), ""));
+    assertThrows(IllegalArgumentException.class, () -> NameIdentifier.of(empty, null));
+    assertThrows(IllegalArgumentException.class, () -> NameIdentifier.of(empty, ""));
 
     assertThrows(IllegalArgumentException.class, () -> NameIdentifier.parse(null));
     assertThrows(IllegalArgumentException.class, () -> NameIdentifier.parse(""));
@@ -94,36 +95,31 @@ public class TestNameIdentifier {
 
   @Test
   public void testCheckNameIdentifier() {
+    NameIdentifier abc = NameIdentifier.of("a", "b", "c");
+    NameIdentifier abcd = NameIdentifier.of("a", "b", "c", "d");
+
     // Test metalake
     assertThrows(IllegalNameIdentifierException.class, () -> NameIdentifier.checkMetalake(null));
     Throwable excep =
-        assertThrows(
-            IllegalNamespaceException.class,
-            () -> NameIdentifier.checkMetalake(NameIdentifier.of("a", "b", "c")));
+        assertThrows(IllegalNamespaceException.class, () -> NameIdentifier.checkMetalake(abc));
     assertTrue(excep.getMessage().contains("Metalake namespace must be non-null and empty"));
 
     // test catalog
     assertThrows(IllegalNameIdentifierException.class, () -> NameIdentifier.checkCatalog(null));
     Throwable excep1 =
-        assertThrows(
-            IllegalNamespaceException.class,
-            () -> NameIdentifier.checkCatalog(NameIdentifier.of("a", "b", "c")));
+        assertThrows(IllegalNamespaceException.class, () -> NameIdentifier.checkCatalog(abc));
     assertTrue(excep1.getMessage().contains("Catalog namespace must be non-null and have 1 level"));
 
     // test schema
     assertThrows(IllegalNameIdentifierException.class, () -> NameIdentifier.checkSchema(null));
     Throwable excep2 =
-        assertThrows(
-            IllegalNamespaceException.class,
-            () -> NameIdentifier.checkSchema(NameIdentifier.of("a", "b", "c", "d")));
+        assertThrows(IllegalNamespaceException.class, () -> NameIdentifier.checkSchema(abcd));
     assertTrue(excep2.getMessage().contains("Schema namespace must be non-null and have 2 levels"));
 
     // test table
     assertThrows(IllegalNameIdentifierException.class, () -> NameIdentifier.checkTable(null));
     Throwable excep3 =
-        assertThrows(
-            IllegalNamespaceException.class,
-            () -> NameIdentifier.checkTable(NameIdentifier.of("a", "b", "c")));
+        assertThrows(IllegalNamespaceException.class, () -> NameIdentifier.checkTable(abc));
     assertTrue(excep3.getMessage().contains("Table namespace must be non-null and have 3 levels"));
   }
 }

--- a/api/src/test/java/com/datastrato/gravitino/TestNamespace.java
+++ b/api/src/test/java/com/datastrato/gravitino/TestNamespace.java
@@ -36,36 +36,35 @@ public class TestNamespace {
 
   @Test
   public void testCheckNamespace() {
+    Namespace a = Namespace.of("a");
+    Namespace ab = Namespace.of("a", "b");
+    Namespace abcd = Namespace.of("a", "b", "c", "d");
+
     // Test metalake
     Assertions.assertThrows(IllegalNamespaceException.class, () -> Namespace.checkMetalake(null));
     Throwable excep =
-        Assertions.assertThrows(
-            IllegalNamespaceException.class, () -> Namespace.checkMetalake(Namespace.of("a", "b")));
+        Assertions.assertThrows(IllegalNamespaceException.class, () -> Namespace.checkMetalake(ab));
     Assertions.assertTrue(
         excep.getMessage().contains("Metalake namespace must be non-null and empty"));
 
     // Test catalog
     Assertions.assertThrows(IllegalNamespaceException.class, () -> Namespace.checkCatalog(null));
     Throwable excep1 =
-        Assertions.assertThrows(
-            IllegalNamespaceException.class, () -> Namespace.checkCatalog(Namespace.of("a", "b")));
+        Assertions.assertThrows(IllegalNamespaceException.class, () -> Namespace.checkCatalog(ab));
     Assertions.assertTrue(
         excep1.getMessage().contains("Catalog namespace must be non-null and have 1 level"));
 
     // Test schema
     Assertions.assertThrows(IllegalNamespaceException.class, () -> Namespace.checkSchema(null));
     Throwable excep2 =
-        Assertions.assertThrows(
-            IllegalNamespaceException.class, () -> Namespace.checkSchema(Namespace.of("a")));
+        Assertions.assertThrows(IllegalNamespaceException.class, () -> Namespace.checkSchema(a));
     Assertions.assertTrue(
         excep2.getMessage().contains("Schema namespace must be non-null and have 2 levels"));
 
     // Test table
     Assertions.assertThrows(IllegalNamespaceException.class, () -> Namespace.checkTable(null));
     Throwable excep3 =
-        Assertions.assertThrows(
-            IllegalNamespaceException.class,
-            () -> Namespace.checkTable(Namespace.of("a", "b", "c", "d")));
+        Assertions.assertThrows(IllegalNamespaceException.class, () -> Namespace.checkTable(abcd));
     Assertions.assertTrue(
         excep3.getMessage().contains("Table namespace must be non-null and have 3 levels"));
   }

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveCatalog.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveCatalog.java
@@ -7,6 +7,7 @@ package com.datastrato.gravitino.catalog.hive;
 import static com.datastrato.gravitino.catalog.hive.HiveCatalogPropertiesMeta.METASTORE_URIS;
 
 import com.datastrato.gravitino.Namespace;
+import com.datastrato.gravitino.catalog.PropertiesMetadata;
 import com.datastrato.gravitino.catalog.hive.miniHMS.MiniHiveMetastoreService;
 import com.datastrato.gravitino.meta.AuditInfo;
 import com.datastrato.gravitino.meta.CatalogEntity;
@@ -63,21 +64,24 @@ public class TestHiveCatalog extends MiniHiveMetastoreService {
             .build();
 
     Map<String, String> conf = Maps.newHashMap();
+    Map<String, String> properties = Maps.newHashMap();
+
     metastore.hiveConf().forEach(e -> conf.put(e.getKey(), e.getValue()));
 
     try (HiveCatalogOperations ops = new HiveCatalogOperations(entity)) {
       ops.initialize(conf);
+      PropertiesMetadata metadata = ops.catalogPropertiesMetadata();
+
       Assertions.assertDoesNotThrow(
           () -> {
             Map<String, String> map = Maps.newHashMap();
             map.put(METASTORE_URIS, "/tmp");
-            ops.catalogPropertiesMetadata().validatePropertyForCreate(map);
+            metadata.validatePropertyForCreate(map);
           });
 
       Throwable throwable =
           Assertions.assertThrows(
-              IllegalArgumentException.class,
-              () -> ops.catalogPropertiesMetadata().validatePropertyForCreate(Maps.newHashMap()));
+              IllegalArgumentException.class, () -> metadata.validatePropertyForCreate(properties));
 
       Assertions.assertTrue(
           throwable

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveSchema.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveSchema.java
@@ -15,6 +15,7 @@ import com.datastrato.gravitino.meta.AuditInfo;
 import com.datastrato.gravitino.meta.CatalogEntity;
 import com.datastrato.gravitino.rel.Schema;
 import com.datastrato.gravitino.rel.SchemaChange;
+import com.datastrato.gravitino.rel.SupportsSchemas;
 import com.google.common.collect.Maps;
 import java.time.Instant;
 import java.util.Arrays;
@@ -67,18 +68,19 @@ public class TestHiveSchema extends MiniHiveMetastoreService {
     properties.put("key1", "val1");
     properties.put("key2", "val2");
     String comment = "comment";
+    SupportsSchemas schemas = hiveCatalog.asSchemas();
 
-    Schema schema = hiveCatalog.asSchemas().createSchema(ident, comment, properties);
+    Schema schema = schemas.createSchema(ident, comment, properties);
     Assertions.assertEquals(ident.name(), schema.name());
     Assertions.assertEquals(comment, schema.comment());
     Assertions.assertEquals(properties, schema.properties());
 
-    Assertions.assertTrue(hiveCatalog.asSchemas().schemaExists(ident));
+    Assertions.assertTrue(schemas.schemaExists(ident));
 
-    NameIdentifier[] idents = hiveCatalog.asSchemas().listSchemas(ident.namespace());
+    NameIdentifier[] idents = schemas.listSchemas(ident.namespace());
     Assertions.assertTrue(Arrays.asList(idents).contains(ident));
 
-    Schema loadedSchema = hiveCatalog.asSchemas().loadSchema(ident);
+    Schema loadedSchema = schemas.loadSchema(ident);
     Assertions.assertEquals(schema.auditInfo().creator(), loadedSchema.auditInfo().creator());
     Assertions.assertNull(loadedSchema.auditInfo().createTime());
     Assertions.assertEquals("val1", loadedSchema.properties().get("key1"));
@@ -89,7 +91,7 @@ public class TestHiveSchema extends MiniHiveMetastoreService {
         Assertions.assertThrows(
             SchemaAlreadyExistsException.class,
             () -> {
-              hiveCatalog.asSchemas().createSchema(ident, comment, properties);
+              schemas.createSchema(ident, comment, properties);
             });
     Assertions.assertTrue(exception.getMessage().contains("already exists in Hive Metastore"));
   }

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveTable.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveTable.java
@@ -20,6 +20,7 @@ import com.datastrato.gravitino.meta.AuditInfo;
 import com.datastrato.gravitino.meta.CatalogEntity;
 import com.datastrato.gravitino.rel.Column;
 import com.datastrato.gravitino.rel.Table;
+import com.datastrato.gravitino.rel.TableCatalog;
 import com.datastrato.gravitino.rel.TableChange;
 import com.datastrato.gravitino.rel.expressions.NamedReference;
 import com.datastrato.gravitino.rel.expressions.distributions.Distribution;
@@ -186,20 +187,19 @@ public class TestHiveTable extends MiniHiveMetastoreService {
     }
 
     // Test exception
+    TableCatalog tableCatalog = hiveCatalog.asTableCatalog();
     Throwable exception =
         Assertions.assertThrows(
             TableAlreadyExistsException.class,
             () ->
-                hiveCatalog
-                    .asTableCatalog()
-                    .createTable(
-                        tableIdentifier,
-                        columns,
-                        HIVE_COMMENT,
-                        properties,
-                        new Transform[0],
-                        distribution,
-                        sortOrders));
+                tableCatalog.createTable(
+                    tableIdentifier,
+                    columns,
+                    HIVE_COMMENT,
+                    properties,
+                    new Transform[0],
+                    distribution,
+                    sortOrders));
     Assertions.assertTrue(exception.getMessage().contains("Table already exists"));
 
     HiveColumn illegalColumn =
@@ -214,16 +214,14 @@ public class TestHiveTable extends MiniHiveMetastoreService {
         Assertions.assertThrows(
             IllegalArgumentException.class,
             () ->
-                hiveCatalog
-                    .asTableCatalog()
-                    .createTable(
-                        tableIdentifier,
-                        new Column[] {illegalColumn},
-                        HIVE_COMMENT,
-                        properties,
-                        new Transform[0],
-                        distribution,
-                        sortOrders));
+                tableCatalog.createTable(
+                    tableIdentifier,
+                    new Column[] {illegalColumn},
+                    HIVE_COMMENT,
+                    properties,
+                    new Transform[0],
+                    distribution,
+                    sortOrders));
     Assertions.assertTrue(
         exception
             .getMessage()
@@ -243,16 +241,14 @@ public class TestHiveTable extends MiniHiveMetastoreService {
         Assertions.assertThrows(
             IllegalArgumentException.class,
             () ->
-                hiveCatalog
-                    .asTableCatalog()
-                    .createTable(
-                        tableIdentifier,
-                        new Column[] {withDefault},
-                        HIVE_COMMENT,
-                        properties,
-                        Transforms.EMPTY_TRANSFORM,
-                        distribution,
-                        sortOrders));
+                tableCatalog.createTable(
+                    tableIdentifier,
+                    new Column[] {withDefault},
+                    HIVE_COMMENT,
+                    properties,
+                    Transforms.EMPTY_TRANSFORM,
+                    distribution,
+                    sortOrders));
     Assertions.assertTrue(
         exception
             .getMessage()
@@ -286,17 +282,16 @@ public class TestHiveTable extends MiniHiveMetastoreService {
 
     Transform[] partitions = new Transform[] {identity(col2.name())};
 
+    TableCatalog tableCatalog = hiveCatalog.asTableCatalog();
     Table table =
-        hiveCatalog
-            .asTableCatalog()
-            .createTable(tableIdentifier, columns, HIVE_COMMENT, properties, partitions);
+        tableCatalog.createTable(tableIdentifier, columns, HIVE_COMMENT, properties, partitions);
     Assertions.assertEquals(tableIdentifier.name(), table.name());
     Assertions.assertEquals(HIVE_COMMENT, table.comment());
     Assertions.assertEquals("val1", table.properties().get("key1"));
     Assertions.assertEquals("val2", table.properties().get("key2"));
     Assertions.assertArrayEquals(partitions, table.partitioning());
 
-    Table loadedTable = hiveCatalog.asTableCatalog().loadTable(tableIdentifier);
+    Table loadedTable = tableCatalog.loadTable(tableIdentifier);
 
     Assertions.assertEquals(table.auditInfo().creator(), loadedTable.auditInfo().creator());
     Assertions.assertNull(loadedTable.auditInfo().lastModifier());
@@ -306,55 +301,41 @@ public class TestHiveTable extends MiniHiveMetastoreService {
     Assertions.assertEquals("val2", loadedTable.properties().get("key2"));
     Assertions.assertArrayEquals(partitions, loadedTable.partitioning());
 
-    Assertions.assertTrue(hiveCatalog.asTableCatalog().tableExists(tableIdentifier));
-    NameIdentifier[] tableIdents =
-        hiveCatalog.asTableCatalog().listTables(tableIdentifier.namespace());
+    Assertions.assertTrue(tableCatalog.tableExists(tableIdentifier));
+    NameIdentifier[] tableIdents = tableCatalog.listTables(tableIdentifier.namespace());
     Assertions.assertTrue(Arrays.asList(tableIdents).contains(tableIdentifier));
 
     // Test exception
+    Transform[] partitions2 = new Transform[] {day(new String[] {col2.name()})};
     Throwable exception =
         Assertions.assertThrows(
             IllegalArgumentException.class,
             () ->
-                hiveCatalog
-                    .asTableCatalog()
-                    .createTable(
-                        tableIdentifier,
-                        columns,
-                        HIVE_COMMENT,
-                        properties,
-                        new Transform[] {day(new String[] {col2.name()})}));
+                tableCatalog.createTable(
+                    tableIdentifier, columns, HIVE_COMMENT, properties, partitions2));
     Assertions.assertTrue(
         exception.getMessage().contains("Hive partition only supports identity transform"));
+
+    Transform[] partitions3 = new Transform[] {identity(new String[] {col1.name(), col2.name()})};
+    String hiveName = hiveCatalog.name();
+    String schemaName = hiveSchema.name();
+    String randomName = genRandomName();
+    NameIdentifier randid = NameIdentifier.of(META_LAKE_NAME, hiveName, schemaName, randomName);
 
     exception =
         Assertions.assertThrows(
             RuntimeException.class,
-            () ->
-                hiveCatalog
-                    .asTableCatalog()
-                    .createTable(
-                        NameIdentifier.of(
-                            META_LAKE_NAME, hiveCatalog.name(), hiveSchema.name(), genRandomName()),
-                        columns,
-                        HIVE_COMMENT,
-                        properties,
-                        new Transform[] {identity(new String[] {col1.name(), col2.name()})}));
+            () -> tableCatalog.createTable(randid, columns, HIVE_COMMENT, properties, partitions3));
     Assertions.assertTrue(
         exception.getMessage().contains("Hive partition does not support nested field"));
 
+    Transform[] partitions4 = new Transform[] {identity(new String[] {col1.name()})};
     exception =
         Assertions.assertThrows(
             IllegalArgumentException.class,
             () ->
-                hiveCatalog
-                    .asTableCatalog()
-                    .createTable(
-                        tableIdentifier,
-                        columns,
-                        HIVE_COMMENT,
-                        properties,
-                        new Transform[] {identity(new String[] {col1.name()})}));
+                tableCatalog.createTable(
+                    tableIdentifier, columns, HIVE_COMMENT, properties, partitions4));
     Assertions.assertEquals(
         "The partition field must be placed at the end of the columns in order",
         exception.getMessage());
@@ -401,9 +382,10 @@ public class TestHiveTable extends MiniHiveMetastoreService {
   @Test
   public void testListTableException() {
     Namespace tableNs = Namespace.of("metalake", hiveCatalog.name(), "not_exist_db");
+    TableCatalog tableCatalog = hiveCatalog.asTableCatalog();
     Throwable exception =
         Assertions.assertThrows(
-            NoSuchSchemaException.class, () -> hiveCatalog.asTableCatalog().listTables(tableNs));
+            NoSuchSchemaException.class, () -> tableCatalog.listTables(tableNs));
     Assertions.assertTrue(exception.getMessage().contains("Schema (database) does not exist"));
   }
 
@@ -433,71 +415,54 @@ public class TestHiveTable extends MiniHiveMetastoreService {
     Distribution distribution = createDistribution();
     SortOrder[] sortOrders = createSortOrder();
 
+    TableCatalog tableCatalog = hiveCatalog.asTableCatalog();
     Table createdTable =
-        hiveCatalog
-            .asTableCatalog()
-            .createTable(
-                tableIdentifier,
-                columns,
-                HIVE_COMMENT,
-                properties,
-                new Transform[] {identity(col2.name())},
-                distribution,
-                sortOrders);
+        tableCatalog.createTable(
+            tableIdentifier,
+            columns,
+            HIVE_COMMENT,
+            properties,
+            new Transform[] {identity(col2.name())},
+            distribution,
+            sortOrders);
     Assertions.assertTrue(hiveCatalog.asTableCatalog().tableExists(tableIdentifier));
 
+    TableChange tableChange1 =
+        TableChange.updateColumnPosition(
+            new String[] {"not_exist_col"}, TableChange.ColumnPosition.after("col_1"));
     // test exception
     Throwable exception =
         Assertions.assertThrows(
             IllegalArgumentException.class,
-            () ->
-                hiveCatalog
-                    .asTableCatalog()
-                    .alterTable(
-                        tableIdentifier,
-                        TableChange.updateColumnPosition(
-                            new String[] {"not_exist_col"},
-                            TableChange.ColumnPosition.after("col_1"))));
+            () -> tableCatalog.alterTable(tableIdentifier, tableChange1));
     Assertions.assertTrue(exception.getMessage().contains("UpdateColumnPosition does not exist"));
 
+    TableChange tableChange2 =
+        TableChange.updateColumnPosition(
+            new String[] {"col_1"}, TableChange.ColumnPosition.after("not_exist_col"));
+
     exception =
         Assertions.assertThrows(
             IllegalArgumentException.class,
-            () ->
-                hiveCatalog
-                    .asTableCatalog()
-                    .alterTable(
-                        tableIdentifier,
-                        TableChange.updateColumnPosition(
-                            new String[] {"col_1"},
-                            TableChange.ColumnPosition.after("not_exist_col"))));
+            () -> tableCatalog.alterTable(tableIdentifier, tableChange2));
     Assertions.assertTrue(exception.getMessage().contains("Column does not exist"));
 
-    exception =
-        Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                hiveCatalog
-                    .asTableCatalog()
-                    .alterTable(
-                        tableIdentifier,
-                        TableChange.updateColumnPosition(new String[] {"col_1"}, null)));
-    Assertions.assertTrue(exception.getMessage().contains("Column position cannot be null"));
+    TableChange tableChange3 = TableChange.updateColumnPosition(new String[] {"col_1"}, null);
 
     exception =
         Assertions.assertThrows(
             IllegalArgumentException.class,
-            () ->
-                hiveCatalog
-                    .asTableCatalog()
-                    .alterTable(
-                        tableIdentifier,
-                        TableChange.addColumn(
-                            new String[] {"col_3"},
-                            Types.ByteType.get(),
-                            null,
-                            TableChange.ColumnPosition.first(),
-                            false)));
+            () -> tableCatalog.alterTable(tableIdentifier, tableChange3));
+    Assertions.assertTrue(exception.getMessage().contains("Column position cannot be null"));
+
+    TableChange.ColumnPosition first = TableChange.ColumnPosition.first();
+    TableChange tableChange4 =
+        TableChange.addColumn(new String[] {"col_3"}, Types.ByteType.get(), null, first, false);
+
+    exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> tableCatalog.alterTable(tableIdentifier, tableChange4));
     Assertions.assertTrue(
         exception
             .getMessage()
@@ -505,76 +470,58 @@ public class TestHiveTable extends MiniHiveMetastoreService {
                 "The NOT NULL constraint for column is only supported since Hive 3.0, "
                     + "but the current Gravitino Hive catalog only supports Hive 2.x"));
 
+    TableChange.ColumnPosition pos = TableChange.ColumnPosition.after(col2.name());
+    TableChange tableChange5 =
+        TableChange.addColumn(new String[] {"col_3"}, Types.ByteType.get(), pos);
     exception =
         Assertions.assertThrows(
             IllegalArgumentException.class,
-            () ->
-                hiveCatalog
-                    .asTableCatalog()
-                    .alterTable(
-                        tableIdentifier,
-                        TableChange.addColumn(
-                            new String[] {"col_3"},
-                            Types.ByteType.get(),
-                            TableChange.ColumnPosition.after(col2.name()))));
+            () -> tableCatalog.alterTable(tableIdentifier, tableChange5));
     Assertions.assertTrue(
         exception.getMessage().contains("Cannot add column after partition column"));
 
+    pos = TableChange.ColumnPosition.after(col1.name());
+    TableChange tableChange6 =
+        TableChange.addColumn(new String[] {col1.name()}, Types.ByteType.get(), "comment", pos);
     exception =
         Assertions.assertThrows(
             IllegalArgumentException.class,
-            () ->
-                hiveCatalog
-                    .asTableCatalog()
-                    .alterTable(
-                        tableIdentifier,
-                        TableChange.addColumn(
-                            new String[] {col1.name()},
-                            Types.ByteType.get(),
-                            "comment",
-                            TableChange.ColumnPosition.after(col1.name()))));
+            () -> tableCatalog.alterTable(tableIdentifier, tableChange6));
     Assertions.assertTrue(exception.getMessage().contains("Cannot add column with duplicate name"));
 
+    TableChange tableChange7 = TableChange.updateColumnNullability(new String[] {"col_1"}, false);
     exception =
         Assertions.assertThrows(
             IllegalArgumentException.class,
-            () ->
-                hiveCatalog
-                    .asTableCatalog()
-                    .alterTable(
-                        tableIdentifier,
-                        TableChange.updateColumnNullability(new String[] {"col_1"}, false)));
+            () -> tableCatalog.alterTable(tableIdentifier, tableChange7));
     Assertions.assertEquals(
         "Hive does not support altering column nullability", exception.getMessage());
 
     // test alter
-    hiveCatalog
-        .asTableCatalog()
-        .alterTable(
-            tableIdentifier,
-            TableChange.rename("test_hive_table_new"),
-            TableChange.updateComment(HIVE_COMMENT + "_new"),
-            TableChange.removeProperty("key1"),
-            TableChange.setProperty("key2", "val2_new"),
-            // columns current format: [col_1:I8:comment, col_2:DATE:comment]
-            TableChange.addColumn(new String[] {"col_3"}, Types.StringType.get()),
-            // columns current format: [col_1:I8:comment, col_3:STRING:null, col_2:DATE:comment]
-            TableChange.renameColumn(new String[] {"col_3"}, "col_3_new"),
-            // columns current format: [col_1:I8:comment, col_3_new:STRING:null, col_2:DATE:comment]
-            TableChange.updateColumnComment(new String[] {"col_1"}, HIVE_COMMENT + "_new"),
-            // columns current format: [col_1:I8:comment_new, col_3_new:STRING:null,
-            // col_2:DATE:comment]
-            TableChange.updateColumnType(new String[] {"col_1"}, Types.IntegerType.get()),
-            // columns current format: [col_1:I32:comment_new, col_3_new:STRING:null,
-            // col_2:DATE:comment]
-            TableChange.updateColumnPosition(
-                new String[] {"col_3_new"}, TableChange.ColumnPosition.first())
-            // columns current: [col_3_new:STRING:null, col_1:I32:comment_new, col_2:DATE:comment]
-            );
+    tableCatalog.alterTable(
+        tableIdentifier,
+        TableChange.rename("test_hive_table_new"),
+        TableChange.updateComment(HIVE_COMMENT + "_new"),
+        TableChange.removeProperty("key1"),
+        TableChange.setProperty("key2", "val2_new"),
+        // columns current format: [col_1:I8:comment, col_2:DATE:comment]
+        TableChange.addColumn(new String[] {"col_3"}, Types.StringType.get()),
+        // columns current format: [col_1:I8:comment, col_3:STRING:null, col_2:DATE:comment]
+        TableChange.renameColumn(new String[] {"col_3"}, "col_3_new"),
+        // columns current format: [col_1:I8:comment, col_3_new:STRING:null, col_2:DATE:comment]
+        TableChange.updateColumnComment(new String[] {"col_1"}, HIVE_COMMENT + "_new"),
+        // columns current format: [col_1:I8:comment_new, col_3_new:STRING:null,
+        // col_2:DATE:comment]
+        TableChange.updateColumnType(new String[] {"col_1"}, Types.IntegerType.get()),
+        // columns current format: [col_1:I32:comment_new, col_3_new:STRING:null,
+        // col_2:DATE:comment]
+        TableChange.updateColumnPosition(
+            new String[] {"col_3_new"}, TableChange.ColumnPosition.first())
+        // columns current: [col_3_new:STRING:null, col_1:I32:comment_new, col_2:DATE:comment]
+        );
     Table alteredTable =
-        hiveCatalog
-            .asTableCatalog()
-            .loadTable(NameIdentifier.of(tableIdentifier.namespace(), "test_hive_table_new"));
+        tableCatalog.loadTable(
+            NameIdentifier.of(tableIdentifier.namespace(), "test_hive_table_new"));
 
     Assertions.assertEquals(HIVE_COMMENT + "_new", alteredTable.comment());
     Assertions.assertFalse(alteredTable.properties().containsKey("key1"));
@@ -607,21 +554,16 @@ public class TestHiveTable extends MiniHiveMetastoreService {
     Assertions.assertArrayEquals(expected, alteredTable.columns());
 
     // test delete column change
-    hiveCatalog
-        .asTableCatalog()
-        .alterTable(
-            NameIdentifier.of(tableIdentifier.namespace(), "test_hive_table_new"),
-            TableChange.deleteColumn(new String[] {"not_exist_col"}, true));
+    tableCatalog.alterTable(
+        NameIdentifier.of(tableIdentifier.namespace(), "test_hive_table_new"),
+        TableChange.deleteColumn(new String[] {"not_exist_col"}, true));
 
-    hiveCatalog
-        .asTableCatalog()
-        .alterTable(
-            NameIdentifier.of(tableIdentifier.namespace(), "test_hive_table_new"),
-            TableChange.deleteColumn(new String[] {"col_1"}, false));
+    tableCatalog.alterTable(
+        NameIdentifier.of(tableIdentifier.namespace(), "test_hive_table_new"),
+        TableChange.deleteColumn(new String[] {"col_1"}, false));
     Table alteredTable1 =
-        hiveCatalog
-            .asTableCatalog()
-            .loadTable(NameIdentifier.of(tableIdentifier.namespace(), "test_hive_table_new"));
+        tableCatalog.loadTable(
+            NameIdentifier.of(tableIdentifier.namespace(), "test_hive_table_new"));
     expected =
         Arrays.stream(expected).filter(c -> !"col_1".equals(c.name())).toArray(Column[]::new);
     Assertions.assertArrayEquals(expected, alteredTable1.columns());
@@ -699,24 +641,23 @@ public class TestHiveTable extends MiniHiveMetastoreService {
 
     Distribution distribution = createDistribution();
     SortOrder[] sortOrders = createSortOrder();
+    TableCatalog tableCatalog = hiveCatalog.asTableCatalog();
 
-    hiveCatalog
-        .asTableCatalog()
-        .createTable(
-            tableIdentifier,
-            columns,
-            HIVE_COMMENT,
-            properties,
-            new Transform[0],
-            distribution,
-            sortOrders);
-    Assertions.assertTrue(hiveCatalog.asTableCatalog().tableExists(tableIdentifier));
+    tableCatalog.createTable(
+        tableIdentifier,
+        columns,
+        HIVE_COMMENT,
+        properties,
+        new Transform[0],
+        distribution,
+        sortOrders);
+    Assertions.assertTrue(tableCatalog.tableExists(tableIdentifier));
     Assertions.assertThrows(
         UnsupportedOperationException.class,
         () -> {
-          hiveCatalog.asTableCatalog().purgeTable(tableIdentifier);
+          tableCatalog.purgeTable(tableIdentifier);
         },
         "Can't purge a external hive table");
-    Assertions.assertTrue(hiveCatalog.asTableCatalog().tableExists(tableIdentifier));
+    Assertions.assertTrue(tableCatalog.tableExists(tableIdentifier));
   }
 }

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveTableOperations.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveTableOperations.java
@@ -16,6 +16,7 @@ import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.catalog.hive.miniHMS.MiniHiveMetastoreService;
 import com.datastrato.gravitino.exceptions.NoSuchPartitionException;
 import com.datastrato.gravitino.rel.Column;
+import com.datastrato.gravitino.rel.SupportsPartitions;
 import com.datastrato.gravitino.rel.expressions.literals.Literal;
 import com.datastrato.gravitino.rel.expressions.literals.Literals;
 import com.datastrato.gravitino.rel.expressions.transforms.Transform;
@@ -99,14 +100,15 @@ public class TestHiveTableOperations extends MiniHiveMetastoreService {
 
   @Test
   public void testGetPartition() {
-    Partition partition = hiveTable.supportPartitions().getPartition(existingPartition.name());
+    SupportsPartitions partitions = hiveTable.supportPartitions();
+    Partition partition = partitions.getPartition(existingPartition.name());
     Assertions.assertEquals(existingPartition, partition);
 
     NoSuchPartitionException exception =
         Assertions.assertThrows(
             NoSuchPartitionException.class,
             () -> {
-              hiveTable.supportPartitions().getPartition("does_not_exist_partition");
+              partitions.getPartition("does_not_exist_partition");
             });
     Assertions.assertEquals(
         "Hive partition does_not_exist_partition does not exist in Hive Metastore",
@@ -124,8 +126,9 @@ public class TestHiveTableOperations extends MiniHiveMetastoreService {
         Partitions.identity(
             new String[][] {fieldCity, fieldDt}, new Literal<?>[] {valueCity, valueDt});
 
-    Partition addedPartition = hiveTable.supportPartitions().addPartition(partition);
-    Partition gotPartition = hiveTable.supportPartitions().getPartition(addedPartition.name());
+    SupportsPartitions partitions = hiveTable.supportPartitions();
+    Partition addedPartition = partitions.addPartition(partition);
+    Partition gotPartition = partitions.getPartition(addedPartition.name());
     Assertions.assertEquals(addedPartition, gotPartition);
 
     // test exception
@@ -134,8 +137,7 @@ public class TestHiveTableOperations extends MiniHiveMetastoreService {
     Partition partition1 = Partitions.identity(new String[][] {field1}, new Literal<?>[] {value1});
     IllegalArgumentException exception =
         Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () -> hiveTable.supportPartitions().addPartition(partition1));
+            IllegalArgumentException.class, () -> partitions.addPartition(partition1));
     Assertions.assertTrue(
         exception
             .getMessage()
@@ -149,8 +151,7 @@ public class TestHiveTableOperations extends MiniHiveMetastoreService {
         Partitions.identity(new String[][] {field1, field2}, new Literal<?>[] {value1, value2});
     exception =
         Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () -> hiveTable.supportPartitions().addPartition(partition2));
+            IllegalArgumentException.class, () -> partitions.addPartition(partition2));
     Assertions.assertTrue(
         exception
             .getMessage()

--- a/catalogs/catalog-jdbc-common/src/test/java/com/datastrato/gravitino/catalog/jdbc/operation/TestJdbcTableOperations.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/com/datastrato/gravitino/catalog/jdbc/operation/TestJdbcTableOperations.java
@@ -171,14 +171,12 @@ public class TestJdbcTableOperations {
     allTables = JDBC_TABLE_OPERATIONS.listTables(DATABASE_NAME);
     Assertions.assertEquals(newName, allTables.get(0));
 
+    TableChange tableChange =
+        TableChange.updateColumnType(new String[] {col_a.name()}, Types.StringType.get());
     // Sqlite does not support modifying the column type of table
     Assertions.assertThrows(
         UnsupportedOperationException.class,
-        () ->
-            JDBC_TABLE_OPERATIONS.alterTable(
-                DATABASE_NAME,
-                newName,
-                TableChange.updateColumnType(new String[] {col_a.name()}, Types.StringType.get())));
+        () -> JDBC_TABLE_OPERATIONS.alterTable(DATABASE_NAME, newName, tableChange));
 
     // delete table.
     JDBC_TABLE_OPERATIONS.drop(DATABASE_NAME, newName);

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/operation/TestPostgreSqlTableOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/operation/TestPostgreSqlTableOperations.java
@@ -48,17 +48,17 @@ public class TestPostgreSqlTableOperations {
         successBuilder.toString());
 
     // Test append index sql failed.
+    Index primary = Indexes.primary("test_pk", new String[][] {{"col_1", "col_2"}});
+    Index unique1 = Indexes.unique("u1_key", new String[][] {{"col_2", "col_3"}});
+    Index unique2 = Indexes.unique("u2_key", new String[][] {{"col_3", "col_4"}});
+    StringBuilder stringBuilder = new StringBuilder();
+
     IllegalArgumentException illegalArgumentException =
         Assertions.assertThrows(
             IllegalArgumentException.class,
             () ->
                 PostgreSqlTableOperations.appendIndexesSql(
-                    new Index[] {
-                      Indexes.primary("test_pk", new String[][] {{"col_1", "col_2"}}),
-                      Indexes.unique("u1_key", new String[][] {{"col_2", "col_3"}}),
-                      Indexes.unique("u2_key", new String[][] {{"col_3", "col_4"}})
-                    },
-                    new StringBuilder()));
+                    new Index[] {primary, unique1, unique2}, stringBuilder));
     Assertions.assertTrue(
         StringUtils.contains(
             illegalArgumentException.getMessage(),

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergCatalog.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergCatalog.java
@@ -6,6 +6,7 @@ package com.datastrato.gravitino.catalog.lakehouse.iceberg;
 
 import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.catalog.CatalogOperations;
+import com.datastrato.gravitino.catalog.PropertiesMetadata;
 import com.datastrato.gravitino.catalog.lakehouse.iceberg.ops.IcebergTableOps;
 import com.datastrato.gravitino.meta.AuditInfo;
 import com.datastrato.gravitino.meta.CatalogEntity;
@@ -64,27 +65,28 @@ public class TestIcebergCatalog {
 
     try (IcebergCatalogOperations ops = new IcebergCatalogOperations(entity)) {
       ops.initialize(conf);
+      Map<String, String> map1 = Maps.newHashMap();
+      map1.put(IcebergCatalogPropertiesMetadata.CATALOG_BACKEND_NAME, "test");
+      PropertiesMetadata metadata = ops.catalogPropertiesMetadata();
       Assertions.assertThrows(
           IllegalArgumentException.class,
           () -> {
-            Map<String, String> map = Maps.newHashMap();
-            map.put(IcebergCatalogPropertiesMetadata.CATALOG_BACKEND_NAME, "test");
-            ops.catalogPropertiesMetadata().validatePropertyForCreate(map);
+            metadata.validatePropertyForCreate(map1);
           });
 
+      Map<String, String> map2 = Maps.newHashMap();
+      map2.put(IcebergCatalogPropertiesMetadata.CATALOG_BACKEND_NAME, "hive");
+      map2.put(IcebergCatalogPropertiesMetadata.URI, "127.0.0.1");
+      map2.put(IcebergCatalogPropertiesMetadata.WAREHOUSE, "test");
       Assertions.assertDoesNotThrow(
           () -> {
-            Map<String, String> map = Maps.newHashMap();
-            map.put(IcebergCatalogPropertiesMetadata.CATALOG_BACKEND_NAME, "hive");
-            map.put(IcebergCatalogPropertiesMetadata.URI, "127.0.0.1");
-            map.put(IcebergCatalogPropertiesMetadata.WAREHOUSE, "test");
-            ops.catalogPropertiesMetadata().validatePropertyForCreate(map);
+            metadata.validatePropertyForCreate(map2);
           });
 
+      Map<String, String> map3 = Maps.newHashMap();
       Throwable throwable =
           Assertions.assertThrows(
-              IllegalArgumentException.class,
-              () -> ops.catalogPropertiesMetadata().validatePropertyForCreate(Maps.newHashMap()));
+              IllegalArgumentException.class, () -> metadata.validatePropertyForCreate(map3));
 
       Assertions.assertTrue(
           throwable.getMessage().contains(IcebergCatalogPropertiesMetadata.CATALOG_BACKEND_NAME));

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergTable.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergTable.java
@@ -12,6 +12,7 @@ import static com.datastrato.gravitino.rel.expressions.transforms.Transforms.tru
 
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
+import com.datastrato.gravitino.catalog.PropertiesMetadata;
 import com.datastrato.gravitino.exceptions.NoSuchSchemaException;
 import com.datastrato.gravitino.exceptions.TableAlreadyExistsException;
 import com.datastrato.gravitino.meta.AuditInfo;
@@ -224,20 +225,20 @@ public class TestIcebergTable {
             .withNullable(false)
             .withDefaultValue(Literals.NULL)
             .build();
+
+    TableCatalog tableCatalog = icebergCatalog.asTableCatalog();
     exception =
         Assertions.assertThrows(
             IllegalArgumentException.class,
             () ->
-                icebergCatalog
-                    .asTableCatalog()
-                    .createTable(
-                        tableIdentifier,
-                        new Column[] {withDefaultValue},
-                        ICEBERG_COMMENT,
-                        properties,
-                        EMPTY_TRANSFORM,
-                        Distributions.NONE,
-                        null));
+                tableCatalog.createTable(
+                    tableIdentifier,
+                    new Column[] {withDefaultValue},
+                    ICEBERG_COMMENT,
+                    properties,
+                    EMPTY_TRANSFORM,
+                    Distributions.NONE,
+                    null));
     Assertions.assertTrue(
         exception.getMessage().contains("Iceberg does not support column default value"),
         "The exception message is: " + exception.getMessage());
@@ -293,54 +294,32 @@ public class TestIcebergTable {
     Assertions.assertTrue(Arrays.asList(tableIdents).contains(tableIdentifier));
 
     // Test exception
+    TableCatalog tableCatalog = icebergCatalog.asTableCatalog();
+    Transform[] partitions1 = new Transform[] {day(col2.name())};
     Throwable exception =
         Assertions.assertThrows(
             TableAlreadyExistsException.class,
             () ->
-                icebergCatalog
-                    .asTableCatalog()
-                    .createTable(
-                        tableIdentifier,
-                        columns,
-                        ICEBERG_COMMENT,
-                        properties,
-                        new Transform[] {day(col2.name())}));
+                tableCatalog.createTable(
+                    tableIdentifier, columns, ICEBERG_COMMENT, properties, partitions1));
     Assertions.assertTrue(exception.getMessage().contains("Table already exists"));
 
+    String icebergName = icebergCatalog.name();
+    String schemaName = icebergSchema.name();
+    String randomName = genRandomName();
+    NameIdentifier id = NameIdentifier.of(META_LAKE_NAME, icebergName, schemaName, randomName);
+    Transform[] partitions2 = new Transform[] {identity(new String[] {col1.name(), col2.name()})};
     exception =
         Assertions.assertThrows(
             RuntimeException.class,
-            () ->
-                icebergCatalog
-                    .asTableCatalog()
-                    .createTable(
-                        NameIdentifier.of(
-                            META_LAKE_NAME,
-                            icebergCatalog.name(),
-                            icebergSchema.name(),
-                            genRandomName()),
-                        columns,
-                        ICEBERG_COMMENT,
-                        properties,
-                        new Transform[] {identity(new String[] {col1.name(), col2.name()})}));
+            () -> tableCatalog.createTable(id, columns, ICEBERG_COMMENT, properties, partitions2));
     Assertions.assertTrue(exception.getMessage().contains("Cannot find source column"));
 
+    Transform[] partitions3 = new Transform[] {identity("not_exist_field")};
     exception =
         Assertions.assertThrows(
             IllegalArgumentException.class,
-            () ->
-                icebergCatalog
-                    .asTableCatalog()
-                    .createTable(
-                        NameIdentifier.of(
-                            META_LAKE_NAME,
-                            icebergCatalog.name(),
-                            icebergSchema.name(),
-                            genRandomName()),
-                        columns,
-                        ICEBERG_COMMENT,
-                        properties,
-                        new Transform[] {identity("not_exist_field")}));
+            () -> tableCatalog.createTable(id, columns, ICEBERG_COMMENT, properties, partitions3));
     Assertions.assertTrue(
         exception.getMessage().contains("Cannot find source column: not_exist_field"));
   }
@@ -387,9 +366,10 @@ public class TestIcebergTable {
   @Test
   public void testListTableException() {
     Namespace tableNs = Namespace.of("metalake", icebergCatalog.name(), "not_exist_db");
+    TableCatalog tableCatalog = icebergCatalog.asTableCatalog();
     Throwable exception =
         Assertions.assertThrows(
-            NoSuchSchemaException.class, () -> icebergCatalog.asTableCatalog().listTables(tableNs));
+            NoSuchSchemaException.class, () -> tableCatalog.listTables(tableNs));
     Assertions.assertTrue(exception.getMessage().contains("Schema (database) does not exist"));
   }
 
@@ -433,16 +413,13 @@ public class TestIcebergTable {
                 sortOrders);
     Assertions.assertTrue(icebergCatalog.asTableCatalog().tableExists(tableIdentifier));
 
+    TableCatalog tableCatalog = icebergCatalog.asTableCatalog();
+    TableChange update = TableChange.updateComment(ICEBERG_COMMENT + "_new");
+    TableChange rename = TableChange.rename("test_iceberg_table_new");
     Throwable exception =
         Assertions.assertThrows(
             IllegalArgumentException.class,
-            () ->
-                icebergCatalog
-                    .asTableCatalog()
-                    .alterTable(
-                        tableIdentifier,
-                        TableChange.updateComment(ICEBERG_COMMENT + "_new"),
-                        TableChange.rename("test_iceberg_table_new")));
+            () -> tableCatalog.alterTable(tableIdentifier, update, rename));
     Assertions.assertTrue(
         exception.getMessage().contains("The operation to change the table name cannot"));
 
@@ -536,16 +513,17 @@ public class TestIcebergTable {
       map.put(IcebergTablePropertiesMetadata.SORT_ORDER, "test");
       map.put(IcebergTablePropertiesMetadata.IDENTIFIER_FIELDS, "test");
       for (Map.Entry<String, String> entry : map.entrySet()) {
+        HashMap<String, String> properties =
+            new HashMap<String, String>() {
+              {
+                put(entry.getKey(), entry.getValue());
+              }
+            };
+        PropertiesMetadata metadata = ops.tablePropertiesMetadata();
         Assertions.assertThrows(
             IllegalArgumentException.class,
             () -> {
-              ops.tablePropertiesMetadata()
-                  .validatePropertyForCreate(
-                      new HashMap<String, String>() {
-                        {
-                          put(entry.getKey(), entry.getValue());
-                        }
-                      });
+              metadata.validatePropertyForCreate(properties);
             });
       }
 
@@ -553,15 +531,16 @@ public class TestIcebergTable {
       map.put("key1", "val1");
       map.put("key2", "val2");
       for (Map.Entry<String, String> entry : map.entrySet()) {
+        HashMap<String, String> properties =
+            new HashMap<String, String>() {
+              {
+                put(entry.getKey(), entry.getValue());
+              }
+            };
+        PropertiesMetadata metadata = ops.tablePropertiesMetadata();
         Assertions.assertDoesNotThrow(
             () -> {
-              ops.tablePropertiesMetadata()
-                  .validatePropertyForCreate(
-                      new HashMap<String, String>() {
-                        {
-                          put(entry.getKey(), entry.getValue());
-                        }
-                      });
+              metadata.validatePropertyForCreate(properties);
             });
       }
     }

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergTable.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergTable.java
@@ -201,20 +201,19 @@ public class TestIcebergTable {
     // Compare sort and order
 
     // Test exception
+    TableCatalog tableCatalog = icebergCatalog.asTableCatalog();
     Throwable exception =
         Assertions.assertThrows(
             TableAlreadyExistsException.class,
             () ->
-                icebergCatalog
-                    .asTableCatalog()
-                    .createTable(
-                        tableIdentifier,
-                        columns,
-                        ICEBERG_COMMENT,
-                        properties,
-                        new Transform[0],
-                        Distributions.NONE,
-                        sortOrders));
+                tableCatalog.createTable(
+                    tableIdentifier,
+                    columns,
+                    ICEBERG_COMMENT,
+                    properties,
+                    new Transform[0],
+                    Distributions.NONE,
+                    sortOrders));
     Assertions.assertTrue(exception.getMessage().contains("Table already exists"));
 
     IcebergColumn withDefaultValue =
@@ -226,7 +225,6 @@ public class TestIcebergTable {
             .withDefaultValue(Literals.NULL)
             .build();
 
-    TableCatalog tableCatalog = icebergCatalog.asTableCatalog();
     exception =
         Assertions.assertThrows(
             IllegalArgumentException.class,

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/TestConvertUtil.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/TestConvertUtil.java
@@ -9,6 +9,8 @@ import com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergTable;
 import com.datastrato.gravitino.meta.AuditInfo;
 import com.datastrato.gravitino.rel.Column;
 import com.datastrato.gravitino.rel.expressions.sorts.SortOrder;
+import com.datastrato.gravitino.rel.types.Types.ByteType;
+import com.datastrato.gravitino.rel.types.Types.ShortType;
 import com.google.common.collect.Maps;
 import java.time.Instant;
 import java.util.Arrays;
@@ -81,23 +83,19 @@ public class TestConvertUtil extends TestBaseConvert {
 
   @Test
   public void testToPrimitiveType() {
+    ByteType byteType = ByteType.get();
     IllegalArgumentException exception =
         Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                ConvertUtil.toIcebergType(
-                    true, com.datastrato.gravitino.rel.types.Types.ByteType.get()));
+            IllegalArgumentException.class, () -> ConvertUtil.toIcebergType(true, byteType));
     Assertions.assertTrue(
         exception
             .getMessage()
             .contains("Iceberg do not support Byte and Short Type, use Integer instead"));
 
+    ShortType shortType = ShortType.get();
     exception =
         Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                ConvertUtil.toIcebergType(
-                    true, com.datastrato.gravitino.rel.types.Types.ShortType.get()));
+            IllegalArgumentException.class, () -> ConvertUtil.toIcebergType(true, shortType));
     Assertions.assertTrue(
         exception
             .getMessage()

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/ops/TestIcebergTableUpdate.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/ops/TestIcebergTableUpdate.java
@@ -298,14 +298,12 @@ public class TestIcebergTableUpdate {
     Assertions.assertTrue(loadTableResponse.tableMetadata().schema().columns().get(0).isOptional());
 
     // update struct_int from optional to required
+    TableChange tableChange =
+        TableChange.updateColumnNullability(
+            new String[] {fourthField[0], "element", "struct_map"}, false);
     IllegalArgumentException exception =
         Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                updateTable(
-                    identifier,
-                    TableChange.updateColumnNullability(
-                        new String[] {fourthField[0], "element", "struct_map"}, false)));
+            IllegalArgumentException.class, () -> updateTable(identifier, tableChange));
     Assertions.assertEquals(
         "Cannot change column nullability: foo_struct.element.struct_map: optional -> required",
         exception.getMessage());

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestGravitinoClient.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestGravitinoClient.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.Method;
@@ -94,7 +95,8 @@ public class TestGravitinoClient extends TestBase {
 
     MetalakeResponse resp = new MetalakeResponse(mockMetalake);
     buildMockResource(Method.GET, "/api/metalakes/mock", null, resp, HttpStatus.SC_OK);
-    GravitinoMetaLake metaLake = client.loadMetalake(NameIdentifier.of("mock"));
+    NameIdentifier id = NameIdentifier.of("mock");
+    GravitinoMetaLake metaLake = client.loadMetalake(id);
     Assertions.assertEquals("mock", metaLake.name());
     Assertions.assertEquals("comment", metaLake.comment());
     Assertions.assertEquals("creator", metaLake.auditInfo().creator());
@@ -104,23 +106,20 @@ public class TestGravitinoClient extends TestBase {
         ErrorResponse.notFound(NoSuchMetalakeException.class.getSimpleName(), "mock error");
     buildMockResource(Method.GET, "/api/metalakes/mock", null, errorResp, HttpStatus.SC_NOT_FOUND);
     Throwable excep =
-        Assertions.assertThrows(
-            NoSuchMetalakeException.class, () -> client.loadMetalake(NameIdentifier.of("mock")));
+        Assertions.assertThrows(NoSuchMetalakeException.class, () -> client.loadMetalake(id));
     Assertions.assertTrue(excep.getMessage().contains("mock error"));
 
     // Test illegal metalake name identifier
+    NameIdentifier badName = NameIdentifier.parse("mock.mock");
+
     Throwable excep1 =
-        Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () -> client.loadMetalake(NameIdentifier.parse("mock.mock")));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> client.loadMetalake(badName));
     Assertions.assertTrue(
         excep1.getMessage().contains("Metalake namespace must be non-null and empty"));
 
     // Test return unparsed system error
     buildMockResource(Method.GET, "/api/metalakes/mock", null, null, HttpStatus.SC_CONFLICT);
-    Throwable excep2 =
-        Assertions.assertThrows(
-            RESTException.class, () -> client.loadMetalake(NameIdentifier.of("mock")));
+    Throwable excep2 = Assertions.assertThrows(RESTException.class, () -> client.loadMetalake(id));
     Assertions.assertTrue(excep2.getMessage().contains("Error code: " + HttpStatus.SC_CONFLICT));
   }
 
@@ -138,8 +137,10 @@ public class TestGravitinoClient extends TestBase {
         new MetalakeCreateRequest("mock", "comment", Collections.emptyMap());
     MetalakeResponse resp = new MetalakeResponse(mockMetalake);
     buildMockResource(Method.POST, "/api/metalakes", req, resp, HttpStatus.SC_OK);
-    GravitinoMetaLake metaLake =
-        client.createMetalake(NameIdentifier.parse("mock"), "comment", Collections.emptyMap());
+    NameIdentifier id = NameIdentifier.parse("mock");
+    GravitinoMetaLake metaLake = client.createMetalake(id, "comment", Collections.emptyMap());
+    Map<String, String> emptyMap = Collections.emptyMap();
+
     Assertions.assertEquals("mock", metaLake.name());
     Assertions.assertEquals("comment", metaLake.comment());
     Assertions.assertEquals("creator", metaLake.auditInfo().creator());
@@ -152,19 +153,14 @@ public class TestGravitinoClient extends TestBase {
     Throwable excep =
         Assertions.assertThrows(
             MetalakeAlreadyExistsException.class,
-            () ->
-                client.createMetalake(
-                    NameIdentifier.parse("mock"), "comment", Collections.emptyMap()));
+            () -> client.createMetalake(id, "comment", emptyMap));
     Assertions.assertTrue(excep.getMessage().contains("mock error"));
 
     // Test return unparsed system error
     buildMockResource(Method.POST, "/api/metalakes", req, null, HttpStatus.SC_CONFLICT);
     Throwable excep1 =
         Assertions.assertThrows(
-            RESTException.class,
-            () ->
-                client.createMetalake(
-                    NameIdentifier.parse("mock"), "comment", Collections.emptyMap()));
+            RESTException.class, () -> client.createMetalake(id, "comment", emptyMap));
     Assertions.assertTrue(excep1.getMessage().contains("Error code: " + HttpStatus.SC_CONFLICT));
   }
 
@@ -190,7 +186,8 @@ public class TestGravitinoClient extends TestBase {
     MetalakeResponse resp = new MetalakeResponse(mockMetalake);
 
     buildMockResource(Method.PUT, "/api/metalakes/mock", req, resp, HttpStatus.SC_OK);
-    GravitinoMetaLake metaLake = client.alterMetalake(NameIdentifier.of("mock"), changes);
+    NameIdentifier id = NameIdentifier.of("mock");
+    GravitinoMetaLake metaLake = client.alterMetalake(id, changes);
     Assertions.assertEquals("newName", metaLake.name());
     Assertions.assertEquals("newComment", metaLake.comment());
     Assertions.assertEquals("creator", metaLake.auditInfo().creator());
@@ -201,15 +198,13 @@ public class TestGravitinoClient extends TestBase {
     buildMockResource(Method.PUT, "/api/metalakes/mock", req, errorResp, HttpStatus.SC_NOT_FOUND);
     Throwable excep =
         Assertions.assertThrows(
-            NoSuchMetalakeException.class,
-            () -> client.alterMetalake(NameIdentifier.of("mock"), changes));
+            NoSuchMetalakeException.class, () -> client.alterMetalake(id, changes));
     Assertions.assertTrue(excep.getMessage().contains("mock error"));
 
     // Test illegal argument
     Throwable excep1 =
         Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () -> client.alterMetalake(NameIdentifier.parse("mock.mock"), changes));
+            IllegalArgumentException.class, () -> client.alterMetalake(id, changes));
     Assertions.assertTrue(
         excep1.getMessage().contains("Metalake namespace must be non-null and empty"));
   }
@@ -231,10 +226,9 @@ public class TestGravitinoClient extends TestBase {
     Assertions.assertFalse(client.dropMetalake(NameIdentifier.of("mock")));
 
     // Test illegal metalake name identifier
+    NameIdentifier id = NameIdentifier.parse("mock.mock");
     Throwable excep1 =
-        Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () -> client.dropMetalake(NameIdentifier.parse("mock.mock")));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> client.dropMetalake(id));
     Assertions.assertTrue(
         excep1.getMessage().contains("Metalake namespace must be non-null and empty"));
   }

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestGravitinoClient.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestGravitinoClient.java
@@ -202,9 +202,10 @@ public class TestGravitinoClient extends TestBase {
     Assertions.assertTrue(excep.getMessage().contains("mock error"));
 
     // Test illegal argument
+    NameIdentifier id2 = NameIdentifier.parse("mock.mock");
     Throwable excep1 =
         Assertions.assertThrows(
-            IllegalArgumentException.class, () -> client.alterMetalake(id, changes));
+            IllegalArgumentException.class, () -> client.alterMetalake(id2, changes));
     Assertions.assertTrue(
         excep1.getMessage().contains("Metalake namespace must be non-null and empty"));
   }

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestGravitinoMetalake.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestGravitinoMetalake.java
@@ -29,6 +29,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.Method;
@@ -57,10 +58,11 @@ public class TestGravitinoMetalake extends TestBase {
 
     NameIdentifier ident1 = NameIdentifier.of(metalakeName, "mock");
     NameIdentifier ident2 = NameIdentifier.of(metalakeName, "mock2");
+    Namespace namespace = Namespace.of(metalakeName);
 
     EntityListResponse resp = new EntityListResponse(new NameIdentifier[] {ident1, ident2});
     buildMockResource(Method.GET, path, null, resp, HttpStatus.SC_OK);
-    NameIdentifier[] catalogs = metalake.listCatalogs(Namespace.of(metalakeName));
+    NameIdentifier[] catalogs = metalake.listCatalogs(namespace);
 
     Assertions.assertEquals(2, catalogs.length);
     Assertions.assertEquals(ident1, catalogs[0]);
@@ -69,22 +71,20 @@ public class TestGravitinoMetalake extends TestBase {
     // Test return empty catalog list
     EntityListResponse resp1 = new EntityListResponse(new NameIdentifier[] {});
     buildMockResource(Method.GET, path, null, resp1, HttpStatus.SC_OK);
-    NameIdentifier[] catalogs1 = metalake.listCatalogs(Namespace.of(metalakeName));
+    NameIdentifier[] catalogs1 = metalake.listCatalogs(namespace);
     Assertions.assertEquals(0, catalogs1.length);
 
     // Test return internal error
     ErrorResponse errorResp = ErrorResponse.internalError("mock error");
     buildMockResource(Method.GET, path, null, errorResp, HttpStatus.SC_INTERNAL_SERVER_ERROR);
     Throwable ex =
-        Assertions.assertThrows(
-            RuntimeException.class, () -> metalake.listCatalogs(Namespace.of(metalakeName)));
+        Assertions.assertThrows(RuntimeException.class, () -> metalake.listCatalogs(namespace));
     Assertions.assertTrue(ex.getMessage().contains("mock error"));
 
     // Test return unparsed system error
     buildMockResource(Method.GET, path, null, "mock error", HttpStatus.SC_CONFLICT);
     Throwable ex1 =
-        Assertions.assertThrows(
-            RESTException.class, () -> metalake.listCatalogs(Namespace.of(metalakeName)));
+        Assertions.assertThrows(RESTException.class, () -> metalake.listCatalogs(namespace));
     Assertions.assertTrue(ex1.getMessage().contains("Error code: " + HttpStatus.SC_CONFLICT));
   }
 
@@ -115,10 +115,9 @@ public class TestGravitinoMetalake extends TestBase {
     ErrorResponse errorResponse =
         ErrorResponse.notFound(NoSuchCatalogException.class.getSimpleName(), "mock error");
     buildMockResource(Method.GET, path, null, errorResponse, HttpStatus.SC_NOT_FOUND);
+    NameIdentifier id = NameIdentifier.of(metalakeName, catalogName);
     Throwable ex =
-        Assertions.assertThrows(
-            NoSuchCatalogException.class,
-            () -> metalake.loadCatalog(NameIdentifier.of(metalakeName, catalogName)));
+        Assertions.assertThrows(NoSuchCatalogException.class, () -> metalake.loadCatalog(id));
     Assertions.assertTrue(ex.getMessage().contains("mock error"));
 
     // Test return unsupported catalog type
@@ -133,25 +132,17 @@ public class TestGravitinoMetalake extends TestBase {
             .build();
     CatalogResponse resp1 = new CatalogResponse(mockCatalog1);
     buildMockResource(Method.GET, path, null, resp1, HttpStatus.SC_OK);
-    Assertions.assertThrows(
-        UnsupportedOperationException.class,
-        () -> metalake.loadCatalog(NameIdentifier.of(metalakeName, catalogName)));
+    Assertions.assertThrows(UnsupportedOperationException.class, () -> metalake.loadCatalog(id));
 
     // Test return internal error
     ErrorResponse errorResp = ErrorResponse.internalError("mock error");
     buildMockResource(Method.GET, path, null, errorResp, HttpStatus.SC_INTERNAL_SERVER_ERROR);
-    Throwable ex1 =
-        Assertions.assertThrows(
-            RuntimeException.class,
-            () -> metalake.loadCatalog(NameIdentifier.of(metalakeName, catalogName)));
+    Throwable ex1 = Assertions.assertThrows(RuntimeException.class, () -> metalake.loadCatalog(id));
     Assertions.assertTrue(ex1.getMessage().contains("mock error"));
 
     // Test return unparsed system error
     buildMockResource(Method.GET, path, null, "mock error", HttpStatus.SC_CONFLICT);
-    Throwable ex2 =
-        Assertions.assertThrows(
-            RESTException.class,
-            () -> metalake.loadCatalog(NameIdentifier.of(metalakeName, catalogName)));
+    Throwable ex2 = Assertions.assertThrows(RESTException.class, () -> metalake.loadCatalog(id));
     Assertions.assertTrue(ex2.getMessage().contains("Error code: " + HttpStatus.SC_CONFLICT));
   }
 
@@ -201,15 +192,12 @@ public class TestGravitinoMetalake extends TestBase {
             catalogName, Catalog.Type.FILE, provider, "comment", Collections.emptyMap());
     CatalogResponse resp1 = new CatalogResponse(mockCatalog1);
     buildMockResource(Method.POST, path, req1, resp1, HttpStatus.SC_OK);
+    NameIdentifier id = NameIdentifier.of(metalakeName, catalogName);
+    Map<String, String> emptyMap = Collections.emptyMap();
+
     Assertions.assertThrows(
         UnsupportedOperationException.class,
-        () ->
-            metalake.createCatalog(
-                NameIdentifier.of(metalakeName, catalogName),
-                Catalog.Type.FILE,
-                provider,
-                "comment",
-                Collections.emptyMap()));
+        () -> metalake.createCatalog(id, Catalog.Type.FILE, provider, "comment", emptyMap));
 
     // Test return NoSuchMetalakeException
     ErrorResponse errorResponse =
@@ -219,12 +207,7 @@ public class TestGravitinoMetalake extends TestBase {
         Assertions.assertThrows(
             NoSuchMetalakeException.class,
             () ->
-                metalake.createCatalog(
-                    NameIdentifier.of(metalakeName, catalogName),
-                    Catalog.Type.RELATIONAL,
-                    provider,
-                    "comment",
-                    Collections.emptyMap()));
+                metalake.createCatalog(id, Catalog.Type.RELATIONAL, provider, "comment", emptyMap));
     Assertions.assertTrue(ex.getMessage().contains("mock error"));
 
     // Test return CatalogAlreadyExistsException
@@ -236,12 +219,7 @@ public class TestGravitinoMetalake extends TestBase {
         Assertions.assertThrows(
             CatalogAlreadyExistsException.class,
             () ->
-                metalake.createCatalog(
-                    NameIdentifier.of(metalakeName, catalogName),
-                    Catalog.Type.RELATIONAL,
-                    provider,
-                    "comment",
-                    Collections.emptyMap()));
+                metalake.createCatalog(id, Catalog.Type.RELATIONAL, provider, "comment", emptyMap));
     Assertions.assertTrue(ex1.getMessage().contains("mock error"));
 
     // Test return internal error
@@ -251,12 +229,7 @@ public class TestGravitinoMetalake extends TestBase {
         Assertions.assertThrows(
             RuntimeException.class,
             () ->
-                metalake.createCatalog(
-                    NameIdentifier.of(metalakeName, catalogName),
-                    Catalog.Type.RELATIONAL,
-                    provider,
-                    "comment",
-                    Collections.emptyMap()));
+                metalake.createCatalog(id, Catalog.Type.RELATIONAL, provider, "comment", emptyMap));
     Assertions.assertTrue(ex2.getMessage().contains("mock error"));
   }
 
@@ -285,8 +258,8 @@ public class TestGravitinoMetalake extends TestBase {
     CatalogUpdatesRequest updatesRequest = new CatalogUpdatesRequest(reqs);
 
     buildMockResource(Method.PUT, path, updatesRequest, resp, HttpStatus.SC_OK);
-    Catalog catalog =
-        metalake.alterCatalog(NameIdentifier.of(metalakeName, catalogName), change1, change2);
+    NameIdentifier id = NameIdentifier.of(metalakeName, catalogName);
+    Catalog catalog = metalake.alterCatalog(id, change1, change2);
     Assertions.assertEquals("mock1", catalog.name());
     Assertions.assertEquals("comment1", catalog.comment());
     Assertions.assertEquals(Catalog.Type.RELATIONAL, catalog.type());
@@ -297,10 +270,7 @@ public class TestGravitinoMetalake extends TestBase {
     buildMockResource(Method.PUT, path, updatesRequest, errorResponse, HttpStatus.SC_NOT_FOUND);
     Throwable ex =
         Assertions.assertThrows(
-            NoSuchCatalogException.class,
-            () ->
-                metalake.alterCatalog(
-                    NameIdentifier.of(metalakeName, catalogName), change1, change2));
+            NoSuchCatalogException.class, () -> metalake.alterCatalog(id, change1, change2));
     Assertions.assertTrue(ex.getMessage().contains("mock error"));
 
     // Test return IllegalArgumentException
@@ -308,10 +278,7 @@ public class TestGravitinoMetalake extends TestBase {
     buildMockResource(Method.PUT, path, updatesRequest, errorResponse1, HttpStatus.SC_BAD_REQUEST);
     Throwable ex1 =
         Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                metalake.alterCatalog(
-                    NameIdentifier.of(metalakeName, catalogName), change1, change2));
+            IllegalArgumentException.class, () -> metalake.alterCatalog(id, change1, change2));
     Assertions.assertTrue(ex1.getMessage().contains("mock error"));
 
     // Test return internal error
@@ -320,10 +287,7 @@ public class TestGravitinoMetalake extends TestBase {
         Method.PUT, path, updatesRequest, errorResp, HttpStatus.SC_INTERNAL_SERVER_ERROR);
     Throwable ex2 =
         Assertions.assertThrows(
-            RuntimeException.class,
-            () ->
-                metalake.alterCatalog(
-                    NameIdentifier.of(metalakeName, catalogName), change1, change2));
+            RuntimeException.class, () -> metalake.alterCatalog(id, change1, change2));
     Assertions.assertTrue(ex2.getMessage().contains("mock error"));
   }
 

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestOAuth2TokenProvider.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestOAuth2TokenProvider.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 
 import com.datastrato.gravitino.auth.AuthConstants;
+import com.datastrato.gravitino.client.DefaultOAuth2TokenProvider.Builder;
 import com.datastrato.gravitino.dto.responses.OAuth2ErrorResponse;
 import com.datastrato.gravitino.dto.responses.OAuth2TokenResponse;
 import com.datastrato.gravitino.exceptions.BadRequestException;
@@ -46,21 +47,15 @@ public class TestOAuth2TokenProvider {
 
   @Test
   public void testProviderInitException() throws Exception {
+    Builder tokenProvider1 = DefaultOAuth2TokenProvider.builder().withUri("test");
+    Builder tokenProvider2 =
+        DefaultOAuth2TokenProvider.builder().withUri("test").withCredential("xx");
+    Builder tokenProvider3 =
+        DefaultOAuth2TokenProvider.builder().withUri("test").withCredential("xx").withScope("test");
 
-    Assertions.assertThrows(
-        IllegalArgumentException.class,
-        () -> DefaultOAuth2TokenProvider.builder().withUri("test").build());
-    Assertions.assertThrows(
-        IllegalArgumentException.class,
-        () -> DefaultOAuth2TokenProvider.builder().withUri("test").withCredential("xx").build());
-    Assertions.assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            DefaultOAuth2TokenProvider.builder()
-                .withUri("test")
-                .withCredential("xx")
-                .withScope("test")
-                .build());
+    Assertions.assertThrows(IllegalArgumentException.class, () -> tokenProvider1.build());
+    Assertions.assertThrows(IllegalArgumentException.class, () -> tokenProvider2.build());
+    Assertions.assertThrows(IllegalArgumentException.class, () -> tokenProvider3.build());
   }
 
   @Test

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalTable.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalTable.java
@@ -35,6 +35,7 @@ import com.datastrato.gravitino.dto.responses.TableResponse;
 import com.datastrato.gravitino.exceptions.NoSuchPartitionException;
 import com.datastrato.gravitino.exceptions.PartitionAlreadyExistsException;
 import com.datastrato.gravitino.rel.Schema;
+import com.datastrato.gravitino.rel.SupportsPartitions;
 import com.datastrato.gravitino.rel.Table;
 import com.datastrato.gravitino.rel.expressions.literals.Literal;
 import com.datastrato.gravitino.rel.expressions.literals.Literals;
@@ -181,10 +182,10 @@ public class TestRelationalTable extends TestRelationalCatalog {
         ErrorResponse.unsupportedOperation("table does not support partition operations");
     buildMockResource(Method.GET, partitionPath, null, errorResp, SC_NOT_IMPLEMENTED);
 
+    SupportsPartitions supportPartitions = partitionedTable.supportPartitions();
     UnsupportedOperationException exception =
         Assertions.assertThrows(
-            UnsupportedOperationException.class,
-            () -> partitionedTable.supportPartitions().listPartitions());
+            UnsupportedOperationException.class, () -> supportPartitions.listPartitions());
     Assertions.assertEquals("table does not support partition operations", exception.getMessage());
   }
 

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalTable.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalTable.java
@@ -142,10 +142,10 @@ public class TestRelationalTable extends TestRelationalCatalog {
         ErrorResponse.unsupportedOperation("table does not support partition operations");
     buildMockResource(Method.GET, partitionPath, null, errorResp, SC_NOT_IMPLEMENTED);
 
+    SupportsPartitions partitions = partitionedTable.supportPartitions();
     UnsupportedOperationException exception =
         Assertions.assertThrows(
-            UnsupportedOperationException.class,
-            () -> partitionedTable.supportPartitions().listPartitionNames());
+            UnsupportedOperationException.class, () -> partitions.listPartitionNames());
     Assertions.assertEquals("table does not support partition operations", exception.getMessage());
   }
 
@@ -224,10 +224,10 @@ public class TestRelationalTable extends TestRelationalCatalog {
             NoSuchPartitionException.class.getSimpleName(), "partition not found");
     buildMockResource(Method.GET, partitionPath, null, errorResp, SC_NOT_FOUND);
 
+    SupportsPartitions partitions = partitionedTable.supportPartitions();
     NoSuchPartitionException exception =
         Assertions.assertThrows(
-            NoSuchPartitionException.class,
-            () -> table.supportPartitions().getPartition(partitionName));
+            NoSuchPartitionException.class, () -> partitions.getPartition(partitionName));
     Assertions.assertEquals("partition not found", exception.getMessage());
   }
 
@@ -255,10 +255,10 @@ public class TestRelationalTable extends TestRelationalCatalog {
             PartitionAlreadyExistsException.class.getSimpleName(), "partition already exists");
     buildMockResource(Method.POST, partitionPath, req, errorResp, SC_CONFLICT);
 
+    SupportsPartitions partitions = partitionedTable.supportPartitions();
     PartitionAlreadyExistsException exception =
         Assertions.assertThrows(
-            PartitionAlreadyExistsException.class,
-            () -> partitionedTable.supportPartitions().addPartition(partition));
+            PartitionAlreadyExistsException.class, () -> partitions.addPartition(partition));
     Assertions.assertEquals("partition already exists", exception.getMessage());
   }
 }

--- a/common/src/test/java/com/datastrato/gravitino/json/TestDTOJsonSerDe.java
+++ b/common/src/test/java/com/datastrato/gravitino/json/TestDTOJsonSerDe.java
@@ -28,6 +28,7 @@ import com.datastrato.gravitino.dto.rel.partitioning.YearPartitioningDTO;
 import com.datastrato.gravitino.rel.Column;
 import com.datastrato.gravitino.rel.types.Type;
 import com.datastrato.gravitino.rel.types.Types;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.cfg.EnumFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.collect.ImmutableMap;
@@ -354,10 +355,10 @@ public class TestDTOJsonSerDe {
   public void testPartitioningDTOSerDeFail() throws Exception {
     // test `strategy` value null
     String wrongJson1 = "{\"strategy\": null,\"fieldName\":[\"dt\"]}";
+    ObjectMapper map = JsonUtils.objectMapper();
     IllegalArgumentException illegalArgumentException =
         Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () -> JsonUtils.objectMapper().readValue(wrongJson1, Partitioning.class));
+            IllegalArgumentException.class, () -> map.readValue(wrongJson1, Partitioning.class));
     Assertions.assertTrue(
         illegalArgumentException
             .getMessage()
@@ -367,16 +368,14 @@ public class TestDTOJsonSerDe {
     String wrongJson2 = "{\"strategy\": \"day\",\"fieldName\":[]}";
     IllegalArgumentException exception =
         Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () -> JsonUtils.objectMapper().readValue(wrongJson2, Partitioning.class));
+            IllegalArgumentException.class, () -> map.readValue(wrongJson2, Partitioning.class));
     Assertions.assertTrue(exception.getMessage().contains("fieldName cannot be null or empty"));
 
     // test invalid `strategy` value
     String wrongJson6 = "{\"strategy\": \"my_strategy\"}";
     exception =
         Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () -> JsonUtils.objectMapper().readValue(wrongJson6, Partitioning.class));
+            IllegalArgumentException.class, () -> map.readValue(wrongJson6, Partitioning.class));
     Assertions.assertTrue(exception.getMessage().contains("Invalid partitioning strategy"));
   }
 }

--- a/core/src/test/java/com/datastrato/gravitino/TestEntityStore.java
+++ b/core/src/test/java/com/datastrato/gravitino/TestEntityStore.java
@@ -208,9 +208,9 @@ public class TestEntityStore {
     Assertions.assertEquals(tableEntity, retrievedTable);
 
     store.delete(metalake.nameIdentifier(), EntityType.METALAKE);
+    NameIdentifier id = metalake.nameIdentifier();
     Assertions.assertThrows(
-        NoSuchEntityException.class,
-        () -> store.get(metalake.nameIdentifier(), EntityType.METALAKE, BaseMetalake.class));
+        NoSuchEntityException.class, () -> store.get(id, EntityType.METALAKE, BaseMetalake.class));
 
     Assertions.assertThrows(EntityAlreadyExistsException.class, () -> store.put(catalog, false));
     store.close();

--- a/core/src/test/java/com/datastrato/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/com/datastrato/gravitino/catalog/TestCatalogManager.java
@@ -12,6 +12,7 @@ import com.datastrato.gravitino.Config;
 import com.datastrato.gravitino.Configs;
 import com.datastrato.gravitino.EntityStore;
 import com.datastrato.gravitino.NameIdentifier;
+import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.StringIdentifier;
 import com.datastrato.gravitino.TestEntityStore;
 import com.datastrato.gravitino.TestEntityStore.InMemoryEntityStore;
@@ -192,16 +193,16 @@ public class TestCatalogManager {
             catalogManager.createCatalog(
                 ident2, Catalog.Type.RELATIONAL, provider, "comment", props2));
 
+    CatalogChange change1 = CatalogChange.setProperty("key1", "value1");
     Exception e1 =
         Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () -> catalogManager.alterCatalog(ident, CatalogChange.setProperty("key1", "value1")));
+            IllegalArgumentException.class, () -> catalogManager.alterCatalog(ident, change1));
     Assertions.assertTrue(e1.getMessage().contains("Property key1 is immutable"));
 
+    CatalogChange change2 = CatalogChange.setProperty("key3", "value2");
     Exception e2 =
         Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () -> catalogManager.alterCatalog(ident2, CatalogChange.setProperty("key3", "value2")));
+            IllegalArgumentException.class, () -> catalogManager.alterCatalog(ident2, change2));
     Assertions.assertTrue(e2.getMessage().contains("Property key3 is immutable"));
 
     Assertions.assertDoesNotThrow(
@@ -209,14 +210,12 @@ public class TestCatalogManager {
     Assertions.assertDoesNotThrow(
         () -> catalogManager.alterCatalog(ident2, CatalogChange.setProperty("key2", "value2")));
 
+    CatalogChange change3 = CatalogChange.setProperty("key4", "value4");
+    CatalogChange change4 = CatalogChange.removeProperty("key1");
     Exception e3 =
         Assertions.assertThrows(
             IllegalArgumentException.class,
-            () ->
-                catalogManager.alterCatalog(
-                    ident2,
-                    CatalogChange.setProperty("key4", "value4"),
-                    CatalogChange.removeProperty("key1")));
+            () -> catalogManager.alterCatalog(ident2, change3, change4));
     Assertions.assertTrue(e3.getMessage().contains("Property key1 is immutable"));
     reset();
   }
@@ -352,9 +351,10 @@ public class TestCatalogManager {
 
     // Test list under non-existed metalake
     NameIdentifier ident2 = NameIdentifier.of("metalake1", "test1");
+    Namespace namespace = ident2.namespace();
     Throwable exception =
         Assertions.assertThrows(
-            NoSuchMetalakeException.class, () -> catalogManager.listCatalogs(ident2.namespace()));
+            NoSuchMetalakeException.class, () -> catalogManager.listCatalogs(namespace));
     Assertions.assertTrue(exception.getMessage().contains("Metalake metalake1 does not exist"));
   }
 

--- a/core/src/test/java/com/datastrato/gravitino/lock/TestLockManager.java
+++ b/core/src/test/java/com/datastrato/gravitino/lock/TestLockManager.java
@@ -532,13 +532,13 @@ public class TestLockManager {
 
     CompletionService<Integer> service = createCompletionService();
     int concurrentThreadCount = 1;
+    NameIdentifier abcd = NameIdentifier.of("a", "b", "c", "d");
     for (int i = 0; i < concurrentThreadCount; i++) {
       service.submit(
           () -> {
             for (int j = 0; j < 1000; j++) {
               Assertions.assertThrows(
-                  RuntimeException.class,
-                  () -> lockManager.createTreeLock(NameIdentifier.of("a", "b", "c", "d")));
+                  RuntimeException.class, () -> lockManager.createTreeLock(abcd));
             }
             return 0;
           });

--- a/core/src/test/java/com/datastrato/gravitino/meta/TestMetalakeManager.java
+++ b/core/src/test/java/com/datastrato/gravitino/meta/TestMetalakeManager.java
@@ -96,10 +96,10 @@ public class TestMetalakeManager {
     testProperties(props, loadedMetalake.properties());
 
     // Test with NoSuchMetalakeException
+    NameIdentifier id = NameIdentifier.of("test3");
     Throwable exception =
         Assertions.assertThrows(
-            NoSuchMetalakeException.class,
-            () -> metalakeManager.loadMetalake(NameIdentifier.of("test3")));
+            NoSuchMetalakeException.class, () -> metalakeManager.loadMetalake(id));
     Assertions.assertTrue(exception.getMessage().contains("Metalake test3 does not exist"));
   }
 
@@ -141,10 +141,10 @@ public class TestMetalakeManager {
     testProperties(expectedProps, alteredMetalake2.properties());
 
     // Test with NoSuchMetalakeException
+    NameIdentifier id = NameIdentifier.of("test3");
     Throwable exception =
         Assertions.assertThrows(
-            NoSuchMetalakeException.class,
-            () -> metalakeManager.alterMetalake(NameIdentifier.of("test3"), change));
+            NoSuchMetalakeException.class, () -> metalakeManager.alterMetalake(id, change));
     Assertions.assertTrue(exception.getMessage().contains("Metalake test3 does not exist"));
   }
 

--- a/core/src/test/java/com/datastrato/gravitino/storage/kv/TestEntityKeyEncoding.java
+++ b/core/src/test/java/com/datastrato/gravitino/storage/kv/TestEntityKeyEncoding.java
@@ -190,13 +190,12 @@ public class TestEntityKeyEncoding {
 
       // Unsupported operation
       Mockito.doReturn(10L).when(mockIdGenerator).nextId();
+      namespace = Namespace.of("metalake1", "catalog2", "schema3", "table1");
+      NameIdentifier id = NameIdentifier.of(namespace, "column1");
       Assertions.assertThrows(
           UnsupportedOperationException.class,
           () -> {
-            encoder.encode(
-                NameIdentifier.of(
-                    Namespace.of("metalake1", "catalog2", "schema3", "table1"), "column1"),
-                EntityType.COLUMN);
+            encoder.encode(id, EntityType.COLUMN);
           });
     }
   }
@@ -268,13 +267,10 @@ public class TestEntityKeyEncoding {
       Assertions.assertArrayEquals(expectKey, realKey);
 
       Mockito.doReturn(3L).when(mockIdGenerator).nextId();
+      namespace = Namespace.of("metalake1", "catalog2", "schema3", "table1");
+      NameIdentifier id = NameIdentifier.of(namespace, WILD_CARD);
       Assertions.assertThrows(
-          UnsupportedOperationException.class,
-          () ->
-              encoder.encode(
-                  NameIdentifier.of(
-                      Namespace.of("metalake1", "catalog2", "schema3", "table1"), WILD_CARD),
-                  EntityType.COLUMN));
+          UnsupportedOperationException.class, () -> encoder.encode(id, EntityType.COLUMN));
     }
   }
 

--- a/core/src/test/java/com/datastrato/gravitino/storage/kv/TestKvEntityStorage.java
+++ b/core/src/test/java/com/datastrato/gravitino/storage/kv/TestKvEntityStorage.java
@@ -612,9 +612,10 @@ public class TestKvEntityStorage {
           NonEmptyEntityException.class,
           () -> store.delete(catalog.nameIdentifier(), EntityType.CATALOG));
       store.delete(catalog.nameIdentifier(), EntityType.CATALOG, true);
+      NameIdentifier id = catalog.nameIdentifier();
       Assertions.assertThrowsExactly(
           NoSuchEntityException.class,
-          () -> store.get(catalog.nameIdentifier(), EntityType.CATALOG, CatalogEntity.class));
+          () -> store.get(id, EntityType.CATALOG, CatalogEntity.class));
 
       Assertions.assertThrowsExactly(
           NoSuchEntityException.class,
@@ -657,9 +658,10 @@ public class TestKvEntityStorage {
           createCatalog(Namespace.of("metalake"), "catalogCopyAgain", auditInfo);
 
       // First, we try to test transactional is OK
+      final NameIdentifier id1 = metalake.nameIdentifier();
       Assertions.assertThrows(
           NoSuchEntityException.class,
-          () -> store.get(metalake.nameIdentifier(), EntityType.METALAKE, BaseMetalake.class));
+          () -> store.get(id1, EntityType.METALAKE, BaseMetalake.class));
 
       store.put(metalake);
       store.put(catalog);
@@ -692,14 +694,15 @@ public class TestKvEntityStorage {
       store.delete(catalog.nameIdentifier(), EntityType.CATALOG);
       Assertions.assertThrows(
           NoSuchEntityException.class,
-          () -> store.get(catalog.nameIdentifier(), EntityType.CATALOG, CatalogEntity.class));
+          () -> store.get(id1, EntityType.CATALOG, CatalogEntity.class));
 
       Assertions.assertThrows(
           EntityAlreadyExistsException.class, () -> store.put(catalogCopy, false));
       store.delete(catalogCopy.nameIdentifier(), EntityType.CATALOG);
+      final NameIdentifier id2 = catalogCopy.nameIdentifier();
       Assertions.assertThrows(
           NoSuchEntityException.class,
-          () -> store.get(catalogCopy.nameIdentifier(), EntityType.CATALOG, CatalogEntity.class));
+          () -> store.get(id2, EntityType.CATALOG, CatalogEntity.class));
 
       Assertions.assertThrowsExactly(
           NonEmptyEntityException.class,
@@ -708,7 +711,7 @@ public class TestKvEntityStorage {
       Assertions.assertTrue(store.delete(metalake.nameIdentifier(), EntityType.METALAKE));
       Assertions.assertThrows(
           NoSuchEntityException.class,
-          () -> store.get(metalake.nameIdentifier(), EntityType.METALAKE, BaseMetalake.class));
+          () -> store.get(id1, EntityType.METALAKE, BaseMetalake.class));
 
       // Test update
       BaseMetalake updatedMetalake = createBaseMakeLake("updatedMetalake", auditInfo);
@@ -720,7 +723,7 @@ public class TestKvEntityStorage {
           store.get(updatedMetalake.nameIdentifier(), EntityType.METALAKE, BaseMetalake.class));
       Assertions.assertThrows(
           NoSuchEntityException.class,
-          () -> store.get(metalake.nameIdentifier(), EntityType.METALAKE, BaseMetalake.class));
+          () -> store.get(id1, EntityType.METALAKE, BaseMetalake.class));
 
       // Add new updateMetaLake.
       // 'updatedMetalake2' is a new name, which will trigger id allocation
@@ -940,9 +943,10 @@ public class TestKvEntityStorage {
           () -> store.get(NameIdentifier.of("metalake2"), EntityType.METALAKE, BaseMetalake.class));
       Assertions.assertDoesNotThrow(
           () -> store.get(NameIdentifier.of("metalake1"), EntityType.METALAKE, BaseMetalake.class));
+      NameIdentifier id = NameIdentifier.of("metalake3");
       Assertions.assertThrows(
           NoSuchEntityException.class,
-          () -> store.get(NameIdentifier.of("metalake3"), EntityType.METALAKE, BaseMetalake.class));
+          () -> store.get(id, EntityType.METALAKE, BaseMetalake.class));
 
       // Test catalog
       CatalogEntity catalog1 = createCatalog(Namespace.of("metalake1"), "catalog1", auditInfo);

--- a/core/src/test/java/com/datastrato/gravitino/storage/kv/TestKvEntityStorage.java
+++ b/core/src/test/java/com/datastrato/gravitino/storage/kv/TestKvEntityStorage.java
@@ -658,10 +658,10 @@ public class TestKvEntityStorage {
           createCatalog(Namespace.of("metalake"), "catalogCopyAgain", auditInfo);
 
       // First, we try to test transactional is OK
-      final NameIdentifier id1 = metalake.nameIdentifier();
+      final NameIdentifier metalakeID1 = metalake.nameIdentifier();
       Assertions.assertThrows(
           NoSuchEntityException.class,
-          () -> store.get(id1, EntityType.METALAKE, BaseMetalake.class));
+          () -> store.get(metalakeID1, EntityType.METALAKE, BaseMetalake.class));
 
       store.put(metalake);
       store.put(catalog);
@@ -692,26 +692,28 @@ public class TestKvEntityStorage {
 
       Assertions.assertThrows(EntityAlreadyExistsException.class, () -> store.put(catalog, false));
       store.delete(catalog.nameIdentifier(), EntityType.CATALOG);
+      final NameIdentifier metalakeID2 = catalog.nameIdentifier();
       Assertions.assertThrows(
           NoSuchEntityException.class,
-          () -> store.get(id1, EntityType.CATALOG, CatalogEntity.class));
+          () -> store.get(metalakeID2, EntityType.CATALOG, CatalogEntity.class));
 
       Assertions.assertThrows(
           EntityAlreadyExistsException.class, () -> store.put(catalogCopy, false));
       store.delete(catalogCopy.nameIdentifier(), EntityType.CATALOG);
-      final NameIdentifier id2 = catalogCopy.nameIdentifier();
+      final NameIdentifier metalakeID3 = catalogCopy.nameIdentifier();
       Assertions.assertThrows(
           NoSuchEntityException.class,
-          () -> store.get(id2, EntityType.CATALOG, CatalogEntity.class));
+          () -> store.get(metalakeID3, EntityType.CATALOG, CatalogEntity.class));
 
       Assertions.assertThrowsExactly(
           NonEmptyEntityException.class,
           () -> store.delete(metalake.nameIdentifier(), EntityType.METALAKE));
       store.delete(catalogCopyAgain.nameIdentifier(), EntityType.CATALOG);
       Assertions.assertTrue(store.delete(metalake.nameIdentifier(), EntityType.METALAKE));
+      final NameIdentifier metalakeID4 = metalake.nameIdentifier();
       Assertions.assertThrows(
           NoSuchEntityException.class,
-          () -> store.get(id1, EntityType.METALAKE, BaseMetalake.class));
+          () -> store.get(metalakeID4, EntityType.METALAKE, BaseMetalake.class));
 
       // Test update
       BaseMetalake updatedMetalake = createBaseMakeLake("updatedMetalake", auditInfo);
@@ -721,9 +723,10 @@ public class TestKvEntityStorage {
       Assertions.assertEquals(
           updatedMetalake,
           store.get(updatedMetalake.nameIdentifier(), EntityType.METALAKE, BaseMetalake.class));
+      final NameIdentifier metalakeID5 = metalake.nameIdentifier();
       Assertions.assertThrows(
           NoSuchEntityException.class,
-          () -> store.get(id1, EntityType.METALAKE, BaseMetalake.class));
+          () -> store.get(metalakeID5, EntityType.METALAKE, BaseMetalake.class));
 
       // Add new updateMetaLake.
       // 'updatedMetalake2' is a new name, which will trigger id allocation

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/hive/CatalogHiveIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/hive/CatalogHiveIT.java
@@ -1196,17 +1196,17 @@ public class CatalogHiveIT extends AbstractIT {
     // Test rename catalog
     String newCatalogName = GravitinoITUtils.genRandomName("CatalogHiveIT_catalog_new");
     NameIdentifier newId2 = NameIdentifier.of(metalakeName, newMetalakeName);
-    NameIdentifier id2 = NameIdentifier.of(metalakeName, newCatalogName);
+    NameIdentifier oldId = NameIdentifier.of(metalakeName, catalogName);
     for (int i = 0; i < 2; i++) {
       Assertions.assertThrows(NoSuchCatalogException.class, () -> metalake.loadCatalog(newId2));
       metalake.alterCatalog(
           NameIdentifier.of(metalakeName, catalogName), CatalogChange.rename(newCatalogName));
       metalake.loadCatalog(NameIdentifier.of(metalakeName, newCatalogName));
-      Assertions.assertThrows(NoSuchCatalogException.class, () -> metalake.loadCatalog(id2));
+      Assertions.assertThrows(NoSuchCatalogException.class, () -> metalake.loadCatalog(oldId));
 
       metalake.alterCatalog(
           NameIdentifier.of(metalakeName, newCatalogName), CatalogChange.rename(catalogName));
-      catalog = metalake.loadCatalog(id2);
+      catalog = metalake.loadCatalog(oldId);
       Assertions.assertThrows(NoSuchCatalogException.class, () -> metalake.loadCatalog(newId2));
     }
 

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/hive/CatalogHiveIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/hive/CatalogHiveIT.java
@@ -406,19 +406,18 @@ public class CatalogHiveIT extends AbstractIT {
     // Bad name in distribution
     final Distribution badDistribution =
         Distributions.of(Strategy.EVEN, 10, NamedReference.field(HIVE_COL_NAME1 + "bad_name"));
+    TableCatalog tableCatalog = catalog.asTableCatalog();
     Assertions.assertThrows(
         Exception.class,
         () -> {
-          catalog
-              .asTableCatalog()
-              .createTable(
-                  nameIdentifier,
-                  columns,
-                  TABLE_COMMENT,
-                  properties,
-                  Transforms.EMPTY_TRANSFORM,
-                  badDistribution,
-                  sortOrders);
+          tableCatalog.createTable(
+              nameIdentifier,
+              columns,
+              TABLE_COMMENT,
+              properties,
+              Transforms.EMPTY_TRANSFORM,
+              badDistribution,
+              sortOrders);
         });
 
     final SortOrder[] badSortOrders =
@@ -432,16 +431,14 @@ public class CatalogHiveIT extends AbstractIT {
     Assertions.assertThrows(
         Exception.class,
         () -> {
-          catalog
-              .asTableCatalog()
-              .createTable(
-                  nameIdentifier,
-                  columns,
-                  TABLE_COMMENT,
-                  properties,
-                  Transforms.EMPTY_TRANSFORM,
-                  distribution,
-                  badSortOrders);
+          tableCatalog.createTable(
+              nameIdentifier,
+              columns,
+              TABLE_COMMENT,
+              properties,
+              Transforms.EMPTY_TRANSFORM,
+              distribution,
+              badSortOrders);
         });
   }
 

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/hive/CatalogHiveIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/hive/CatalogHiveIT.java
@@ -51,7 +51,9 @@ import com.datastrato.gravitino.integration.test.util.AbstractIT;
 import com.datastrato.gravitino.integration.test.util.GravitinoITUtils;
 import com.datastrato.gravitino.rel.Schema;
 import com.datastrato.gravitino.rel.SchemaChange;
+import com.datastrato.gravitino.rel.SupportsSchemas;
 import com.datastrato.gravitino.rel.Table;
+import com.datastrato.gravitino.rel.TableCatalog;
 import com.datastrato.gravitino.rel.TableChange;
 import com.datastrato.gravitino.rel.expressions.NamedReference;
 import com.datastrato.gravitino.rel.expressions.distributions.Distribution;
@@ -560,15 +562,14 @@ public class CatalogHiveIT extends AbstractIT {
     checkTableReadWrite(actualTable2);
 
     // test alter properties exception
+    TableCatalog tableCatalog = catalog.asTableCatalog();
+    NameIdentifier id = NameIdentifier.of(metalakeName, catalogName, schemaName, tableName);
+    TableChange change = TableChange.setProperty(TRANSIENT_LAST_DDL_TIME, "1234");
     IllegalArgumentException exception =
         assertThrows(
             IllegalArgumentException.class,
             () -> {
-              catalog
-                  .asTableCatalog()
-                  .alterTable(
-                      NameIdentifier.of(metalakeName, catalogName, schemaName, tableName),
-                      TableChange.setProperty(TRANSIENT_LAST_DDL_TIME, "1234"));
+              tableCatalog.alterTable(id, change);
             });
     Assertions.assertTrue(exception.getMessage().contains("cannot be set"));
   }
@@ -647,21 +648,18 @@ public class CatalogHiveIT extends AbstractIT {
     checkTableReadWrite(hiveTab);
 
     // test exception
+    TableCatalog tableCatalog = catalog.asTableCatalog();
+    Transform[] transforms =
+        new Transform[] {
+          IdentityPartitioningDTO.of(columns[0].name()),
+          IdentityPartitioningDTO.of(columns[1].name())
+        };
     RuntimeException exception =
         assertThrows(
             RuntimeException.class,
             () -> {
-              catalog
-                  .asTableCatalog()
-                  .createTable(
-                      nameIdentifier,
-                      columns,
-                      TABLE_COMMENT,
-                      properties,
-                      new Transform[] {
-                        IdentityPartitioningDTO.of(columns[0].name()),
-                        IdentityPartitioningDTO.of(columns[1].name())
-                      });
+              tableCatalog.createTable(
+                  nameIdentifier, columns, TABLE_COMMENT, properties, transforms);
             });
     Assertions.assertTrue(
         exception
@@ -907,10 +905,12 @@ public class CatalogHiveIT extends AbstractIT {
   @Test
   void testAlterUnknownTable() {
     NameIdentifier identifier = NameIdentifier.of(metalakeName, catalogName, schemaName, "unknown");
+    TableCatalog tableCatalog = catalog.asTableCatalog();
+    TableChange change = TableChange.updateComment("new_comment");
     Assertions.assertThrows(
         NoSuchTableException.class,
         () -> {
-          catalog.asTableCatalog().alterTable(identifier, TableChange.updateComment("new_comment"));
+          tableCatalog.alterTable(identifier, change);
         });
   }
 
@@ -973,16 +973,15 @@ public class CatalogHiveIT extends AbstractIT {
     checkTableReadWrite(hiveTab);
 
     // test alter partition column exception
+    TableCatalog tableCatalog = catalog.asTableCatalog();
+    NameIdentifier id = NameIdentifier.of(metalakeName, catalogName, schemaName, ALTER_TABLE_NAME);
+    TableChange updateType =
+        TableChange.updateColumnType(new String[] {HIVE_COL_NAME3}, Types.IntegerType.get());
     RuntimeException exception =
         assertThrows(
             RuntimeException.class,
             () -> {
-              catalog
-                  .asTableCatalog()
-                  .alterTable(
-                      NameIdentifier.of(metalakeName, catalogName, schemaName, ALTER_TABLE_NAME),
-                      TableChange.updateColumnType(
-                          new String[] {HIVE_COL_NAME3}, Types.IntegerType.get()));
+              tableCatalog.alterTable(id, updateType);
             });
     Assertions.assertTrue(exception.getMessage().contains("Cannot alter partition column"));
 
@@ -1023,16 +1022,13 @@ public class CatalogHiveIT extends AbstractIT {
             Distributions.NONE,
             new SortOrder[0]);
 
+    TableChange updatePos =
+        TableChange.updateColumnPosition(
+            new String[] {"date_of_birth"}, TableChange.ColumnPosition.first());
     exception =
         assertThrows(
             IllegalArgumentException.class,
-            () ->
-                catalog
-                    .asTableCatalog()
-                    .alterTable(
-                        tableIdentifier,
-                        TableChange.updateColumnPosition(
-                            new String[] {"date_of_birth"}, TableChange.ColumnPosition.first())));
+            () -> tableCatalog.alterTable(tableIdentifier, updatePos));
     Assertions.assertTrue(
         exception
             .getMessage()
@@ -1123,69 +1119,48 @@ public class CatalogHiveIT extends AbstractIT {
     for (int i = 1; i < metalakeName.length(); i++) {
       // We can't get the metalake by prefix
       final int length = i;
-      Assertions.assertThrows(
-          NoSuchMetalakeException.class,
-          () -> client.loadMetalake(NameIdentifier.of(metalakeName.substring(0, length))));
+      final NameIdentifier id = NameIdentifier.of(metalakeName.substring(0, length));
+      Assertions.assertThrows(NoSuchMetalakeException.class, () -> client.loadMetalake(id));
     }
-    Assertions.assertThrows(
-        NoSuchMetalakeException.class,
-        () -> client.loadMetalake(NameIdentifier.of(metalakeName + "a")));
+    final NameIdentifier idA = NameIdentifier.of(metalakeName + "a");
+    Assertions.assertThrows(NoSuchMetalakeException.class, () -> client.loadMetalake(idA));
 
     for (int i = 1; i < catalogName.length(); i++) {
       // We can't get the catalog by prefix
       final int length = i;
-      Assertions.assertThrows(
-          NoSuchCatalogException.class,
-          () ->
-              metalake.loadCatalog(
-                  NameIdentifier.of(metalakeName, catalogName.substring(0, length))));
+      final NameIdentifier id = NameIdentifier.of(metalakeName, catalogName.substring(0, length));
+      Assertions.assertThrows(NoSuchCatalogException.class, () -> metalake.loadCatalog(id));
     }
 
     // We can't load the catalog.
-    Assertions.assertThrows(
-        NoSuchCatalogException.class,
-        () -> metalake.loadCatalog(NameIdentifier.of(metalakeName, catalogName + "a")));
+    final NameIdentifier idB = NameIdentifier.of(metalakeName, catalogName + "a");
+    Assertions.assertThrows(NoSuchCatalogException.class, () -> metalake.loadCatalog(idB));
+
+    SupportsSchemas schemas = catalog.asSchemas();
 
     for (int i = 1; i < schemaName.length(); i++) {
       // We can't get the schema by prefix
       final int length = i;
-      Assertions.assertThrows(
-          NoSuchSchemaException.class,
-          () ->
-              catalog
-                  .asSchemas()
-                  .loadSchema(
-                      NameIdentifier.of(
-                          metalakeName, catalogName, schemaName.substring(0, length))));
+      final NameIdentifier id =
+          NameIdentifier.of(metalakeName, catalogName, schemaName.substring(0, length));
+      Assertions.assertThrows(NoSuchSchemaException.class, () -> schemas.loadSchema(id));
     }
 
-    Assertions.assertThrows(
-        NoSuchSchemaException.class,
-        () ->
-            catalog
-                .asSchemas()
-                .loadSchema(NameIdentifier.of(metalakeName, catalogName, schemaName + "a")));
+    NameIdentifier idC = NameIdentifier.of(metalakeName, catalogName, schemaName + "a");
+    Assertions.assertThrows(NoSuchSchemaException.class, () -> schemas.loadSchema(idC));
+
+    TableCatalog tableCatalog = catalog.asTableCatalog();
 
     for (int i = 1; i < tableName.length(); i++) {
       // We can't get the table by prefix
       final int length = i;
-      Assertions.assertThrows(
-          NoSuchTableException.class,
-          () ->
-              catalog
-                  .asTableCatalog()
-                  .loadTable(
-                      NameIdentifier.of(
-                          metalakeName, catalogName, schemaName, tableName.substring(0, length))));
+      final NameIdentifier id =
+          NameIdentifier.of(metalakeName, catalogName, schemaName, tableName.substring(0, length));
+      Assertions.assertThrows(NoSuchTableException.class, () -> tableCatalog.loadTable(id));
     }
 
-    Assertions.assertThrows(
-        NoSuchTableException.class,
-        () ->
-            catalog
-                .asTableCatalog()
-                .loadTable(
-                    NameIdentifier.of(metalakeName, catalogName, schemaName, tableName + "a")));
+    NameIdentifier idD = NameIdentifier.of(metalakeName, catalogName, schemaName, tableName + "a");
+    Assertions.assertThrows(NoSuchTableException.class, () -> tableCatalog.loadTable(idD));
   }
 
   @Test
@@ -1196,21 +1171,17 @@ public class CatalogHiveIT extends AbstractIT {
     String newMetalakeName = GravitinoITUtils.genRandomName("CatalogHiveIT_metalake_new");
 
     // Test rename metalake
+    NameIdentifier id = NameIdentifier.of(metalakeName);
+    NameIdentifier newId = NameIdentifier.of(newMetalakeName);
     for (int i = 0; i < 2; i++) {
-      Assertions.assertThrows(
-          NoSuchMetalakeException.class,
-          () -> client.loadMetalake(NameIdentifier.of(newMetalakeName)));
-      client.alterMetalake(NameIdentifier.of(metalakeName), MetalakeChange.rename(newMetalakeName));
-      client.loadMetalake(NameIdentifier.of(newMetalakeName));
-      Assertions.assertThrows(
-          NoSuchMetalakeException.class,
-          () -> client.loadMetalake(NameIdentifier.of(metalakeName)));
+      Assertions.assertThrows(NoSuchMetalakeException.class, () -> client.loadMetalake(newId));
+      client.alterMetalake(id, MetalakeChange.rename(newMetalakeName));
+      client.loadMetalake(newId);
+      Assertions.assertThrows(NoSuchMetalakeException.class, () -> client.loadMetalake(id));
 
-      client.alterMetalake(NameIdentifier.of(newMetalakeName), MetalakeChange.rename(metalakeName));
-      client.loadMetalake(NameIdentifier.of(metalakeName));
-      Assertions.assertThrows(
-          NoSuchMetalakeException.class,
-          () -> client.loadMetalake(NameIdentifier.of(newMetalakeName)));
+      client.alterMetalake(newId, MetalakeChange.rename(metalakeName));
+      client.loadMetalake(id);
+      Assertions.assertThrows(NoSuchMetalakeException.class, () -> client.loadMetalake(newId));
     }
 
     String catalogName = GravitinoITUtils.genRandomName("CatalogHiveIT_catalog");
@@ -1224,23 +1195,19 @@ public class CatalogHiveIT extends AbstractIT {
     Catalog catalog = metalake.loadCatalog(NameIdentifier.of(metalakeName, catalogName));
     // Test rename catalog
     String newCatalogName = GravitinoITUtils.genRandomName("CatalogHiveIT_catalog_new");
+    NameIdentifier newId2 = NameIdentifier.of(metalakeName, newMetalakeName);
+    NameIdentifier id2 = NameIdentifier.of(metalakeName, newCatalogName);
     for (int i = 0; i < 2; i++) {
-      Assertions.assertThrows(
-          NoSuchCatalogException.class,
-          () -> metalake.loadCatalog(NameIdentifier.of(metalakeName, newMetalakeName)));
+      Assertions.assertThrows(NoSuchCatalogException.class, () -> metalake.loadCatalog(newId2));
       metalake.alterCatalog(
           NameIdentifier.of(metalakeName, catalogName), CatalogChange.rename(newCatalogName));
       metalake.loadCatalog(NameIdentifier.of(metalakeName, newCatalogName));
-      Assertions.assertThrows(
-          NoSuchCatalogException.class,
-          () -> metalake.loadCatalog(NameIdentifier.of(metalakeName, catalogName)));
+      Assertions.assertThrows(NoSuchCatalogException.class, () -> metalake.loadCatalog(id2));
 
       metalake.alterCatalog(
           NameIdentifier.of(metalakeName, newCatalogName), CatalogChange.rename(catalogName));
-      catalog = metalake.loadCatalog(NameIdentifier.of(metalakeName, catalogName));
-      Assertions.assertThrows(
-          NoSuchCatalogException.class,
-          () -> metalake.loadCatalog(NameIdentifier.of(metalakeName, newMetalakeName)));
+      catalog = metalake.loadCatalog(id2);
+      Assertions.assertThrows(NoSuchCatalogException.class, () -> metalake.loadCatalog(newId2));
     }
 
     // Schema does not have the rename operation.
@@ -1264,41 +1231,25 @@ public class CatalogHiveIT extends AbstractIT {
             createProperties(),
             Transforms.EMPTY_TRANSFORM);
 
+    NameIdentifier id3 = NameIdentifier.of(metalakeName, catalogName, schemaName, newTableName);
+    NameIdentifier id4 = NameIdentifier.of(metalakeName, catalogName, schemaName, tableName);
+    TableChange newRename = TableChange.rename(newTableName);
+    TableChange oldRename = TableChange.rename(tableName);
+    TableCatalog tableCatalog = catalog.asTableCatalog();
+    TableCatalog tableCata = cata.asTableCatalog();
+
     for (int i = 0; i < 2; i++) {
       // The table to be renamed does not exist
-      Assertions.assertThrows(
-          NoSuchTableException.class,
-          () ->
-              cata.asTableCatalog()
-                  .loadTable(
-                      NameIdentifier.of(metalakeName, catalogName, schemaName, newTableName)));
-      catalog
-          .asTableCatalog()
-          .alterTable(
-              NameIdentifier.of(metalakeName, catalogName, schemaName, tableName),
-              TableChange.rename(newTableName));
-      Table table =
-          catalog
-              .asTableCatalog()
-              .loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, newTableName));
+      Assertions.assertThrows(NoSuchTableException.class, () -> tableCata.loadTable(id3));
+      tableCatalog.alterTable(id4, newRename);
+      Table table = tableCatalog.loadTable(id3);
       Assertions.assertNotNull(table);
 
       // Old Table should not exist anymore.
-      Assertions.assertThrows(
-          NoSuchTableException.class,
-          () ->
-              cata.asTableCatalog()
-                  .loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, tableName)));
+      Assertions.assertThrows(NoSuchTableException.class, () -> tableCata.loadTable(id4));
 
-      catalog
-          .asTableCatalog()
-          .alterTable(
-              NameIdentifier.of(metalakeName, catalogName, schemaName, newTableName),
-              TableChange.rename(tableName));
-      table =
-          catalog
-              .asTableCatalog()
-              .loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, tableName));
+      tableCatalog.alterTable(id3, oldRename);
+      table = catalog.asTableCatalog().loadTable(id4);
       Assertions.assertNotNull(table);
     }
   }
@@ -1320,8 +1271,12 @@ public class CatalogHiveIT extends AbstractIT {
 
     client.loadMetalake(NameIdentifier.of(metalakeName2));
 
+    NameIdentifier of = NameIdentifier.of(metalakeName1);
     Assertions.assertThrows(
-        NoSuchMetalakeException.class, () -> client.loadMetalake(NameIdentifier.of(metalakeName1)));
+        NoSuchMetalakeException.class,
+        () -> {
+          client.loadMetalake(of);
+        });
   }
 
   @Test
@@ -1419,12 +1374,12 @@ public class CatalogHiveIT extends AbstractIT {
         hiveClientPool.run(client -> client.getTable(schemaName, tableName));
     checkTableReadWrite(hiveTab);
     Assertions.assertEquals(EXTERNAL_TABLE.name(), hiveTab.getTableType());
+    TableCatalog tableCatalog = catalog.asTableCatalog();
+    NameIdentifier id = NameIdentifier.of(metalakeName, catalogName, schemaName, tableName);
     Assertions.assertThrows(
         UnsupportedOperationException.class,
         () -> {
-          catalog
-              .asTableCatalog()
-              .purgeTable(NameIdentifier.of(metalakeName, catalogName, schemaName, tableName));
+          tableCatalog.purgeTable(id);
         },
         "Can't purge a external hive table");
 

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/hive/ProxyCatalogHiveIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/hive/ProxyCatalogHiveIT.java
@@ -20,7 +20,9 @@ import com.datastrato.gravitino.integration.test.container.HiveContainer;
 import com.datastrato.gravitino.integration.test.util.AbstractIT;
 import com.datastrato.gravitino.integration.test.util.GravitinoITUtils;
 import com.datastrato.gravitino.rel.Column;
+import com.datastrato.gravitino.rel.SupportsSchemas;
 import com.datastrato.gravitino.rel.Table;
+import com.datastrato.gravitino.rel.TableCatalog;
 import com.datastrato.gravitino.rel.expressions.literals.Literal;
 import com.datastrato.gravitino.rel.expressions.literals.Literals;
 import com.datastrato.gravitino.rel.expressions.transforms.Transform;
@@ -142,10 +144,10 @@ public class ProxyCatalogHiveIT extends AbstractIT {
             containerSuite.getHiveContainer().getContainerIpAddress(),
             HiveContainer.HDFS_DEFAULTFS_PORT,
             anotherSchemaName.toLowerCase()));
+    SupportsSchemas schemas = anotherCatalog.asSchemas();
     Exception e =
         Assertions.assertThrows(
-            RuntimeException.class,
-            () -> anotherCatalog.asSchemas().createSchema(anotherIdent, comment, properties));
+            RuntimeException.class, () -> schemas.createSchema(anotherIdent, comment, properties));
     Assertions.assertTrue(e.getMessage().contains("AccessControlException Permission denied"));
   }
 
@@ -182,18 +184,15 @@ public class ProxyCatalogHiveIT extends AbstractIT {
     Assertions.assertEquals(EXPECT_USER, hiveTab.getOwner());
 
     // create table with exception with system user
+    TableCatalog tableCatalog = anotherCatalog.asTableCatalog();
+    ImmutableMap<String, String> of = ImmutableMap.of();
     Exception e =
         Assertions.assertThrows(
             RuntimeException.class,
-            () ->
-                anotherCatalog
-                    .asTableCatalog()
-                    .createTable(
-                        anotherNameIdentifier,
-                        columns,
-                        comment,
-                        ImmutableMap.of(),
-                        Partitioning.EMPTY_PARTITIONING));
+            () -> {
+              tableCatalog.createTable(
+                  anotherNameIdentifier, columns, comment, of, Partitioning.EMPTY_PARTITIONING);
+            });
     Assertions.assertTrue(e.getMessage().contains("AccessControlException Permission denied"));
   }
 
@@ -265,12 +264,12 @@ public class ProxyCatalogHiveIT extends AbstractIT {
             new Literal<?>[] {primaryPartition, anotherSecondaryPartition});
 
     // create partition with exception with system user
+    TableCatalog tableCatalog = anotherCatalog.asTableCatalog();
     Exception e =
         Assertions.assertThrows(
             RuntimeException.class,
             () ->
-                anotherCatalog
-                    .asTableCatalog()
+                tableCatalog
                     .loadTable(nameIdentifier)
                     .supportPartitions()
                     .addPartition(anotherIdentity));

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/MysqlTableOperationsIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/MysqlTableOperationsIT.java
@@ -133,12 +133,11 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
     assertionsTableInfo(newName, tableComment, alterColumns, properties, indexes, load);
 
     // Detect unsupported properties
+    TableChange setProperty = TableChange.setProperty(MYSQL_ENGINE_KEY, "ABC");
     GravitinoRuntimeException gravitinoRuntimeException =
         Assertions.assertThrows(
             GravitinoRuntimeException.class,
-            () ->
-                TABLE_OPERATIONS.alterTable(
-                    TEST_DB_NAME, newName, TableChange.setProperty(MYSQL_ENGINE_KEY, "ABC")));
+            () -> TABLE_OPERATIONS.alterTable(TEST_DB_NAME, newName, setProperty));
     Assertions.assertTrue(
         StringUtils.contains(
             gravitinoRuntimeException.getMessage(), "Unknown storage engine 'ABC'"));
@@ -149,14 +148,11 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
     load = TABLE_OPERATIONS.load(TEST_DB_NAME, newName);
     assertionsTableInfo(newName, tableComment, columns, properties, indexes, load);
 
+    TableChange deleteColumn = TableChange.deleteColumn(new String[] {newColumn.name()}, false);
     IllegalArgumentException illegalArgumentException =
         Assertions.assertThrows(
             IllegalArgumentException.class,
-            () ->
-                TABLE_OPERATIONS.alterTable(
-                    TEST_DB_NAME,
-                    newName,
-                    TableChange.deleteColumn(new String[] {newColumn.name()}, false)));
+            () -> TABLE_OPERATIONS.alterTable(TEST_DB_NAME, newName, deleteColumn));
     Assertions.assertEquals(
         "Delete column does not exist: " + newColumn.name(), illegalArgumentException.getMessage());
     Assertions.assertDoesNotThrow(
@@ -400,15 +396,12 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
 
     assertionsTableInfo(tableName, newComment, columns, properties, indexes, load);
 
+    TableChange updateColumn =
+        TableChange.updateColumnNullability(new String[] {col3.name()}, !col3.nullable());
     IllegalArgumentException exception =
         Assertions.assertThrows(
             IllegalArgumentException.class,
-            () ->
-                TABLE_OPERATIONS.alterTable(
-                    TEST_DB_NAME,
-                    tableName,
-                    TableChange.updateColumnNullability(
-                        new String[] {col3.name()}, !col3.nullable())));
+            () -> TABLE_OPERATIONS.alterTable(TEST_DB_NAME, tableName, updateColumn));
     Assertions.assertTrue(
         exception.getMessage().contains("with null default value cannot be changed to not null"));
   }
@@ -594,18 +587,21 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
       columns.add(
           new JdbcColumn.Builder().withName("col_1").withType(type).withNullable(false).build());
 
+      JdbcColumn[] jdbcCols = columns.toArray(new JdbcColumn[0]);
+      Map<String, String> emptyMap = Collections.emptyMap();
       IllegalArgumentException illegalArgumentException =
           Assertions.assertThrows(
               IllegalArgumentException.class,
-              () ->
-                  TABLE_OPERATIONS.create(
-                      TEST_DB_NAME,
-                      tableName,
-                      columns.toArray(new JdbcColumn[0]),
-                      tableComment,
-                      Collections.emptyMap(),
-                      null,
-                      Indexes.EMPTY_INDEXES));
+              () -> {
+                TABLE_OPERATIONS.create(
+                    TEST_DB_NAME,
+                    tableName,
+                    jdbcCols,
+                    tableComment,
+                    emptyMap,
+                    null,
+                    Indexes.EMPTY_INDEXES);
+              });
       Assertions.assertTrue(
           illegalArgumentException
               .getMessage()
@@ -796,20 +792,14 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
           .build()
     };
 
+    final Index[] primaryIndex =
+        new Index[] {Indexes.createMysqlPrimaryKey(new String[][] {{"col_1"}, {"col_4"}})};
     exception =
         Assertions.assertThrows(
             IllegalArgumentException.class,
             () ->
                 TABLE_OPERATIONS.create(
-                    TEST_DB_NAME,
-                    tableName,
-                    newColumns,
-                    comment,
-                    properties,
-                    null,
-                    new Index[] {
-                      Indexes.createMysqlPrimaryKey(new String[][] {{"col_1"}, {"col_4"}})
-                    }));
+                    TEST_DB_NAME, tableName, newColumns, comment, properties, null, primaryIndex));
     Assertions.assertTrue(
         StringUtils.contains(
             exception.getMessage(),

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/client/MetalakeIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/client/MetalakeIT.java
@@ -21,6 +21,7 @@ import com.datastrato.gravitino.integration.test.util.AbstractIT;
 import com.datastrato.gravitino.integration.test.util.GravitinoITUtils;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -78,17 +79,20 @@ public class MetalakeIT extends AbstractIT {
     assertEquals(metaLakeA.name(), metalakeNameA);
 
     // metalake does not exist
+    NameIdentifier noexist = NameIdentifier.of(metalakeNameB);
     assertThrows(
-        NoSuchMetalakeException.class, () -> client.loadMetalake(NameIdentifier.of(metalakeNameB)));
+        NoSuchMetalakeException.class,
+        () -> {
+          client.loadMetalake(noexist);
+        });
 
     // metalake empty name
-    assertThrows(
-        IllegalNameIdentifierException.class, () -> client.loadMetalake(NameIdentifier.of("")));
+    NameIdentifier empty = NameIdentifier.of("");
+    assertThrows(IllegalNameIdentifierException.class, () -> client.loadMetalake(empty));
 
     // metalake bad name
-    assertThrows(
-        IllegalNamespaceException.class,
-        () -> client.loadMetalake(NameIdentifier.of("A", "B", "C")));
+    NameIdentifier abc = NameIdentifier.of("A", "B", "C");
+    assertThrows(IllegalNamespaceException.class, () -> client.loadMetalake(abc));
   }
 
   @Test
@@ -113,8 +117,8 @@ public class MetalakeIT extends AbstractIT {
     assertEquals("new metalake comment", newMetalake.comment());
 
     // Old name does not exist
-    assertThrows(
-        NoSuchMetalakeException.class, () -> client.loadMetalake(NameIdentifier.of(metalakeNameA)));
+    NameIdentifier old = NameIdentifier.of(metalakeNameA);
+    assertThrows(NoSuchMetalakeException.class, () -> client.loadMetalake(old));
   }
 
   @Test
@@ -130,9 +134,8 @@ public class MetalakeIT extends AbstractIT {
         };
 
     // rename non existent metalake
-    assertThrows(
-        NoSuchMetalakeException.class,
-        () -> client.alterMetalake(NameIdentifier.of(metalakeNameB), changes));
+    NameIdentifier noexists = NameIdentifier.of(metalakeNameB);
+    assertThrows(NoSuchMetalakeException.class, () -> client.alterMetalake(noexists, changes));
   }
 
   @Test
@@ -146,11 +149,13 @@ public class MetalakeIT extends AbstractIT {
     assertEquals(AuthConstants.ANONYMOUS_USER, metalake.auditInfo().creator());
 
     // Test metalake name already exists
+    Map<String, String> emptyMap = Collections.emptyMap();
+    NameIdentifier exists = NameIdentifier.parse(metalakeNameA);
     assertThrows(
         MetalakeAlreadyExistsException.class,
-        () ->
-            client.createMetalake(
-                NameIdentifier.parse(metalakeNameA), "metalake A comment", Collections.emptyMap()));
+        () -> {
+          client.createMetalake(exists, "metalake A comment", emptyMap);
+        });
   }
 
   @Test
@@ -159,15 +164,23 @@ public class MetalakeIT extends AbstractIT {
         client.createMetalake(
             NameIdentifier.parse(metalakeNameA), "metalake A comment", Collections.emptyMap());
     assertTrue(client.dropMetalake(NameIdentifier.of(metalakeA.name())));
+    NameIdentifier id = NameIdentifier.of(metalakeNameA);
     assertThrows(
-        NoSuchMetalakeException.class, () -> client.loadMetalake(NameIdentifier.of(metalakeNameA)));
+        NoSuchMetalakeException.class,
+        () -> {
+          client.loadMetalake(id);
+        });
 
     // Metalake does not exist, so we return false
     assertFalse(client.dropMetalake(NameIdentifier.of(metalakeA.name())));
 
     // Bad metalake name
+    NameIdentifier badname = NameIdentifier.of("A", "B");
     assertThrows(
-        IllegalNamespaceException.class, () -> client.dropMetalake(NameIdentifier.of("A", "B")));
+        IllegalNamespaceException.class,
+        () -> {
+          client.dropMetalake(badname);
+        });
   }
 
   public void dropMetalakes() {
@@ -178,9 +191,12 @@ public class MetalakeIT extends AbstractIT {
 
     // Reload metadata from backend to check if the drop operations are applied
     for (GravitinoMetaLake metalake : metaLakes) {
+      NameIdentifier id = NameIdentifier.of(metalake.name());
       Assertions.assertThrows(
           NoSuchMetalakeException.class,
-          () -> client.loadMetalake(NameIdentifier.of(metalake.name())));
+          () -> {
+            client.loadMetalake(id);
+          });
     }
 
     for (GravitinoMetaLake metalake : metaLakes) {

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/client/MetalakeIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/client/MetalakeIT.java
@@ -86,9 +86,9 @@ public class MetalakeIT extends AbstractIT {
           client.loadMetalake(noexist);
         });
 
-    // metalake empty name
-    NameIdentifier empty = NameIdentifier.of("");
-    assertThrows(IllegalNameIdentifierException.class, () -> client.loadMetalake(empty));
+    // metalake empty name - note it's NameIdentifier.of("") that fails not the load
+    assertThrows(
+        IllegalNameIdentifierException.class, () -> client.loadMetalake(NameIdentifier.of("")));
 
     // metalake bad name
     NameIdentifier abc = NameIdentifier.of("A", "B", "C");

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoConnectorIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoConnectorIT.java
@@ -18,6 +18,7 @@ import com.datastrato.gravitino.dto.rel.partitioning.Partitioning;
 import com.datastrato.gravitino.integration.test.catalog.jdbc.utils.JdbcDriverDownloader;
 import com.datastrato.gravitino.integration.test.container.ContainerSuite;
 import com.datastrato.gravitino.integration.test.container.HiveContainer;
+import com.datastrato.gravitino.integration.test.container.TrinoContainer;
 import com.datastrato.gravitino.integration.test.util.AbstractIT;
 import com.datastrato.gravitino.integration.test.util.GravitinoITUtils;
 import com.datastrato.gravitino.integration.test.util.ITUtils;
@@ -1073,8 +1074,12 @@ public class TrinoConnectorIT extends AbstractIT {
     final String sql1 =
         String.format("drop schema \"%s.%s\".%s cascade", metalakeName, catalogName, schemaName);
     // Will fail because the iceberg catalog does not support cascade drop
+    TrinoContainer trinoContainer = containerSuite.getTrinoContainer();
     Assertions.assertThrows(
-        RuntimeException.class, () -> containerSuite.getTrinoContainer().executeUpdateSQL(sql1));
+        RuntimeException.class,
+        () -> {
+          trinoContainer.executeUpdateSQL(sql1);
+        });
 
     final String sql2 =
         String.format("show schemas in \"%s.%s\" like '%s'", metalakeName, catalogName, schemaName);

--- a/server-common/src/test/java/com/datastrato/gravitino/server/auth/TestKerberosAuthenticator.java
+++ b/server-common/src/test/java/com/datastrato/gravitino/server/auth/TestKerberosAuthenticator.java
@@ -100,29 +100,34 @@ public class TestKerberosAuthenticator extends KerberosSecurityTestcase {
     Assertions.assertEquals("Empty token authorization header", e.getMessage());
 
     // case2 : Invalid token authorization header
+    byte[] bytes = "Xx".getBytes(StandardCharsets.UTF_8);
     e =
         Assertions.assertThrows(
             UnauthorizedException.class,
-            () -> kerberosAuthenticator.authenticateToken("Xx".getBytes(StandardCharsets.UTF_8)));
+            () -> {
+              kerberosAuthenticator.authenticateToken(bytes);
+            });
     Assertions.assertEquals("Invalid token authorization header", e.getMessage());
 
     // case 3: Blank token found
+    byte[] bytes2 = AuthConstants.AUTHORIZATION_NEGOTIATE_HEADER.getBytes(StandardCharsets.UTF_8);
     e =
         Assertions.assertThrows(
             UnauthorizedException.class,
-            () ->
-                kerberosAuthenticator.authenticateToken(
-                    AuthConstants.AUTHORIZATION_NEGOTIATE_HEADER.getBytes(StandardCharsets.UTF_8)));
+            () -> {
+              kerberosAuthenticator.authenticateToken(bytes2);
+            });
     Assertions.assertEquals("Blank token found", e.getMessage());
 
     // case 4: Fail to validate the token
+    String header = AuthConstants.AUTHORIZATION_NEGOTIATE_HEADER + "xxxx";
+    byte[] bytes3 = header.getBytes(StandardCharsets.UTF_8);
     e =
         Assertions.assertThrows(
             UnauthorizedException.class,
-            () ->
-                kerberosAuthenticator.authenticateToken(
-                    (AuthConstants.AUTHORIZATION_NEGOTIATE_HEADER + "xxxx")
-                        .getBytes(StandardCharsets.UTF_8)));
+            () -> {
+              kerberosAuthenticator.authenticateToken(bytes3);
+            });
     Assertions.assertEquals("Fail to validate the token", e.getMessage());
   }
 

--- a/server-common/src/test/java/com/datastrato/gravitino/server/auth/TestOAuth2TokenAuthenticator.java
+++ b/server-common/src/test/java/com/datastrato/gravitino/server/auth/TestOAuth2TokenAuthenticator.java
@@ -116,7 +116,7 @@ public class TestOAuth2TokenAuthenticator {
             .setExpiration(new Date(System.currentTimeMillis() + 1000 * 100))
             .signWith(keyPair.getPrivate(), SignatureAlgorithm.RS256)
             .compact();
-    String header4 = AuthConstants.AUTHORIZATION_BEARER_HEADER + token3;
+    String header4 = AuthConstants.AUTHORIZATION_BEARER_HEADER + token4;
     byte[] bytes6 = header4.getBytes(StandardCharsets.UTF_8);
     e =
         Assertions.assertThrows(

--- a/server-common/src/test/java/com/datastrato/gravitino/server/auth/TestOAuth2TokenAuthenticator.java
+++ b/server-common/src/test/java/com/datastrato/gravitino/server/auth/TestOAuth2TokenAuthenticator.java
@@ -79,7 +79,7 @@ public class TestOAuth2TokenAuthenticator {
             .setExpiration(new Date(System.currentTimeMillis() + 1000 * 100))
             .signWith(keyPair.getPrivate(), SignatureAlgorithm.RS256)
             .compact();
-    String header2 = AuthConstants.AUTHORIZATION_BEARER_HEADER + token1;
+    String header2 = AuthConstants.AUTHORIZATION_BEARER_HEADER + token2;
     byte[] bytes4 = header2.getBytes(StandardCharsets.UTF_8);
     e =
         Assertions.assertThrows(

--- a/server-common/src/test/java/com/datastrato/gravitino/server/auth/TestOAuth2TokenAuthenticator.java
+++ b/server-common/src/test/java/com/datastrato/gravitino/server/auth/TestOAuth2TokenAuthenticator.java
@@ -43,17 +43,18 @@ public class TestOAuth2TokenAuthenticator {
         Assertions.assertThrows(
             UnauthorizedException.class, () -> auth2TokenAuthenticator.authenticateToken(null));
     Assertions.assertEquals("Empty token authorization header", e.getMessage());
+    byte[] bytes = "Xx".getBytes(StandardCharsets.UTF_8);
     e =
         Assertions.assertThrows(
-            UnauthorizedException.class,
-            () -> auth2TokenAuthenticator.authenticateToken("Xx".getBytes(StandardCharsets.UTF_8)));
+            UnauthorizedException.class, () -> auth2TokenAuthenticator.authenticateToken(bytes));
     Assertions.assertEquals("Invalid token authorization header", e.getMessage());
+    byte[] bytes2 = AuthConstants.AUTHORIZATION_BEARER_HEADER.getBytes(StandardCharsets.UTF_8);
     e =
         Assertions.assertThrows(
             UnauthorizedException.class,
-            () ->
-                auth2TokenAuthenticator.authenticateToken(
-                    AuthConstants.AUTHORIZATION_BEARER_HEADER.getBytes(StandardCharsets.UTF_8)));
+            () -> {
+              auth2TokenAuthenticator.authenticateToken(bytes2);
+            });
     Assertions.assertEquals("Blank token found", e.getMessage());
     String token1 =
         Jwts.builder()
@@ -61,13 +62,14 @@ public class TestOAuth2TokenAuthenticator {
             .setExpiration(new Date(System.currentTimeMillis() + 1000 * 100))
             .signWith(keyPair.getPrivate(), SignatureAlgorithm.RS256)
             .compact();
+    String header1 = AuthConstants.AUTHORIZATION_BEARER_HEADER + token1;
+    byte[] bytes3 = header1.getBytes(StandardCharsets.UTF_8);
     e =
         Assertions.assertThrows(
             UnauthorizedException.class,
-            () ->
-                auth2TokenAuthenticator.authenticateToken(
-                    (AuthConstants.AUTHORIZATION_BEARER_HEADER + token1)
-                        .getBytes(StandardCharsets.UTF_8)));
+            () -> {
+              auth2TokenAuthenticator.authenticateToken(bytes3);
+            });
     Assertions.assertEquals("Found null Audience in token", e.getMessage());
 
     String token2 =
@@ -77,13 +79,11 @@ public class TestOAuth2TokenAuthenticator {
             .setExpiration(new Date(System.currentTimeMillis() + 1000 * 100))
             .signWith(keyPair.getPrivate(), SignatureAlgorithm.RS256)
             .compact();
+    String header2 = AuthConstants.AUTHORIZATION_BEARER_HEADER + token1;
+    byte[] bytes4 = header2.getBytes(StandardCharsets.UTF_8);
     e =
         Assertions.assertThrows(
-            UnauthorizedException.class,
-            () ->
-                auth2TokenAuthenticator.authenticateToken(
-                    (AuthConstants.AUTHORIZATION_BEARER_HEADER + token2)
-                        .getBytes(StandardCharsets.UTF_8)));
+            UnauthorizedException.class, () -> auth2TokenAuthenticator.authenticateToken(bytes4));
     Assertions.assertEquals(
         "Audience in the token [xxxx] doesn't contain service1", e.getMessage());
 
@@ -96,13 +96,11 @@ public class TestOAuth2TokenAuthenticator {
             .setExpiration(new Date(System.currentTimeMillis() + 1000 * 100))
             .signWith(keyPair.getPrivate(), SignatureAlgorithm.RS256)
             .compact();
+    String header3 = AuthConstants.AUTHORIZATION_BEARER_HEADER + token3;
+    byte[] bytes5 = header3.getBytes(StandardCharsets.UTF_8);
     e =
         Assertions.assertThrows(
-            UnauthorizedException.class,
-            () ->
-                auth2TokenAuthenticator.authenticateToken(
-                    (AuthConstants.AUTHORIZATION_BEARER_HEADER + token3)
-                        .getBytes(StandardCharsets.UTF_8)));
+            UnauthorizedException.class, () -> auth2TokenAuthenticator.authenticateToken(bytes5));
     Assertions.assertEquals(
         "Audiences in the token [x1, x2, x3] don't contain service1", e.getMessage());
 
@@ -118,13 +116,11 @@ public class TestOAuth2TokenAuthenticator {
             .setExpiration(new Date(System.currentTimeMillis() + 1000 * 100))
             .signWith(keyPair.getPrivate(), SignatureAlgorithm.RS256)
             .compact();
+    String header4 = AuthConstants.AUTHORIZATION_BEARER_HEADER + token3;
+    byte[] bytes6 = header4.getBytes(StandardCharsets.UTF_8);
     e =
         Assertions.assertThrows(
-            UnauthorizedException.class,
-            () ->
-                auth2TokenAuthenticator.authenticateToken(
-                    (AuthConstants.AUTHORIZATION_BEARER_HEADER + token4)
-                        .getBytes(StandardCharsets.UTF_8)));
+            UnauthorizedException.class, () -> auth2TokenAuthenticator.authenticateToken(bytes6));
     Assertions.assertEquals(
         "Audiences in token is not in expected format: {k1=v1, k2=v2}", e.getMessage());
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Where possible make sure assertThrows only includes one call that can throw an exception.

### Why are the changes needed?

When test code raises a runtime exception, it is good practice to avoid having multiple method calls inside the assert throws as It can be confusing what is being tested. This change improves the clarity of the tests and avoids potential incorrect testing when another method could raise an exception.

Fix: # N/A

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Tested locally.
