### PR TITLE
[#2357] improvement(trino): Fix varchar type mapping between Gravitino JDBC catalog and Trino

### DIFF
--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/jdbc/mysql/MySQLDataTypeTransformer.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/jdbc/mysql/MySQLDataTypeTransformer.java
@@ -11,27 +11,62 @@ import com.datastrato.gravitino.rel.types.Types;
 import com.datastrato.gravitino.trino.connector.GravitinoErrorCode;
 import com.datastrato.gravitino.trino.connector.util.GeneralDataTypeTransformer;
 import io.trino.spi.TrinoException;
+import io.trino.spi.type.CharType;
 
 /** Type transformer between MySQL and Trino */
 public class MySQLDataTypeTransformer extends GeneralDataTypeTransformer {
   private static final int MYSQL_CHAR_LENGTH_LIMIT = 255;
+  // 65535 / 4 = 16383.
+  private static final int MYSQL_VARCHAR_LENGTH_LIMIT = 16383;
+
+  @Override
+  public io.trino.spi.type.Type getTrinoType(Type type) {
+    if (type.name() == Name.STRING) {
+      return io.trino.spi.type.VarcharType.createUnboundedVarcharType();
+    }
+
+    return super.getTrinoType(type);
+  }
 
   @Override
   public Type getGravitinoType(io.trino.spi.type.Type type) {
-    Type gravitinoType = super.getGravitinoType(type);
-    if (gravitinoType.name() == Name.VARCHAR) {
-      if (((Types.VarCharType) gravitinoType).length() > MYSQL_CHAR_LENGTH_LIMIT) {
-        return Types.StringType.get();
-      }
-    }
-
-    if (gravitinoType.name() == Name.FIXEDCHAR) {
-      if (((Types.FixedCharType) gravitinoType).length() > MYSQL_CHAR_LENGTH_LIMIT) {
+    Class<? extends io.trino.spi.type.Type> typeClass = type.getClass();
+    if (typeClass == io.trino.spi.type.CharType.class) {
+      CharType charType = (CharType) type;
+      if (charType.getLength() > MYSQL_CHAR_LENGTH_LIMIT) {
         throw new TrinoException(
             GravitinoErrorCode.GRAVITINO_ILLEGAL_ARGUMENT,
-            "MySQL does not support the datatype CHAR with the length greater than 255");
+            "MySQL does not support the datatype CHAR with the length greater than "
+                + MYSQL_CHAR_LENGTH_LIMIT);
       }
+
+      // We do not support the CHAR without a length.
+      if (charType.getLength() == 0) {
+        throw new TrinoException(
+            GravitinoErrorCode.GRAVITINO_ILLEGAL_ARGUMENT,
+            "MySQL does not support the datatype CHAR with the length 0");
+      }
+
+      return Types.FixedCharType.of(charType.getLength());
+    } else if (typeClass == io.trino.spi.type.VarcharType.class) {
+      io.trino.spi.type.VarcharType varcharType = (io.trino.spi.type.VarcharType) type;
+
+      // If the length is not specified, it is a VARCHAR without length, we convert it to a string
+      // type.
+      if (varcharType.getLength().isEmpty()) {
+        return Types.StringType.get();
+      }
+
+      int length = varcharType.getLength().get();
+      if (length > MYSQL_VARCHAR_LENGTH_LIMIT) {
+        throw new TrinoException(
+            GravitinoErrorCode.GRAVITINO_ILLEGAL_ARGUMENT,
+            "MySQL does not support the datatype VARCHAR with the length greater than "
+                + MYSQL_VARCHAR_LENGTH_LIMIT);
+      }
+      return Types.VarCharType.of(length);
     }
-    return gravitinoType;
+
+    return super.getGravitinoType(type);
   }
 }

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/jdbc/postgresql/PostgreSQLDataTypeTransformer.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/jdbc/postgresql/PostgreSQLDataTypeTransformer.java
@@ -8,17 +8,54 @@ package com.datastrato.gravitino.trino.connector.catalog.jdbc.postgresql;
 import com.datastrato.gravitino.rel.types.Type;
 import com.datastrato.gravitino.rel.types.Type.Name;
 import com.datastrato.gravitino.rel.types.Types;
+import com.datastrato.gravitino.trino.connector.GravitinoErrorCode;
 import com.datastrato.gravitino.trino.connector.util.GeneralDataTypeTransformer;
+import io.trino.spi.TrinoException;
+import io.trino.spi.type.CharType;
 
 /** Type transformer between PostgreSQL and Trino */
 public class PostgreSQLDataTypeTransformer extends GeneralDataTypeTransformer {
+  private static final int POSTGRESQL_CHAR_LENGTH_LIMIT = 10485760;
+  private static final int POSTGRESQL_VARCHAR_LENGTH_LIMIT = 10485760;
+
+  @Override
+  public io.trino.spi.type.Type getTrinoType(Type type) {
+    if (type.name() == Name.STRING) {
+      return io.trino.spi.type.VarcharType.createUnboundedVarcharType();
+    }
+
+    return super.getTrinoType(type);
+  }
 
   @Override
   public Type getGravitinoType(io.trino.spi.type.Type type) {
-    Type gravitinoType = super.getGravitinoType(type);
-    if (gravitinoType.name() == Name.VARCHAR || gravitinoType.name() == Name.FIXEDCHAR) {
-      return Types.StringType.get();
+    Class<? extends io.trino.spi.type.Type> typeClass = type.getClass();
+    if (typeClass == io.trino.spi.type.CharType.class) {
+      CharType charType = (CharType) type;
+
+      // Do not need to check the scenario that the length of the CHAR type is greater than
+      // POSTGRESQL_CHAR_LENGTH_LIMIT ,
+      // because the length of the CHAR type in Trino is no greater than 65536
+      // We do not support the CHAR without a length.
+      if (charType.getLength() == 0) {
+        throw new TrinoException(
+            GravitinoErrorCode.GRAVITINO_ILLEGAL_ARGUMENT,
+            "PostgreSQL does not support the datatype CHAR with the length 0");
+      }
+
+      return Types.FixedCharType.of(charType.getLength());
+    } else if (typeClass == io.trino.spi.type.VarcharType.class) {
+      io.trino.spi.type.VarcharType varcharType = (io.trino.spi.type.VarcharType) type;
+
+      // If the length is not specified, it is a VARCHAR without length, we convert it to a string
+      // type.
+      if (varcharType.getLength().isEmpty()) {
+        return Types.StringType.get();
+      }
+
+      return Types.VarCharType.of(varcharType.getLength().get());
     }
-    return gravitinoType;
+
+    return super.getGravitinoType(type);
   }
 }

--- a/trino-connector/src/test/java/com/datastrato/gravitino/trino/connector/catalog/jdbc/mysql/TestMySQLDataTypeTransformer.java
+++ b/trino-connector/src/test/java/com/datastrato/gravitino/trino/connector/catalog/jdbc/mysql/TestMySQLDataTypeTransformer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+
+package com.datastrato.gravitino.trino.connector.catalog.jdbc.mysql;
+
+import com.datastrato.gravitino.rel.types.Type;
+import com.datastrato.gravitino.rel.types.Types;
+import com.datastrato.gravitino.trino.connector.util.GeneralDataTypeTransformer;
+import io.trino.spi.TrinoException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestMySQLDataTypeTransformer {
+
+  @Test
+  public void testTrinoTypeToGravitinoType() {
+    GeneralDataTypeTransformer generalDataTypeTransformer = new MySQLDataTypeTransformer();
+    io.trino.spi.type.Type charTypeWithLengthOne = io.trino.spi.type.CharType.createCharType(1);
+    Assert.assertEquals(
+        generalDataTypeTransformer.getGravitinoType(charTypeWithLengthOne),
+        Types.FixedCharType.of(1));
+
+    io.trino.spi.type.Type charTypeWithLength = io.trino.spi.type.CharType.createCharType(256);
+    Exception e =
+        Assert.expectThrows(
+            TrinoException.class,
+            () -> generalDataTypeTransformer.getGravitinoType(charTypeWithLength));
+    Assert.assertTrue(
+        e.getMessage()
+            .contains("MySQL does not support the datatype CHAR with the length greater than 255"));
+
+    io.trino.spi.type.Type varcharType = io.trino.spi.type.VarcharType.createVarcharType(1);
+    Assert.assertEquals(
+        generalDataTypeTransformer.getGravitinoType(varcharType), Types.VarCharType.of(1));
+
+    io.trino.spi.type.Type varcharTypeWithLength =
+        io.trino.spi.type.VarcharType.createVarcharType(16384);
+    e =
+        Assert.expectThrows(
+            TrinoException.class,
+            () -> generalDataTypeTransformer.getGravitinoType(varcharTypeWithLength));
+    Assert.assertTrue(
+        e.getMessage()
+            .contains(
+                "MySQL does not support the datatype VARCHAR with the length greater than 16383"));
+
+    io.trino.spi.type.Type varcharTypeWithLength2 =
+        io.trino.spi.type.VarcharType.createUnboundedVarcharType();
+    Assert.assertEquals(
+        generalDataTypeTransformer.getGravitinoType(varcharTypeWithLength2),
+        Types.StringType.get());
+  }
+
+  @Test
+  public void testGravitinoCharToTrinoType() {
+    GeneralDataTypeTransformer generalDataTypeTransformer = new MySQLDataTypeTransformer();
+
+    Type stringType = Types.StringType.get();
+    Assert.assertEquals(
+        generalDataTypeTransformer.getTrinoType(stringType),
+        io.trino.spi.type.VarcharType.createUnboundedVarcharType());
+  }
+}

--- a/trino-connector/src/test/java/com/datastrato/gravitino/trino/connector/catalog/jdbc/postgresql/TestPostgreSQLDataTypeTransformer.java
+++ b/trino-connector/src/test/java/com/datastrato/gravitino/trino/connector/catalog/jdbc/postgresql/TestPostgreSQLDataTypeTransformer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+
+package com.datastrato.gravitino.trino.connector.catalog.jdbc.postgresql;
+
+import com.datastrato.gravitino.rel.types.Type;
+import com.datastrato.gravitino.rel.types.Types;
+import com.datastrato.gravitino.trino.connector.util.GeneralDataTypeTransformer;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestPostgreSQLDataTypeTransformer {
+
+  @Test
+  public void testTrinoTypeToGravitinoType() {
+    GeneralDataTypeTransformer generalDataTypeTransformer = new PostgreSQLDataTypeTransformer();
+    io.trino.spi.type.Type charTypeWithLengthOne = io.trino.spi.type.CharType.createCharType(1);
+    Assert.assertEquals(
+        generalDataTypeTransformer.getGravitinoType(charTypeWithLengthOne),
+        Types.FixedCharType.of(1));
+
+    io.trino.spi.type.Type charTypeWithLength = io.trino.spi.type.CharType.createCharType(65536);
+    Assert.assertEquals(
+        generalDataTypeTransformer.getGravitinoType(charTypeWithLength),
+        Types.FixedCharType.of(65536));
+
+    io.trino.spi.type.Type varcharType = io.trino.spi.type.VarcharType.createVarcharType(1);
+    Assert.assertEquals(
+        generalDataTypeTransformer.getGravitinoType(varcharType), Types.VarCharType.of(1));
+
+    io.trino.spi.type.Type varcharTypeWithLength =
+        io.trino.spi.type.VarcharType.createVarcharType(65536);
+
+    Assert.assertEquals(
+        generalDataTypeTransformer.getGravitinoType(varcharTypeWithLength),
+        Types.VarCharType.of(65536));
+
+    io.trino.spi.type.Type varcharTypeWithLength2 =
+        io.trino.spi.type.VarcharType.createUnboundedVarcharType();
+    Assert.assertEquals(
+        generalDataTypeTransformer.getGravitinoType(varcharTypeWithLength2),
+        Types.StringType.get());
+  }
+
+  @Test
+  public void testGravitinoCharToTrinoType() {
+    GeneralDataTypeTransformer generalDataTypeTransformer = new PostgreSQLDataTypeTransformer();
+    Type stringType = Types.StringType.get();
+    Assert.assertEquals(
+        generalDataTypeTransformer.getTrinoType(stringType),
+        io.trino.spi.type.VarcharType.createUnboundedVarcharType());
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Modify the type mapping for VARCHAR and CHAR to match Gravitino and Trino.

### Why are the changes needed?

please see issue #2356

Fix: #2035, #2357

### Does this PR introduce _any_ user-facing change?

N/A. 

### How was this patch tested?

New UTs.
