### PR TITLE
[#2192] fix: change OAuthConfig.AUTHENTICATOR to Configs.AUTHENTICATOR

### DIFF
--- a/integration-test/src/main/java/com/datastrato/gravitino/integration/test/MiniGravitino.java
+++ b/integration-test/src/main/java/com/datastrato/gravitino/integration/test/MiniGravitino.java
@@ -23,7 +23,6 @@ import com.datastrato.gravitino.integration.test.util.OAuthMockDataProvider;
 import com.datastrato.gravitino.rest.RESTUtils;
 import com.datastrato.gravitino.server.GravitinoServer;
 import com.datastrato.gravitino.server.ServerConfig;
-import com.datastrato.gravitino.server.auth.OAuthConfig;
 import com.datastrato.gravitino.server.web.JettyServerConfig;
 import com.google.common.collect.ImmutableMap;
 import java.io.File;
@@ -96,7 +95,7 @@ public class MiniGravitino {
     if (AuthenticatorType.OAUTH
         .name()
         .toLowerCase()
-        .equals(context.customConfig.get(OAuthConfig.AUTHENTICATOR.getKey()))) {
+        .equals(context.customConfig.get(Configs.AUTHENTICATOR.getKey()))) {
       restClient =
           HTTPClient.builder(ImmutableMap.of())
               .uri(URI)
@@ -105,7 +104,7 @@ public class MiniGravitino {
     } else if (AuthenticatorType.KERBEROS
         .name()
         .toLowerCase()
-        .equals(context.customConfig.get(OAuthConfig.AUTHENTICATOR.getKey()))) {
+        .equals(context.customConfig.get(Configs.AUTHENTICATOR.getKey()))) {
       restClient =
           HTTPClient.builder(ImmutableMap.of())
               .uri(URI)

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/hive/ProxyCatalogHiveIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/hive/ProxyCatalogHiveIT.java
@@ -9,6 +9,7 @@ import static com.datastrato.gravitino.catalog.hive.HiveCatalogPropertiesMeta.ME
 import static com.datastrato.gravitino.server.GravitinoServer.WEBSERVER_CONF_PREFIX;
 
 import com.datastrato.gravitino.Catalog;
+import com.datastrato.gravitino.Configs;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.auth.AuthenticatorType;
 import com.datastrato.gravitino.catalog.hive.HiveClientPool;
@@ -28,7 +29,6 @@ import com.datastrato.gravitino.rel.expressions.transforms.Transforms;
 import com.datastrato.gravitino.rel.partitions.Partition;
 import com.datastrato.gravitino.rel.partitions.Partitions;
 import com.datastrato.gravitino.rel.types.Types;
-import com.datastrato.gravitino.server.auth.OAuthConfig;
 import com.datastrato.gravitino.server.web.JettyServerConfig;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -76,7 +76,7 @@ public class ProxyCatalogHiveIT extends AbstractIT {
     System.setProperty("user.name", "datastrato");
 
     Map<String, String> configs = Maps.newHashMap();
-    configs.put(OAuthConfig.AUTHENTICATOR.getKey(), AuthenticatorType.SIMPLE.name().toLowerCase());
+    configs.put(Configs.AUTHENTICATOR.getKey(), AuthenticatorType.SIMPLE.name().toLowerCase());
     registerCustomConfigs(configs);
     AbstractIT.startIntegrationTest();
     containerSuite.startHiveContainer();

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/AuditCatalogMysqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/AuditCatalogMysqlIT.java
@@ -7,6 +7,7 @@ package com.datastrato.gravitino.integration.test.catalog.jdbc.mysql;
 
 import com.datastrato.gravitino.Catalog;
 import com.datastrato.gravitino.CatalogChange;
+import com.datastrato.gravitino.Configs;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.auth.AuthenticatorType;
 import com.datastrato.gravitino.catalog.jdbc.config.JdbcConfig;
@@ -21,7 +22,6 @@ import com.datastrato.gravitino.rel.Schema;
 import com.datastrato.gravitino.rel.Table;
 import com.datastrato.gravitino.rel.TableChange;
 import com.datastrato.gravitino.rel.types.Types;
-import com.datastrato.gravitino.server.auth.OAuthConfig;
 import com.google.common.collect.Maps;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -55,7 +55,7 @@ public class AuditCatalogMysqlIT extends AbstractIT {
   @BeforeAll
   public static void startIntegrationTest() throws Exception {
     Map<String, String> configs = Maps.newHashMap();
-    configs.put(OAuthConfig.AUTHENTICATOR.getKey(), AuthenticatorType.SIMPLE.name().toLowerCase());
+    configs.put(Configs.AUTHENTICATOR.getKey(), AuthenticatorType.SIMPLE.name().toLowerCase());
     registerCustomConfigs(configs);
     AbstractIT.startIntegrationTest();
 

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/client/AuditIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/client/AuditIT.java
@@ -5,13 +5,13 @@
 
 package com.datastrato.gravitino.integration.test.client;
 
+import com.datastrato.gravitino.Configs;
 import com.datastrato.gravitino.MetalakeChange;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.auth.AuthenticatorType;
 import com.datastrato.gravitino.client.GravitinoMetaLake;
 import com.datastrato.gravitino.integration.test.util.AbstractIT;
 import com.datastrato.gravitino.integration.test.util.GravitinoITUtils;
-import com.datastrato.gravitino.server.auth.OAuthConfig;
 import com.google.common.collect.Maps;
 import java.util.Collections;
 import java.util.Map;
@@ -26,7 +26,7 @@ public class AuditIT extends AbstractIT {
   @BeforeAll
   public static void startIntegrationTest() throws Exception {
     Map<String, String> configs = Maps.newHashMap();
-    configs.put(OAuthConfig.AUTHENTICATOR.getKey(), AuthenticatorType.SIMPLE.name().toLowerCase());
+    configs.put(Configs.AUTHENTICATOR.getKey(), AuthenticatorType.SIMPLE.name().toLowerCase());
     registerCustomConfigs(configs);
     AbstractIT.startIntegrationTest();
   }

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/AbstractIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/AbstractIT.java
@@ -8,6 +8,7 @@ import static com.datastrato.gravitino.Configs.ENTRY_KV_ROCKSDB_BACKEND_PATH;
 import static com.datastrato.gravitino.server.GravitinoServer.WEBSERVER_CONF_PREFIX;
 
 import com.datastrato.gravitino.Config;
+import com.datastrato.gravitino.Configs;
 import com.datastrato.gravitino.auth.AuthenticatorType;
 import com.datastrato.gravitino.client.GravitinoClient;
 import com.datastrato.gravitino.integration.test.MiniGravitino;
@@ -17,7 +18,6 @@ import com.datastrato.gravitino.rel.Table;
 import com.datastrato.gravitino.rel.indexes.Index;
 import com.datastrato.gravitino.server.GravitinoServer;
 import com.datastrato.gravitino.server.ServerConfig;
-import com.datastrato.gravitino.server.auth.OAuthConfig;
 import com.datastrato.gravitino.server.web.JettyServerConfig;
 import java.io.File;
 import java.io.IOException;
@@ -131,17 +131,17 @@ public class AbstractIT {
     if (AuthenticatorType.OAUTH
         .name()
         .toLowerCase()
-        .equals(customConfigs.get(OAuthConfig.AUTHENTICATOR.getKey()))) {
+        .equals(customConfigs.get(Configs.AUTHENTICATOR.getKey()))) {
       client = GravitinoClient.builder(uri).withOAuth(mockDataProvider).build();
     } else if (AuthenticatorType.SIMPLE
         .name()
         .toLowerCase()
-        .equals(customConfigs.get(OAuthConfig.AUTHENTICATOR.getKey()))) {
+        .equals(customConfigs.get(Configs.AUTHENTICATOR.getKey()))) {
       client = GravitinoClient.builder(uri).withSimpleAuth().build();
     } else if (AuthenticatorType.KERBEROS
         .name()
         .toLowerCase()
-        .equals(customConfigs.get(OAuthConfig.AUTHENTICATOR.getKey()))) {
+        .equals(customConfigs.get(Configs.AUTHENTICATOR.getKey()))) {
       uri = "http://localhost:" + jettyServerConfig.getHttpPort();
       client =
           GravitinoClient.builder(uri)

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/rest/OAuth2OperationsIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/rest/OAuth2OperationsIT.java
@@ -4,6 +4,7 @@
  */
 package com.datastrato.gravitino.integration.test.web.rest;
 
+import com.datastrato.gravitino.Configs;
 import com.datastrato.gravitino.auth.AuthenticatorType;
 import com.datastrato.gravitino.client.GravitinoVersion;
 import com.datastrato.gravitino.integration.test.util.AbstractIT;
@@ -41,7 +42,7 @@ public class OAuth2OperationsIT extends AbstractIT {
             .setAudience("service1")
             .signWith(keyPair.getPrivate(), SignatureAlgorithm.RS256)
             .compact();
-    configs.put(OAuthConfig.AUTHENTICATOR.getKey(), AuthenticatorType.OAUTH.name().toLowerCase());
+    configs.put(Configs.AUTHENTICATOR.getKey(), AuthenticatorType.OAUTH.name().toLowerCase());
     configs.put(OAuthConfig.SERVICE_AUDIENCE.getKey(), "service1");
     configs.put(OAuthConfig.DEFAULT_SIGN_KEY.getKey(), publicKey);
     configs.put(OAuthConfig.ALLOW_SKEW_SECONDS.getKey(), "6");


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Fix use of OAuthConfig.AUTHENTICATOR

### Why are the changes needed?

Static members are associated with the class itself, not with any specific instance of the class or its children classes.
Change OAuthConfig.AUTHENTICATOR to Configs.AUTHENTICATOR.

Fix: #2192

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Check there is no OAuthConfig.AUTHENTICATOR.
