### PR TITLE
[#1658] feat(common): redact sensitive string in catalog properties

### DIFF
--- a/common/src/main/java/com/datastrato/gravitino/dto/CatalogDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/CatalogDTO.java
@@ -6,6 +6,7 @@ package com.datastrato.gravitino.dto;
 
 import com.datastrato.gravitino.Audit;
 import com.datastrato.gravitino.Catalog;
+import com.datastrato.gravitino.utils.MapUtils;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import java.util.Map;
@@ -233,6 +234,11 @@ public class CatalogDTO implements Catalog {
       Preconditions.checkArgument(
           StringUtils.isNotBlank(provider), "provider cannot be null or empty");
       Preconditions.checkArgument(audit != null, "audit cannot be null");
+
+      // redact properties
+      if (properties != null) {
+        properties = MapUtils.redactSensitiveValueByKey(properties);
+      }
 
       return new CatalogDTO(name, type, provider, comment, properties, audit);
     }

--- a/common/src/main/java/com/datastrato/gravitino/utils/MapUtils.java
+++ b/common/src/main/java/com/datastrato/gravitino/utils/MapUtils.java
@@ -5,6 +5,7 @@
 
 package com.datastrato.gravitino.utils;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import java.util.Collections;
 import java.util.Map;
@@ -14,7 +15,8 @@ import java.util.regex.Pattern;
 public class MapUtils {
   private static final String PROPERTIES_REDACTION_PATTERN = "(?i)secret|password|token";
   private static final Pattern PROPERTIES_REDACTION = Pattern.compile(PROPERTIES_REDACTION_PATTERN);
-  private static final String REDACTION_REPLACEMENT_TEXT = "*********(redacted)";
+
+  @VisibleForTesting static final String REDACTION_REPLACEMENT_TEXT = "*********(redacted)";
 
   /**
    * Returns a map with all keys that start with the given prefix.
@@ -46,6 +48,12 @@ public class MapUtils {
     return Collections.unmodifiableMap(m);
   }
 
+  /**
+   * Returns a redacted map.
+   *
+   * @param source The map to redact.
+   * @return Map.
+   */
   public static Map<String, String> redactSensitiveValueByKey(Map<String, String> source) {
     Map<String, String> redactedMap = Maps.newHashMap(source);
     redactedMap.replaceAll(

--- a/common/src/main/java/com/datastrato/gravitino/utils/MapUtils.java
+++ b/common/src/main/java/com/datastrato/gravitino/utils/MapUtils.java
@@ -8,9 +8,13 @@ package com.datastrato.gravitino.utils;
 import com.google.common.collect.Maps;
 import java.util.Collections;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /** Utility class for working with maps. */
 public class MapUtils {
+  private static final String PROPERTIES_REDACTION_PATTERN = "(?i)secret|password|token";
+  private static final Pattern PROPERTIES_REDACTION = Pattern.compile(PROPERTIES_REDACTION_PATTERN);
+  private static final String REDACTION_REPLACEMENT_TEXT = "*********(redacted)";
 
   /**
    * Returns a map with all keys that start with the given prefix.
@@ -40,5 +44,17 @@ public class MapUtils {
    */
   public static Map<String, String> unmodifiableMap(Map<String, String> m) {
     return Collections.unmodifiableMap(m);
+  }
+
+  public static Map<String, String> redactSensitiveValueByKey(Map<String, String> source) {
+    Map<String, String> redactedMap = Maps.newHashMap(source);
+    redactedMap.replaceAll(
+        (k, v) -> {
+          if (PROPERTIES_REDACTION.matcher(k).find()) {
+            return REDACTION_REPLACEMENT_TEXT;
+          }
+          return v;
+        });
+    return redactedMap;
   }
 }

--- a/common/src/test/java/com/datastrato/gravitino/utils/TestMapUtils.java
+++ b/common/src/test/java/com/datastrato/gravitino/utils/TestMapUtils.java
@@ -36,10 +36,10 @@ public class TestMapUtils {
             "regular", "value");
     Map<String, String> expected =
         ImmutableMap.of(
-            "secret", "*********(redacted)",
-            "password", "*********(redacted)",
-            "token", "*********(redacted)",
-            "jdbc-password", "*********(redacted)",
+            "secret", MapUtils.REDACTION_REPLACEMENT_TEXT,
+            "password", MapUtils.REDACTION_REPLACEMENT_TEXT,
+            "token", MapUtils.REDACTION_REPLACEMENT_TEXT,
+            "jdbc-password", MapUtils.REDACTION_REPLACEMENT_TEXT,
             "regular", "value");
 
     Map<String, String> result = MapUtils.redactSensitiveValueByKey(source);

--- a/common/src/test/java/com/datastrato/gravitino/utils/TestMapUtils.java
+++ b/common/src/test/java/com/datastrato/gravitino/utils/TestMapUtils.java
@@ -24,4 +24,26 @@ public class TestMapUtils {
     Assertions.assertEquals(ImmutableMap.of("a", ""), MapUtils.getPrefixMap(configs, "b."));
     Assertions.assertEquals(configs, MapUtils.getPrefixMap(configs, ""));
   }
+
+  @Test
+  public void testRedactSensitiveValueByKey() {
+    Map<String, String> source =
+        ImmutableMap.of(
+            "secret", "value",
+            "password", "value",
+            "token", "value",
+            "jdbc-password", "value",
+            "regular", "value");
+    Map<String, String> expected =
+        ImmutableMap.of(
+            "secret", "*********(redacted)",
+            "password", "*********(redacted)",
+            "token", "*********(redacted)",
+            "jdbc-password", "*********(redacted)",
+            "regular", "value");
+
+    Map<String, String> result = MapUtils.redactSensitiveValueByKey(source);
+
+    Assertions.assertEquals(expected, result);
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

redact sensitive string in catalog properties

### Why are the changes needed?

Fix: #1658

### Does this PR introduce _any_ user-facing change?

get catalog proerties from HTTP Rest API will get a redaction string when key reglike '(?i)secret|password|token'

### How was this patch tested?

UT & UI