### PR TITLE
[#2288] Improvement(test) : Add tests to retrieve index keys for tables in wildcard scenarios.

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/CatalogMysqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/mysql/CatalogMysqlIT.java
@@ -1081,12 +1081,14 @@ public class CatalogMysqlIT extends AbstractIT {
     Map<String, String> properties = createProperties();
     TableCatalog tableCatalog = catalog.asTableCatalog();
 
-    String tableName = "t112";
-    Column col1 = Column.of(tableName, Types.LongType.get(), "id", false, false, null);
-    Column[] columns = {col1};
+    String t1_name = "t112";
+    Column t1_col = Column.of(t1_name, Types.LongType.get(), "id", false, false, null);
+    Column[] columns = {t1_col};
+
+    Index[] t1_indexes = {Indexes.unique("u1_key", new String[][] {{t1_name}})};
 
     NameIdentifier tableIdentifier =
-        NameIdentifier.of(metalakeName, catalogName, schemaName, tableName);
+        NameIdentifier.of(metalakeName, catalogName, schemaName, t1_name);
     tableCatalog.createTable(
         tableIdentifier,
         columns,
@@ -1094,12 +1096,14 @@ public class CatalogMysqlIT extends AbstractIT {
         properties,
         Transforms.EMPTY_TRANSFORM,
         Distributions.NONE,
-        new SortOrder[0]);
+        new SortOrder[0],
+        t1_indexes);
 
-    tableName = "t212";
-    col1 = Column.of(tableName, Types.LongType.get(), "id", false, false, null);
-    columns = new Column[] {col1};
-    tableIdentifier = NameIdentifier.of(metalakeName, catalogName, schemaName, tableName);
+    String t2_name = "t212";
+    Column t2_col = Column.of(t2_name, Types.LongType.get(), "id", false, false, null);
+    Index[] t2_indexes = {Indexes.unique("u2_key", new String[][] {{t2_name}})};
+    columns = new Column[] {t2_col};
+    tableIdentifier = NameIdentifier.of(metalakeName, catalogName, schemaName, t2_name);
     tableCatalog.createTable(
         tableIdentifier,
         columns,
@@ -1107,12 +1111,14 @@ public class CatalogMysqlIT extends AbstractIT {
         properties,
         Transforms.EMPTY_TRANSFORM,
         Distributions.NONE,
-        new SortOrder[0]);
+        new SortOrder[0],
+        t2_indexes);
 
-    tableName = "t_12";
-    col1 = Column.of(tableName, Types.LongType.get(), "id", false, false, null);
-    columns = new Column[] {col1};
-    tableIdentifier = NameIdentifier.of(metalakeName, catalogName, schemaName, tableName);
+    String t3_name = "t_12";
+    Column t3_col = Column.of(t3_name, Types.LongType.get(), "id", false, false, null);
+    Index[] t3_indexes = {Indexes.unique("u3_key", new String[][] {{t3_name}})};
+    columns = new Column[] {t3_col};
+    tableIdentifier = NameIdentifier.of(metalakeName, catalogName, schemaName, t3_name);
     tableCatalog.createTable(
         tableIdentifier,
         columns,
@@ -1120,12 +1126,14 @@ public class CatalogMysqlIT extends AbstractIT {
         properties,
         Transforms.EMPTY_TRANSFORM,
         Distributions.NONE,
-        new SortOrder[0]);
+        new SortOrder[0],
+        t3_indexes);
 
-    tableName = "_1__";
-    col1 = Column.of(tableName, Types.LongType.get(), "id", false, false, null);
-    columns = new Column[] {col1};
-    tableIdentifier = NameIdentifier.of(metalakeName, catalogName, schemaName, tableName);
+    String t4_name = "_1__";
+    Column t4_col = Column.of(t4_name, Types.LongType.get(), "id", false, false, null);
+    Index[] t4_indexes = {Indexes.unique("u4_key", new String[][] {{t4_name}})};
+    columns = new Column[] {t4_col};
+    tableIdentifier = NameIdentifier.of(metalakeName, catalogName, schemaName, t4_name);
     tableCatalog.createTable(
         tableIdentifier,
         columns,
@@ -1133,23 +1141,28 @@ public class CatalogMysqlIT extends AbstractIT {
         properties,
         Transforms.EMPTY_TRANSFORM,
         Distributions.NONE,
-        new SortOrder[0]);
+        new SortOrder[0],
+        t4_indexes);
 
     Table t1 =
-        tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, "t112"));
+        tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, t1_name));
     Arrays.stream(t1.columns()).anyMatch(c -> Objects.equals(c.name(), "t112"));
+    assertionsTableInfo(t1_name, table_comment, Arrays.asList(t1_col), properties, t1_indexes, t1);
 
     Table t2 =
-        tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, "t212"));
+        tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, t2_name));
     Arrays.stream(t2.columns()).anyMatch(c -> Objects.equals(c.name(), "t212"));
+    assertionsTableInfo(t2_name, table_comment, Arrays.asList(t2_col), properties, t2_indexes, t2);
 
     Table t3 =
-        tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, "t_12"));
+        tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, t3_name));
     Arrays.stream(t3.columns()).anyMatch(c -> Objects.equals(c.name(), "t_12"));
+    assertionsTableInfo(t3_name, table_comment, Arrays.asList(t3_col), properties, t3_indexes, t3);
 
     Table t4 =
-        tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, "_1__"));
+        tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, t4_name));
     Arrays.stream(t4.columns()).anyMatch(c -> Objects.equals(c.name(), "_1__"));
+    assertionsTableInfo(t4_name, table_comment, Arrays.asList(t4_col), properties, t4_indexes, t4);
   }
 
   @Test

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
@@ -910,12 +910,14 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     Map<String, String> properties = createProperties();
     TableCatalog tableCatalog = catalog.asTableCatalog();
 
-    String tableName = "t112";
-    Column col1 = Column.of(tableName, Types.LongType.get(), "id", false, false, null);
-    Column[] columns = {col1};
+    String t1_name = "t112";
+    Column t1_col = Column.of(t1_name, Types.LongType.get(), "id", false, false, null);
+    Column[] columns = {t1_col};
+
+    Index[] t1_indexes = {Indexes.unique("u1_key", new String[][] {{t1_name}})};
 
     NameIdentifier tableIdentifier =
-        NameIdentifier.of(metalakeName, catalogName, schemaName, tableName);
+        NameIdentifier.of(metalakeName, catalogName, schemaName, t1_name);
     tableCatalog.createTable(
         tableIdentifier,
         columns,
@@ -923,12 +925,14 @@ public class CatalogPostgreSqlIT extends AbstractIT {
         properties,
         Transforms.EMPTY_TRANSFORM,
         Distributions.NONE,
-        new SortOrder[0]);
+        new SortOrder[0],
+        t1_indexes);
 
-    tableName = "t212";
-    col1 = Column.of(tableName, Types.LongType.get(), "id", false, false, null);
-    columns = new Column[] {col1};
-    tableIdentifier = NameIdentifier.of(metalakeName, catalogName, schemaName, tableName);
+    String t2_name = "t212";
+    Column t2_col = Column.of(t2_name, Types.LongType.get(), "id", false, false, null);
+    Index[] t2_indexes = {Indexes.unique("u2_key", new String[][] {{t2_name}})};
+    columns = new Column[] {t2_col};
+    tableIdentifier = NameIdentifier.of(metalakeName, catalogName, schemaName, t2_name);
     tableCatalog.createTable(
         tableIdentifier,
         columns,
@@ -936,12 +940,14 @@ public class CatalogPostgreSqlIT extends AbstractIT {
         properties,
         Transforms.EMPTY_TRANSFORM,
         Distributions.NONE,
-        new SortOrder[0]);
+        new SortOrder[0],
+        t2_indexes);
 
-    tableName = "t_12";
-    col1 = Column.of(tableName, Types.LongType.get(), "id", false, false, null);
-    columns = new Column[] {col1};
-    tableIdentifier = NameIdentifier.of(metalakeName, catalogName, schemaName, tableName);
+    String t3_name = "t_12";
+    Column t3_col = Column.of(t3_name, Types.LongType.get(), "id", false, false, null);
+    Index[] t3_indexes = {Indexes.unique("u3_key", new String[][] {{t3_name}})};
+    columns = new Column[] {t3_col};
+    tableIdentifier = NameIdentifier.of(metalakeName, catalogName, schemaName, t3_name);
     tableCatalog.createTable(
         tableIdentifier,
         columns,
@@ -949,12 +955,14 @@ public class CatalogPostgreSqlIT extends AbstractIT {
         properties,
         Transforms.EMPTY_TRANSFORM,
         Distributions.NONE,
-        new SortOrder[0]);
+        new SortOrder[0],
+        t3_indexes);
 
-    tableName = "_1__";
-    col1 = Column.of(tableName, Types.LongType.get(), "id", false, false, null);
-    columns = new Column[] {col1};
-    tableIdentifier = NameIdentifier.of(metalakeName, catalogName, schemaName, tableName);
+    String t4_name = "_1__";
+    Column t4_col = Column.of(t4_name, Types.LongType.get(), "id", false, false, null);
+    Index[] t4_indexes = {Indexes.unique("u4_key", new String[][] {{t4_name}})};
+    columns = new Column[] {t4_col};
+    tableIdentifier = NameIdentifier.of(metalakeName, catalogName, schemaName, t4_name);
     tableCatalog.createTable(
         tableIdentifier,
         columns,
@@ -962,23 +970,28 @@ public class CatalogPostgreSqlIT extends AbstractIT {
         properties,
         Transforms.EMPTY_TRANSFORM,
         Distributions.NONE,
-        new SortOrder[0]);
+        new SortOrder[0],
+        t4_indexes);
 
     Table t1 =
-        tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, "t112"));
+        tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, t1_name));
     Arrays.stream(t1.columns()).anyMatch(c -> Objects.equals(c.name(), "t112"));
+    assertionsTableInfo(t1_name, table_comment, Arrays.asList(t1_col), properties, t1_indexes, t1);
 
     Table t2 =
-        tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, "t212"));
+        tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, t2_name));
     Arrays.stream(t2.columns()).anyMatch(c -> Objects.equals(c.name(), "t212"));
+    assertionsTableInfo(t2_name, table_comment, Arrays.asList(t2_col), properties, t2_indexes, t2);
 
     Table t3 =
-        tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, "t_12"));
+        tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, t3_name));
     Arrays.stream(t3.columns()).anyMatch(c -> Objects.equals(c.name(), "t_12"));
+    assertionsTableInfo(t3_name, table_comment, Arrays.asList(t3_col), properties, t3_indexes, t3);
 
     Table t4 =
-        tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, "_1__"));
+        tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, t4_name));
     Arrays.stream(t4.columns()).anyMatch(c -> Objects.equals(c.name(), "_1__"));
+    assertionsTableInfo(t4_name, table_comment, Arrays.asList(t4_col), properties, t4_indexes, t4);
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add tests to retrieve index keys for tables in wildcard scenarios.

### Why are the changes needed?

Fix: #2288

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
IT