### PR TITLE
[#1918] improvement(catalog): Add annotation `@EqualsAndHashCode` of `IcebergColumn` and `JdbcColumn`

### DIFF
--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcColumn.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcColumn.java
@@ -5,8 +5,10 @@
 package com.datastrato.gravitino.catalog.jdbc;
 
 import com.datastrato.gravitino.catalog.rel.BaseColumn;
+import lombok.EqualsAndHashCode;
 
 /** Represents a column in the Jdbc column. */
+@EqualsAndHashCode(callSuper = true)
 public class JdbcColumn extends BaseColumn {
 
   private JdbcColumn() {}

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergColumn.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergColumn.java
@@ -5,8 +5,10 @@
 package com.datastrato.gravitino.catalog.lakehouse.iceberg;
 
 import com.datastrato.gravitino.catalog.rel.BaseColumn;
+import lombok.EqualsAndHashCode;
 
 /** Represents a column in the Iceberg column. */
+@EqualsAndHashCode(callSuper = true)
 public class IcebergColumn extends BaseColumn {
 
   private int id;

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergColumn.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergColumn.java
@@ -11,24 +11,10 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = true)
 public class IcebergColumn extends BaseColumn {
 
-  private int id;
-
   private IcebergColumn() {}
-
-  public int getId() {
-    return id;
-  }
 
   /** A builder class for constructing IcebergColumn instances. */
   public static class Builder extends BaseColumnBuilder<Builder, IcebergColumn> {
-
-    /** The ID of this field. */
-    private int id;
-
-    public Builder withId(int id) {
-      this.id = id;
-      return this;
-    }
 
     /**
      * Internal method to build a IcebergColumn instance using the provided values.
@@ -38,7 +24,6 @@ public class IcebergColumn extends BaseColumn {
     @Override
     protected IcebergColumn internalBuild() {
       IcebergColumn icebergColumn = new IcebergColumn();
-      icebergColumn.id = id;
       icebergColumn.name = name;
       icebergColumn.comment = comment;
       icebergColumn.dataType = dataType;

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/ConvertUtil.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/ConvertUtil.java
@@ -58,7 +58,6 @@ public class ConvertUtil {
    */
   public static IcebergColumn fromNestedField(Types.NestedField nestedField) {
     return new IcebergColumn.Builder()
-        .withId(nestedField.fieldId())
         .withName(nestedField.name())
         .withNullable(nestedField.isOptional())
         .withComment(nestedField.doc())

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergTable.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergTable.java
@@ -463,16 +463,19 @@ public class TestIcebergTable {
     Column[] expected =
         new Column[] {
           new IcebergColumn.Builder()
+              .withId(2)
               .withName("col_2_new")
               .withType(Types.DateType.get())
               .withComment(ICEBERG_COMMENT)
               .build(),
           new IcebergColumn.Builder()
+              .withId(1)
               .withName("col_1")
               .withType(Types.IntegerType.get())
               .withComment(ICEBERG_COMMENT + "_new")
               .build(),
           new IcebergColumn.Builder()
+              .withId(3)
               .withName("col_3")
               .withType(Types.StringType.get())
               .withComment(null)

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergTable.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergTable.java
@@ -463,19 +463,16 @@ public class TestIcebergTable {
     Column[] expected =
         new Column[] {
           new IcebergColumn.Builder()
-              .withId(2)
               .withName("col_2_new")
               .withType(Types.DateType.get())
               .withComment(ICEBERG_COMMENT)
               .build(),
           new IcebergColumn.Builder()
-              .withId(1)
               .withName("col_1")
               .withType(Types.IntegerType.get())
               .withComment(ICEBERG_COMMENT + "_new")
               .build(),
           new IcebergColumn.Builder()
-              .withId(3)
               .withName("col_3")
               .withType(Types.StringType.get())
               .withComment(null)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add annotation `@EqualsAndHashCode` of `IcebergColumn` and `JdbcColumn`.

### Why are the changes needed?

As `HiveColumn` has annotation `@EqualsAndHashCode` to support `equals` and `hashCode` method at present, `IcebergColumn` and `JdbcColumn` shoud be added the annotation `@EqualsAndHashCode`.

Fix: #1918

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.