### PR TITLE
[#2362] improvement: enable `UseCorrectAssertInTests` error-prone check

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -294,6 +294,7 @@ subprojects {
         "UnnecessaryTypeArgument",
         "UnusedAnonymousClass",
         "UnusedCollectionModifiedInPlace",
+        "UseCorrectAssertInTests",
         "VarTypeName",
         "XorPower",
         "EqualsGetClass",

--- a/core/src/test/java/com/datastrato/gravitino/utils/TestByteUtils.java
+++ b/core/src/test/java/com/datastrato/gravitino/utils/TestByteUtils.java
@@ -16,7 +16,7 @@ public class TestByteUtils {
     byte[] b = ByteUtils.intToByte(v);
     Assertions.assertArrayEquals(new byte[] {0x00, 0x00, 0x01, 0x02}, b);
     int v2 = ByteUtils.byteToInt(b);
-    assert v == v2;
+    Assertions.assertEquals(v, v2);
   }
 
   @Test
@@ -25,7 +25,7 @@ public class TestByteUtils {
     byte[] b = ByteUtils.longToByte(v);
     Assertions.assertArrayEquals(new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x03}, b);
     long v2 = ByteUtils.byteToLong(b);
-    assert v == v2;
+    Assertions.assertEquals(v, v2);
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Enable `UseCorrectAssertInTests` error-prone check to avoid using `assert` in tests.

### Why are the changes needed?

Error prone has `UseCorrectAssertInTests` bug pattern that Java assert is used in testing code. For testing purposes, prefer using Truth-based assertions in [UseCorrectAssertInTests](https://errorprone.info/bugpattern/UseCorrectAssertInTests). Therefore enable `UseCorrectAssertInTests` check to avoid using `assert` in tests.

Fix: #2362

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`./gradlew build`