### PR TITLE
#1940 : [Improvement](common) MapUtils.java is missing a private constructor

### DIFF
--- a/common/src/main/java/com/datastrato/gravitino/utils/MapUtils.java
+++ b/common/src/main/java/com/datastrato/gravitino/utils/MapUtils.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 /** Utility class for working with maps. */
 public class MapUtils {
+  private MapUtils() {}
 
   /**
    * Returns a map with all keys that start with the given prefix.


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
A private constructor has been added to the MapUtils.java file, which is located at 'common\src\main\java\com\datastrato\gravitino\utils'.

### Why are the changes needed?
In order to follow efficient programming, these changes have been introduced.

Fix: # ([1940](https://github.com/datastrato/gravitino/issues/1940))

### Does this PR introduce _any_ user-facing change?
No.

(Please list the user-facing changes introduced by your change, including
  1. Change in user-facing APIs.
  2. Addition or removal of property keys.)

### How was this patch tested?
Now, for some reason, I am not able to run the `./gradlew :common:spotlessApply` command. I mean it opens a dialog box like this: 

![image](https://github.com/datastrato/gravitino/assets/31406633/972fa4bf-5aed-4b4c-9144-4e8a69f44a2d)

I am not sure what changes are required this time.
When I try executing the command like `bash +x gradlew :common:spotlessApply`, I am getting the following errors:

![image](https://github.com/datastrato/gravitino/assets/31406633/828e0244-1ba9-402d-857b-eaacbdf3523a)

Sincere apologies for all the trouble that's being caused till now.
I don't want to cause any trouble but somehow I am ending up doing that.
If at all there are any changes required then do let me know.
Sincere apologies for any troubles caused.

Thanks and Regards,
Mohit Kambli
