### PR TITLE
[#2365]Improvement(IT): increase retry interval of container status check

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/HiveContainer.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/container/HiveContainer.java
@@ -66,6 +66,7 @@ public class HiveContainer extends BaseContainer {
   protected boolean checkContainerStatus(int retryLimit) {
     int nRetry = 0;
     boolean isHiveContainerReady = false;
+    int sleepTimeMillis = 10_000;
     while (nRetry++ < retryLimit) {
       try {
         String[] commandAndArgs = new String[] {"bash", "/tmp/check-status.sh"};
@@ -83,7 +84,12 @@ public class HiveContainer extends BaseContainer {
           isHiveContainerReady = true;
           break;
         }
-        Thread.sleep(5000);
+        LOG.info(
+            "Hive container is not ready, recheck({}/{}) after {}ms",
+            nRetry,
+            retryLimit,
+            sleepTimeMillis);
+        Thread.sleep(sleepTimeMillis);
       } catch (RuntimeException e) {
         LOG.error(e.getMessage(), e);
       } catch (InterruptedException e) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

increase retry interval of container status check from 5s to 10s

### Why are the changes needed?

 the retry interval is too short to wait HDFS initialization completed

Fix: #2365 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

existing tests
