### PR TITLE
Improvement(fileset): check storage location must be a directory

### DIFF
--- a/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogOperations.java
@@ -206,6 +206,11 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
 
         LOG.info("Created fileset {} location {}", ident, filesetPath);
       } else {
+        if (!fs.isDirectory(filesetPath)) {
+          String errorMsg =
+              "The storage location (%s) of fileset %s should be a directory not a file.";
+          throw new IllegalArgumentException(String.format(errorMsg, filesetPath, ident));
+        }
         LOG.info("Fileset {} manages the existing location {}", ident, filesetPath);
       }
 

--- a/catalogs/catalog-hadoop/src/test/java/com/datastrato/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/test/java/com/datastrato/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
@@ -590,6 +590,31 @@ public class TestHadoopCatalogOperations {
     }
   }
 
+  @Test
+  public void testStorageLocationMustBeDirectory() throws IOException {
+    String schemaName = "schema27";
+    String comment = "comment27";
+    String schemaPath = TEST_ROOT_PATH + "/" + schemaName;
+    createSchema(schemaName, comment, null, schemaPath);
+
+    Path path = new Path(schemaPath);
+    FileSystem fs = path.getFileSystem(new Configuration());
+    boolean res = fs.mkdirs(path);
+    Assertions.assertTrue(res);
+
+    String location = schemaPath + "/fileset27.txt";
+    Path file = new Path(location);
+    boolean created = fs.createNewFile(file);
+    Assertions.assertTrue(created);
+    Assertions.assertTrue(fs.exists(file));
+
+    String name = "fileset27";
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> createFileset(name, schemaName, comment, Fileset.Type.MANAGED, null, location),
+        "The storage location of fileset should be a directory");
+  }
+
   private static Stream<Arguments> locationArguments() {
     return Stream.of(
         // Honor the catalog location


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

- the storage location of fileset should not be a file.

### Why are the changes needed?

- throw exception if the storage location is a file.

### Does this PR introduce _any_ user-facing change?

- no

### How was this patch tested?

- UT and IT
