### PR TITLE
[#2179] Improvement: Improve security when creating and dropping schemas and tables

### DIFF
--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalog.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalog.java
@@ -13,6 +13,7 @@ import com.datastrato.gravitino.connector.BaseCatalog;
 import com.datastrato.gravitino.connector.CatalogOperations;
 import com.datastrato.gravitino.connector.PropertiesMetadata;
 import com.datastrato.gravitino.connector.PropertyEntry;
+import com.datastrato.gravitino.connector.capability.Capability;
 import java.util.Collections;
 import java.util.Map;
 
@@ -50,6 +51,11 @@ public abstract class JdbcCatalog extends BaseCatalog<JdbcCatalog> {
             createJdbcTableOperations(),
             createJdbcColumnDefaultValueConverter());
     return ops;
+  }
+
+  @Override
+  public Capability newCapability() {
+    return new JdbcCatalogCapability();
   }
 
   /** @return The {@link JdbcExceptionConverter} to be used by the catalog. */

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogCapability.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogCapability.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.catalog.jdbc;
+
+import com.datastrato.gravitino.connector.capability.Capability;
+import com.datastrato.gravitino.connector.capability.CapabilityResult;
+
+public class JdbcCatalogCapability implements Capability {
+  /**
+   * Regular expression explanation: Regex that matches any string that maybe a filename with an
+   * optional extension We adopt a blacklist approach that excludes filename or extension that
+   * contains '.', '/', or '\' ^[^.\/\\]+(\.[^.\/\\]+)?$
+   *
+   * <p>^ - Start of the string
+   *
+   * <p>[^.\/\\]+ - matches any filename string that does not contain '.', '/', or '\'
+   *
+   * <p>(\.[^.\/\\]+)? - matches an optional extension
+   *
+   * <p>$ - End of the string
+   */
+  // We use sqlite name pattern to be the default pattern for JDBC catalog for testing purposes
+  public static final String SQLITE_NAME_PATTERN = "^[^.\\/\\\\]+(\\.[^.\\/\\\\]+)?$";
+
+  @Override
+  public CapabilityResult specificationOnName(Scope scope, String name) {
+    // TODO: Validate the name against reserved words
+    if (!name.matches(SQLITE_NAME_PATTERN)) {
+      return CapabilityResult.unsupported(
+          String.format("The %s name '%s' is illegal.", scope, name));
+    }
+    return CapabilityResult.SUPPORTED;
+  }
+}

--- a/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/DorisCatalog.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/DorisCatalog.java
@@ -17,6 +17,7 @@ import com.datastrato.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
 import com.datastrato.gravitino.catalog.jdbc.operation.JdbcDatabaseOperations;
 import com.datastrato.gravitino.catalog.jdbc.operation.JdbcTableOperations;
 import com.datastrato.gravitino.connector.CatalogOperations;
+import com.datastrato.gravitino.connector.capability.Capability;
 import java.util.Map;
 
 /** Implementation of a Doris catalog in Gravitino. */
@@ -36,6 +37,11 @@ public class DorisCatalog extends JdbcCatalog {
         createJdbcDatabaseOperations(),
         createJdbcTableOperations(),
         createJdbcColumnDefaultValueConverter());
+  }
+
+  @Override
+  public Capability newCapability() {
+    return new DorisCatalogCapability();
   }
 
   @Override

--- a/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/DorisCatalogCapability.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/DorisCatalogCapability.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.catalog.doris;
+
+import com.datastrato.gravitino.connector.capability.Capability;
+
+public class DorisCatalogCapability implements Capability {
+  // Doris best practice mention that the name should be in lowercase, separated by underscores
+  // https://doris.apache.org/docs/2.0/table-design/best-practice/
+  // We can use the more general DEFAULT_NAME_PATTERN for Doris and update as needed in the future
+}

--- a/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/MysqlCatalog.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/MysqlCatalog.java
@@ -18,6 +18,7 @@ import com.datastrato.gravitino.catalog.mysql.operation.MysqlDatabaseOperations;
 import com.datastrato.gravitino.catalog.mysql.operation.MysqlTableOperations;
 import com.datastrato.gravitino.connector.CatalogOperations;
 import com.datastrato.gravitino.connector.PropertiesMetadata;
+import com.datastrato.gravitino.connector.capability.Capability;
 import java.util.Map;
 
 /** Implementation of a Mysql catalog in Gravitino. */
@@ -40,6 +41,11 @@ public class MysqlCatalog extends JdbcCatalog {
         createJdbcDatabaseOperations(),
         createJdbcTableOperations(),
         createJdbcColumnDefaultValueConverter());
+  }
+
+  @Override
+  public Capability newCapability() {
+    return new MysqlCatalogCapability();
   }
 
   @Override

--- a/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/MysqlCatalogCapability.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/MysqlCatalogCapability.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.catalog.mysql;
+
+import com.datastrato.gravitino.connector.capability.Capability;
+import com.datastrato.gravitino.connector.capability.CapabilityResult;
+
+public class MysqlCatalogCapability implements Capability {
+  /**
+   * Regular expression explanation: ^[\w\p{L}-$/=]{1,64}$
+   *
+   * <p>^ - Start of the string
+   *
+   * <p>[\w\p{L}-$/=]{1,64} - Consist of 1 to 64 characters of letters (both cases), digits,
+   * underscores, any kind of letter from any language, hyphens, dollar signs, slashes or equal
+   * signs
+   *
+   * <p>\w - matches [a-zA-Z0-9_]
+   *
+   * <p>\p{L} - matches any kind of letter from any language
+   *
+   * <p>$ - End of the string
+   */
+  public static final String MYSQL_NAME_PATTERN = "^[\\w\\p{L}-$/=]{1,64}$";
+
+  @Override
+  public CapabilityResult specificationOnName(Scope scope, String name) {
+    // TODO: Validate the name against reserved words
+    if (!name.matches(MYSQL_NAME_PATTERN)) {
+      return CapabilityResult.unsupported(
+          String.format("The %s name '%s' is illegal.", scope, name));
+    }
+    return CapabilityResult.SUPPORTED;
+  }
+}

--- a/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
@@ -1260,6 +1260,118 @@ public class CatalogMysqlIT extends AbstractIT {
   }
 
   @Test
+  void testMySqlIllegalTableName() {
+    Map<String, String> properties = createProperties();
+    TableCatalog tableCatalog = catalog.asTableCatalog();
+    String table_name = "t123";
+
+    String t1_name = table_name + "`; DROP TABLE important_table; -- ";
+    Column t1_col = Column.of(t1_name, Types.LongType.get(), "id", false, false, null);
+    Column[] columns = {t1_col};
+    Index[] t1_indexes = {Indexes.unique("u1_key", new String[][] {{t1_name}})};
+    NameIdentifier tableIdentifier =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, t1_name);
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          tableCatalog.createTable(
+              tableIdentifier,
+              columns,
+              table_comment,
+              properties,
+              Transforms.EMPTY_TRANSFORM,
+              Distributions.NONE,
+              new SortOrder[0],
+              t1_indexes);
+        });
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          catalog.asTableCatalog().dropTable(tableIdentifier);
+        });
+
+    String t2_name = table_name + "`; SLEEP(10); -- ";
+    Column t2_col = Column.of(t2_name, Types.LongType.get(), "id", false, false, null);
+    Index[] t2_indexes = {Indexes.unique("u2_key", new String[][] {{t2_name}})};
+    Column[] columns2 = new Column[] {t2_col};
+    NameIdentifier tableIdentifier2 =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, t2_name);
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          tableCatalog.createTable(
+              tableIdentifier2,
+              columns2,
+              table_comment,
+              properties,
+              Transforms.EMPTY_TRANSFORM,
+              Distributions.NONE,
+              new SortOrder[0],
+              t2_indexes);
+        });
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          catalog.asTableCatalog().dropTable(tableIdentifier2);
+        });
+
+    String t3_name =
+        table_name + "`; UPDATE Users SET password = 'newpassword' WHERE username = 'admin'; -- ";
+    Column t3_col = Column.of(t3_name, Types.LongType.get(), "id", false, false, null);
+    Index[] t3_indexes = {Indexes.unique("u3_key", new String[][] {{t3_name}})};
+    Column[] columns3 = new Column[] {t3_col};
+    NameIdentifier tableIdentifier3 =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, t3_name);
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          tableCatalog.createTable(
+              tableIdentifier3,
+              columns3,
+              table_comment,
+              properties,
+              Transforms.EMPTY_TRANSFORM,
+              Distributions.NONE,
+              new SortOrder[0],
+              t3_indexes);
+        });
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          catalog.asTableCatalog().dropTable(tableIdentifier3);
+        });
+
+    String invalidInput = StringUtils.repeat("a", 65);
+    Column t4_col = Column.of(invalidInput, Types.LongType.get(), "id", false, false, null);
+    Index[] t4_indexes = {Indexes.unique("u4_key", new String[][] {{invalidInput}})};
+    Column[] columns4 = new Column[] {t4_col};
+    NameIdentifier tableIdentifier4 =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, invalidInput);
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          tableCatalog.createTable(
+              tableIdentifier4,
+              columns4,
+              table_comment,
+              properties,
+              Transforms.EMPTY_TRANSFORM,
+              Distributions.NONE,
+              new SortOrder[0],
+              t4_indexes);
+        });
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          catalog.asTableCatalog().dropTable(tableIdentifier4);
+        });
+  }
+
+  @Test
   void testMySQLTableNameCaseSensitive() {
     Column col1 = Column.of("col_1", Types.LongType.get(), "id", false, false, null);
     Column col2 = Column.of("col_2", Types.ByteType.get(), "yes", false, false, null);

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/PostgreSqlCatalog.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/PostgreSqlCatalog.java
@@ -16,6 +16,7 @@ import com.datastrato.gravitino.catalog.postgresql.converter.PostgreSqlTypeConve
 import com.datastrato.gravitino.catalog.postgresql.operation.PostgreSqlSchemaOperations;
 import com.datastrato.gravitino.catalog.postgresql.operation.PostgreSqlTableOperations;
 import com.datastrato.gravitino.connector.CatalogOperations;
+import com.datastrato.gravitino.connector.capability.Capability;
 import java.util.Map;
 
 public class PostgreSqlCatalog extends JdbcCatalog {
@@ -34,6 +35,11 @@ public class PostgreSqlCatalog extends JdbcCatalog {
         createJdbcDatabaseOperations(),
         createJdbcTableOperations(),
         createJdbcColumnDefaultValueConverter());
+  }
+
+  @Override
+  public Capability newCapability() {
+    return new PostgreSqlCatalogCapability();
   }
 
   @Override

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/PostgreSqlCatalogCapability.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/PostgreSqlCatalogCapability.java
@@ -26,7 +26,7 @@ public class PostgreSqlCatalogCapability implements Capability {
     // TODO: Validate the name against reserved words
     if (!name.matches(POSTGRESQL_NAME_PATTERN)) {
       return CapabilityResult.unsupported(
-              String.format("The %s name '%s' is illegal.", scope, name));
+          String.format("The %s name '%s' is illegal.", scope, name));
     }
     return CapabilityResult.SUPPORTED;
   }

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/PostgreSqlCatalogCapability.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/PostgreSqlCatalogCapability.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.catalog.postgresql;
+
+import com.datastrato.gravitino.connector.capability.Capability;
+import com.datastrato.gravitino.connector.capability.CapabilityResult;
+
+public class PostgreSqlCatalogCapability implements Capability {
+  /**
+   * Regular expression explanation: ^[_a-zA-Z\p{L}/][\w\p{L}-$/=]{0,62}$
+   *
+   * <p>^[_a-zA-Z\p{L}/] - Start with an underscore, a letter, or a letter from any language
+   *
+   * <p>[\w\p{L}-$/=]{0,62} - Consist of 0 to 62 characters (making the total length at most 63) of
+   * letters (both cases), digits, underscores, any kind of letter from any language, hyphens,
+   * dollar signs, slashes or equal signs
+   *
+   * <p>$ - End of the string
+   */
+  public static final String POSTGRESQL_NAME_PATTERN = "^[_a-zA-Z\\p{L}/][\\w\\p{L}-$/=]{0,62}$";
+
+  @Override
+  public CapabilityResult specificationOnName(Scope scope, String name) {
+    // TODO: Validate the name against reserved words
+    if (!name.matches(POSTGRESQL_NAME_PATTERN)) {
+      return CapabilityResult.unsupported(
+              String.format("The %s name '%s' is illegal.", scope, name));
+    }
+    return CapabilityResult.SUPPORTED;
+  }
+}

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
@@ -1091,6 +1091,144 @@ public class CatalogPostgreSqlIT extends AbstractIT {
   }
 
   @Test
+  void testPGIllegalTableName() {
+    Map<String, String> properties = createProperties();
+    TableCatalog tableCatalog = catalog.asTableCatalog();
+    String table_name = "t123";
+
+    String t1_name = table_name + "`; DROP TABLE important_table; -- ";
+    Column t1_col = Column.of(t1_name, Types.LongType.get(), "id", false, false, null);
+    Column[] columns = {t1_col};
+    Index[] t1_indexes = {Indexes.unique("u1_key", new String[][] {{t1_name}})};
+    NameIdentifier tableIdentifier =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, t1_name);
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          tableCatalog.createTable(
+              tableIdentifier,
+              columns,
+              table_comment,
+              properties,
+              Transforms.EMPTY_TRANSFORM,
+              Distributions.NONE,
+              new SortOrder[0],
+              t1_indexes);
+        });
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          catalog.asTableCatalog().dropTable(tableIdentifier);
+        });
+
+    String t2_name = table_name + "`; SLEEP(10); -- ";
+    Column t2_col = Column.of(t2_name, Types.LongType.get(), "id", false, false, null);
+    Index[] t2_indexes = {Indexes.unique("u2_key", new String[][] {{t2_name}})};
+    Column[] columns2 = new Column[] {t2_col};
+    NameIdentifier tableIdentifier2 =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, t2_name);
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          tableCatalog.createTable(
+              tableIdentifier2,
+              columns2,
+              table_comment,
+              properties,
+              Transforms.EMPTY_TRANSFORM,
+              Distributions.NONE,
+              new SortOrder[0],
+              t2_indexes);
+        });
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          catalog.asTableCatalog().dropTable(tableIdentifier2);
+        });
+
+    String t3_name =
+        table_name + "`; UPDATE Users SET password = 'newpassword' WHERE username = 'admin'; -- ";
+    Column t3_col = Column.of(t3_name, Types.LongType.get(), "id", false, false, null);
+    Index[] t3_indexes = {Indexes.unique("u3_key", new String[][] {{t3_name}})};
+    Column[] columns3 = new Column[] {t3_col};
+    NameIdentifier tableIdentifier3 =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, t3_name);
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          tableCatalog.createTable(
+              tableIdentifier3,
+              columns3,
+              table_comment,
+              properties,
+              Transforms.EMPTY_TRANSFORM,
+              Distributions.NONE,
+              new SortOrder[0],
+              t3_indexes);
+        });
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          catalog.asTableCatalog().dropTable(tableIdentifier3);
+        });
+
+    String invalidInput = StringUtils.repeat("a", 64);
+    Column t4_col = Column.of(invalidInput, Types.LongType.get(), "id", false, false, null);
+    Index[] t4_indexes = {Indexes.unique("u4_key", new String[][] {{invalidInput}})};
+    Column[] columns4 = new Column[] {t4_col};
+    NameIdentifier tableIdentifier4 =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, invalidInput);
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          tableCatalog.createTable(
+              tableIdentifier4,
+              columns4,
+              table_comment,
+              properties,
+              Transforms.EMPTY_TRANSFORM,
+              Distributions.NONE,
+              new SortOrder[0],
+              t4_indexes);
+        });
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          catalog.asTableCatalog().dropTable(tableIdentifier4);
+        });
+
+    String invalidInput2 = RandomNameUtils.genRandomName("$test_db");
+    Column t5_col = Column.of(invalidInput2, Types.LongType.get(), "id", false, false, null);
+    Index[] t5_indexes = {Indexes.unique("u5_key", new String[][] {{invalidInput2}})};
+    Column[] columns5 = new Column[] {t5_col};
+    NameIdentifier tableIdentifier5 =
+        NameIdentifier.of(metalakeName, catalogName, schemaName, invalidInput2);
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          tableCatalog.createTable(
+              tableIdentifier5,
+              columns5,
+              table_comment,
+              properties,
+              Transforms.EMPTY_TRANSFORM,
+              Distributions.NONE,
+              new SortOrder[0],
+              t5_indexes);
+        });
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          catalog.asTableCatalog().dropTable(tableIdentifier5);
+        });
+  }
+
+  @Test
   void testPGTableNameCaseSensitive() {
     Column col1 = Column.of("col_1", Types.LongType.get(), "id", false, false, null);
     Column col2 = Column.of("col_2", Types.IntegerType.get(), "yes", false, false, null);

--- a/core/src/main/java/com/datastrato/gravitino/catalog/SchemaNormalizeDispatcher.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/SchemaNormalizeDispatcher.java
@@ -65,10 +65,7 @@ public class SchemaNormalizeDispatcher implements SchemaDispatcher {
 
   @Override
   public boolean dropSchema(NameIdentifier ident, boolean cascade) throws NonEmptySchemaException {
-    // The constraints of the name spec may be more strict than underlying catalog,
-    // and for compatibility reasons, we only apply case-sensitive capabilities here.
-    return dispatcher.dropSchema(
-        applyCaseSensitive(ident, Capability.Scope.SCHEMA, dispatcher), cascade);
+    return dispatcher.dropSchema(normalizeNameIdentifier(ident), cascade);
   }
 
   private NameIdentifier normalizeNameIdentifier(NameIdentifier ident) {

--- a/core/src/main/java/com/datastrato/gravitino/catalog/TableNormalizeDispatcher.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/TableNormalizeDispatcher.java
@@ -82,9 +82,7 @@ public class TableNormalizeDispatcher implements TableDispatcher {
 
   @Override
   public boolean dropTable(NameIdentifier ident) {
-    // The constraints of the name spec may be more strict than underlying catalog,
-    // and for compatibility reasons, we only apply case-sensitive capabilities here.
-    return dispatcher.dropTable(applyCaseSensitive(ident, Capability.Scope.TABLE, dispatcher));
+    return dispatcher.dropTable(normalizeNameIdentifier(ident));
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?

Improve security when creating and dropping schemas and tables.

This PR adds the following checks for identifier names using the capability framework
- Regex check
    - As a best practice, it's generally advised to avoid including spaces in database names. In this PR, database names that include space will be considered illegal.
- String length check, since SQL injection usually requires using longer string
    - Mysql: at most 64 characters
    - Postgresql: at most 63 characters

We refer to specifications of the earliest version of DB that gravitino currently supports:
- Postgresql identifier rules: https://www.postgresql.org/docs/12/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
- Mysql identifier naming: https://dev.mysql.com/doc/refman/5.7/en/identifiers.html
- Mysql identifier length limit: https://dev.mysql.com/doc/refman/5.7/en/identifier-length.html
### Why are the changes needed?

Fix: #2179 

### Does this PR introduce _any_ user-facing change?
Add name identifier checks before attempting to create or drop schemas and tables.

### How was this patch tested?
Add IT tests.
