### PR TITLE
[#2323] docs: document `UnparsedType` data type which handles an unresolvable type from the catalog

### DIFF
--- a/docs/apache-hive-catalog.md
+++ b/docs/apache-hive-catalog.md
@@ -116,6 +116,10 @@ The following table lists the data types mapped from the Hive catalog to Graviti
 | `struct`                    | `struct`            | 0.2.0         |
 | `uniontype`                 | `uniontype`         | 0.2.0         |
 
+:::info
+Since 0.5.0, the data types other than listed above are mapped to Gravitino **[Unparsed Type](./manage-metadata-using-gravitino.md#unparsed-type)** that represents an unresolvable data type from the Hive catalog.
+:::
+
 ### Table properties
 
 Table properties supply or set metadata for the underlying Hive tables.

--- a/docs/jdbc-mysql-catalog.md
+++ b/docs/jdbc-mysql-catalog.md
@@ -103,6 +103,7 @@ Please refer to [Manage Metadata Using Gravitino](./manage-metadata-using-gravit
 
 :::info
 MySQL doesn't support Gravitino `Boolean` `Fixed` `Struct` `List` `Map` `Timestamp_tz` `IntervalDay` `IntervalYear` `Union` `UUID` type.
+Meanwhile, the data types other than listed above are mapped to Gravitino **[Unparsed Type](./manage-metadata-using-gravitino.md#unparsed-type)** that represents an unresolvable data type since 0.5.0.
 :::
 
 #### Table column auto-increment

--- a/docs/jdbc-postgresql-catalog.md
+++ b/docs/jdbc-postgresql-catalog.md
@@ -108,6 +108,7 @@ Please refer to [Manage Metadata Using Gravitino](./manage-metadata-using-gravit
 
 :::info
 PostgreSQL doesn't support Gravitino `Fixed` `Struct` `List` `Map` `IntervalDay` `IntervalYear` `Union` `UUID` type.
+Meanwhile, the data types other than listed above are mapped to Gravitino **[Unparsed Type](./manage-metadata-using-gravitino.md#unparsed-type)** that represents an unresolvable data type since 0.5.0.
 :::
 
 #### Table column auto-increment

--- a/docs/lakehouse-iceberg-catalog.md
+++ b/docs/lakehouse-iceberg-catalog.md
@@ -215,6 +215,7 @@ Apache Iceberg doesn't support Gravitino `EvenDistribution` type.
 
 :::info
 Apache Iceberg doesn't support Gravitino `Varchar` `Fixedchar` `Byte` `Short` `Union` type.
+Meanwhile, the data types other than listed above are mapped to Gravitino **[Unparsed Type](./manage-metadata-using-gravitino.md#unparsed-type)** that represents an unresolvable data type since 0.5.0.
 :::
 
 ### Table properties

--- a/docs/manage-metadata-using-gravitino.md
+++ b/docs/manage-metadata-using-gravitino.md
@@ -609,8 +609,8 @@ You can create a table by sending a `POST` request to the `/api/metalakes/{metal
 ```shell
 curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
 -H "Content-Type: application/json" -d '{
-  "name": "exmaple_table",
-  "comment": "This is an exmaple table",
+  "name": "example_table",
+  "comment": "This is an example table",
   "columns": [
     {
       "name": "id",
@@ -756,7 +756,7 @@ Map<String, String> tablePropertiesMap = ImmutableMap.<String, String>builder()
         .build();
 
 tableCatalog.createTable(
-  NameIdentifier.of("metalake", "catalog", "schema", "exmaple_table"),
+  NameIdentifier.of("metalake", "catalog", "schema", "example_table"),
   new Column[] {
     Column.of("id", Types.IntegerType.get(), "id column comment", false, true, Literals.integerLiteral(-1)),
     Column.of("name", Types.VarCharType.of(500), "name column comment", true, false, Literals.NULL),
@@ -768,7 +768,7 @@ tableCatalog.createTable(
       ), "info column comment", true, false, null),
     Column.of("dt", Types.DateType.get(), "dt column comment", true, false, null)
   },
-  "This is an exmaple table",
+  "This is an example table",
   tablePropertiesMap,
   new Transform[] {Transforms.identity("id")},
   Distributions.of(Strategy.HASH, 32, NamedReference.field("id")),
@@ -822,6 +822,32 @@ The following types that Gravitino supports:
 | Union                     | `Types.UnionType.of([type1, type2, ...])`                                | `{"type": "union", "types": [type JSON, ...]}`                                                                                       | Union type, indicates a union of types                                                           |
 
 The related java doc is [here](pathname:///docs/0.4.0/api/java/com/datastrato/gravitino/rel/types/Type.html).
+
+##### Unparsed type
+
+Unparsed type is a special type of column type, currently serves exclusively for presenting the data type of a column when it's unsolvable.
+The following shows the data structure of an unparsed type in JSON and Java, enabling easy retrieval of its value.
+
+<Tabs>
+  <TabItem value="Json" label="Json">
+
+```json
+{
+  "type": "unparsed",
+  "unparsedType": "user-defined"
+}
+```
+
+  </TabItem>
+  <TabItem value="java" label="Java">
+
+```java
+// The result of the following type is a string "user-defined"
+String unparsedValue = ((UnparsedType) type).unparsedType();
+```
+
+  </TabItem>
+</Tabs>
 
 #### Table column default value
 
@@ -906,7 +932,8 @@ tableCatalog.loadTable(NameIdentifier.of("metalake", "hive_catalog", "schema", "
 </Tabs>
 
 :::note
-When Gravitino loads a table from a catalog that supports default value, if Gravitino is unable to parse the default value, it will use an **[Unparsed Expression](./expression.md#unparsed-expression)** to preserve the original default value, ensuring that the table can be loaded successfully.
+- When Gravitino loads a table from a catalog with various data types, if Gravitino is unable to parse the data type, it will use an **[Unparsed Type](#unparsed-type)** to preserve the original data type, ensuring that the table can be loaded successfully.
+- When Gravitino loads a table from a catalog that supports default value, if Gravitino is unable to parse the default value, it will use an **[Unparsed Expression](./expression.md#unparsed-expression)** to preserve the original default value, ensuring that the table can be loaded successfully.
 :::
 
 ### Alter a table

--- a/docs/open-api/datatype.yaml
+++ b/docs/open-api/datatype.yaml
@@ -14,6 +14,7 @@ components:
         - $ref: "#/components/schemas/ListType"
         - $ref: "#/components/schemas/MapType"
         - $ref: "#/components/schemas/UnionType"
+        - $ref: "#/components/schemas/UnparsedType"
 
     PrimitiveType:
       type: string
@@ -163,3 +164,23 @@ components:
           type: string
           description: The comment of the struct field
           nullable: true
+
+    UnparsedType:
+      type: object
+      required:
+        - type
+        - unparsedType
+      properties:
+        type:
+          type: string
+          enum:
+            - "unparsed"
+        unparsedType:
+          type: string
+          description: The unparsed type
+      example: {
+        "type": "unparsed",
+        "unparsedType": [
+          "user-defined"
+        ]
+      }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Document `UnparsedType` data type which handles an unresolvable type from the catalog.

### Why are the changes needed?

`UnparsedType` data type that handles an unresolvable type from the catalog is supported in #2140.

Fix: #2323

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.