### PR TITLE
[#2326] feat(docker): support build with arg platform=all on Doris docker image

### DIFF
--- a/dev/docker/build-docker.sh
+++ b/dev/docker/build-docker.sh
@@ -80,7 +80,7 @@ elif [ "${component_type}" == "gravitino" ]; then
   . ${script_dir}/gravitino/gravitino-dependency.sh
 elif [ "${component_type}" == "doris" ]; then
   . ${script_dir}/doris/doris-dependency.sh --platform ${platform_type}
-  build_args="--build-arg DORIS_PACKAGE_NAME=${DORIS_PACKAGE_NAME} --build-arg DORIS_FILE_NAME=${DORIS_FILE_NAME}"
+  build_args="--build-arg DORIS_VERSION=${DORIS_VERSION}"
 else
   echo "ERROR : ${component_type} is not a valid component type"
   usage

--- a/dev/docker/doris/Dockerfile
+++ b/dev/docker/doris/Dockerfile
@@ -6,6 +6,7 @@ FROM ubuntu:22.04
 LABEL maintainer="support@datastrato.com"
 
 ARG DORIS_VERSION
+ARG TARGETARCH
 
 WORKDIR /
 
@@ -28,21 +29,22 @@ ENV DORIS_BE_HOME=${DORIS_HOME}/be
 
 ENV PATH=${JAVA_HOME}/bin:${DORIS_FE_HOME}/bin:${DORIS_BE_HOME}/bin:${PATH}
 
-RUN mkdir ${DORIS_HOME}
-COPY packages /tmp/packages
-COPY start.sh ${DORIS_HOME}
-
 ################################################################################
-# setup java, unzip doris package
+# setup java
 
 RUN ARCH=$(uname -m) && \
   if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \
     ln -s /usr/lib/jvm/java-8-openjdk-arm64 ${JAVA_HOME}; \
-    tar -xv -C "${DORIS_HOME}" --strip-components 1 -f /tmp/packages/apache-doris-${DORIS_VERSION}-bin-arm64.tar.xz; \
   else \
     ln -s /usr/lib/jvm/java-8-openjdk-amd64 ${JAVA_HOME}; \
-    tar -xv -C "${DORIS_HOME}" --strip-components 1 -f /tmp/packages/apache-doris-${DORIS_VERSION}-bin-x64.tar.xz; \
   fi
+
+#################################################################################
+## add files
+ADD packages/doris-${TARGETARCH}.tar.xz /opt/
+RUN ln -s /opt/apache-doris-${DORIS_VERSION}-bin-* ${DORIS_HOME} 
+
+COPY start.sh ${DORIS_HOME}
 
 ################################################################################
 # set WORKDIR/EXPOSE/CMD

--- a/dev/docker/doris/Dockerfile
+++ b/dev/docker/doris/Dockerfile
@@ -5,9 +5,7 @@
 FROM ubuntu:22.04
 LABEL maintainer="support@datastrato.com"
 
-ARG DORIS_PACKAGE_NAME
-ARG DORIS_FILE_NAME
-ARG TARGET_ARCH
+ARG DORIS_VERSION
 
 WORKDIR /
 
@@ -30,23 +28,21 @@ ENV DORIS_BE_HOME=${DORIS_HOME}/be
 
 ENV PATH=${JAVA_HOME}/bin:${DORIS_FE_HOME}/bin:${DORIS_BE_HOME}/bin:${PATH}
 
+RUN mkdir ${DORIS_HOME}
+COPY packages /tmp/packages
+COPY start.sh ${DORIS_HOME}
+
 ################################################################################
-# setup java
+# setup java, unzip doris package
 
 RUN ARCH=$(uname -m) && \
   if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \
     ln -s /usr/lib/jvm/java-8-openjdk-arm64 ${JAVA_HOME}; \
+    tar -xv -C "${DORIS_HOME}" --strip-components 1 -f /tmp/packages/apache-doris-${DORIS_VERSION}-bin-arm64.tar.xz; \
   else \
     ln -s /usr/lib/jvm/java-8-openjdk-amd64 ${JAVA_HOME}; \
+    tar -xv -C "${DORIS_HOME}" --strip-components 1 -f /tmp/packages/apache-doris-${DORIS_VERSION}-bin-x64.tar.xz; \
   fi
-
-#################################################################################
-## add files
-
-ADD packages/${DORIS_FILE_NAME} /opt
-RUN ln -s /opt/${DORIS_PACKAGE_NAME} ${DORIS_HOME}
-
-COPY start.sh ${DORIS_HOME}
 
 ################################################################################
 # set WORKDIR/EXPOSE/CMD

--- a/dev/docker/doris/doris-dependency.sh
+++ b/dev/docker/doris/doris-dependency.sh
@@ -20,8 +20,8 @@ if [[ "$1" == "--platform" ]]; then
     echo "INFO : doris build platform type is ${platform_type}"
     TARGET_ARCH="arm64"
   elif [[ "${platform_type}" == "all" ]]; then
-    echo "ERROR : doris not support ${platform_type}"
-    exit 1
+    echo "INFO : doris build platform type is ${platform_type}"
+    TARGET_ARCH="all"
   else
     echo "ERROR : ${platform_type} is not a valid platform type for doris"
     usage
@@ -29,49 +29,61 @@ if [[ "$1" == "--platform" ]]; then
   fi
   shift
 else
-  echo "ERROR: must specify platform for doris"
-  exit 1
+  TARGET_ARCH="all"
 fi
 
 # Environment variables definition
 DORIS_VERSION="1.2.7.1"
 
-DORIS_PACKAGE_NAME="apache-doris-${DORIS_VERSION}-bin-${TARGET_ARCH}"
-DORIS_FILE_NAME="${DORIS_PACKAGE_NAME}.tar.xz"
-DORIS_DOWNLOAD_URL="https://apache-doris-releases.oss-accelerate.aliyuncs.com/${DORIS_FILE_NAME}"
-SHA512SUMS_URL="${DORIS_DOWNLOAD_URL}.sha512"
+download_and_check() {
+  local arch="${1}"
+  # Download doris package
+  DORIS_PACKAGE_NAME="apache-doris-${DORIS_VERSION}-bin-${arch}"
+  DORIS_FILE_NAME="${DORIS_PACKAGE_NAME}.tar.xz"
+  DORIS_DOWNLOAD_URL="https://apache-doris-releases.oss-accelerate.aliyuncs.com/${DORIS_FILE_NAME}"
+  SHA512SUMS_URL="${DORIS_DOWNLOAD_URL}.sha512"
 
-# Prepare download packages
-if [[ ! -d "${doris_dir}/packages" ]]; then
-  mkdir -p "${doris_dir}/packages"
-fi
+  # Prepare download packages
+  if [[ ! -d "${doris_dir}/packages" ]]; then
+    mkdir -p "${doris_dir}/packages"
+  fi
 
-if [[ ! -f "${doris_dir}/packages/${DORIS_FILE_NAME}" ]]; then
-  curl -s -o "${doris_dir}/packages/${DORIS_FILE_NAME}" ${DORIS_DOWNLOAD_URL}
-fi
+  if [[ ! -f "${doris_dir}/packages/${DORIS_FILE_NAME}" ]]; then
+    echo "INFO : Downloading doris package ${DORIS_FILE_NAME}"
+    curl -s -o "${doris_dir}/packages/${DORIS_FILE_NAME}" ${DORIS_DOWNLOAD_URL}
+    echo "INFO : Downloading doris package done"
+  fi
 
-# download sha512sum file
-if [[ ! -f "${doris_dir}/packages/${DORIS_FILE_NAME}.sha512" ]]; then
-  curl -s -o "${doris_dir}/packages/${DORIS_FILE_NAME}.sha512" ${SHA512SUMS_URL}
-fi
+  # download sha512sum file
+  if [[ ! -f "${doris_dir}/packages/${DORIS_FILE_NAME}.sha512" ]]; then
+    curl -s -o "${doris_dir}/packages/${DORIS_FILE_NAME}.sha512" ${SHA512SUMS_URL}
+  fi
 
 
-cd "${doris_dir}/packages" || exit 1
+  cd "${doris_dir}/packages" || exit 1
 
-# check sha512sum, if check file failed, exit 1
-
-if command -v shasum &>/dev/null; then
-  shasum -c "${DORIS_FILE_NAME}.sha512"
-elif command -v sha512sum &>/dev/null; then
-  sha512sum -c "${DORIS_FILE_NAME}.sha512"
-else
-  cat << EOF
-  WARN: cannot find shasum or sha512sum command, skip sha512sum check, please check the sha512sum by yourself.
-  if build Docker image failed, maybe the package is broken.
+  # check sha512sum, if check file failed, exit 1
+  echo "INFO : Checking sha512sum for ${DORIS_FILE_NAME}"
+  if command -v shasum &>/dev/null; then
+    shasum -c "${DORIS_FILE_NAME}.sha512"
+  elif command -v sha512sum &>/dev/null; then
+    sha512sum -c "${DORIS_FILE_NAME}.sha512"
+  else
+    cat << EOF
+    WARN: cannot find shasum or sha512sum command, skip sha512sum check, please check the sha512sum by yourself.
+    if build Docker image failed, maybe the package is broken.
 EOF
-fi
+  fi
 
-if [ $? -ne 0 ]; then
-  echo "ERROR: sha512sum check failed"
-  exit 1
+  if [ $? -ne 0 ]; then
+    echo "ERROR: check doris package sha512sum failed"
+    exit 1
+  fi
+}
+
+if [[ "${TARGET_ARCH}" == "all" ]]; then
+  download_and_check "x64"
+  download_and_check "arm64"
+else
+  download_and_check "${TARGET_ARCH}"
 fi


### PR DESCRIPTION
### What changes were proposed in this pull request?

support `platform=all` for doris images

### Why are the changes needed?

Fix: #2326

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

local

```
./build-docker.sh --type doris --image doris_ci --tag test
./build-docker.sh --platform linux/arm64 --type doris --image doris_ci --tag test
./build-docker.sh --platform linux/amd64 --type doris --image doris_ci --tag test
```
