### PR TITLE
[#2257] improve(core): Fix possible memory leak on TransactionalKvBackendImpl.java

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/storage/kv/TransactionalKvBackendImpl.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/kv/TransactionalKvBackendImpl.java
@@ -53,10 +53,10 @@ public class TransactionalKvBackendImpl implements TransactionalKvBackend {
 
   @VisibleForTesting
   final ThreadLocal<List<Pair<byte[], byte[]>>> putPairs =
-      ThreadLocal.withInitial(() -> Lists.newArrayList());
+      ThreadLocal.withInitial(Lists::newArrayList);
 
   private final ThreadLocal<List<byte[]>> originalKeys =
-      ThreadLocal.withInitial(() -> Lists.newArrayList());
+      ThreadLocal.withInitial(Lists::newArrayList);
 
   @VisibleForTesting final ThreadLocal<Long> txId = new ThreadLocal<>();
 
@@ -124,8 +124,8 @@ public class TransactionalKvBackendImpl implements TransactionalKvBackend {
 
   @Override
   public void closeTransaction() {
-    putPairs.get().clear();
-    originalKeys.get().clear();
+    putPairs.remove();
+    originalKeys.remove();
     txId.remove();
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Possible memory leak issue with TransactionalKvBackendImpl class 

### Why are the changes needed?
Fix: https://github.com/datastrato/gravitino/issues/2257

### Does this PR introduce any user-facing change?
N/A

### How was this patch tested?
By hand