### PR TITLE
[#1918] improvement(catalog): Add annotation `@EqualsAndHashCode` of `IcebergColumn` and `JdbcColumn`

### DIFF
--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcColumn.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcColumn.java
@@ -5,8 +5,10 @@
 package com.datastrato.gravitino.catalog.jdbc;
 
 import com.datastrato.gravitino.catalog.rel.BaseColumn;
+import lombok.EqualsAndHashCode;
 
 /** Represents a column in the Jdbc column. */
+@EqualsAndHashCode(callSuper = true)
 public class JdbcColumn extends BaseColumn {
 
   private JdbcColumn() {}

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergColumn.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergColumn.java
@@ -5,8 +5,10 @@
 package com.datastrato.gravitino.catalog.lakehouse.iceberg;
 
 import com.datastrato.gravitino.catalog.rel.BaseColumn;
+import lombok.EqualsAndHashCode;
 
 /** Represents a column in the Iceberg column. */
+@EqualsAndHashCode(callSuper = true)
 public class IcebergColumn extends BaseColumn {
 
   private int id;


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add annotation `@EqualsAndHashCode` of `IcebergColumn` and `JdbcColumn`.

### Why are the changes needed?

As `HiveColumn` has annotation `@EqualsAndHashCode` to support `equals` and `hashCode` method at present, `IcebergColumn` and `JdbcColumn` shoud be added the annotation `@EqualsAndHashCode`.

Fix: #1918

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.