### PR TITLE
[#2376] fix(trino-connector) Gravitino-trino-connector is incompatible with Trino-435

### DIFF
--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -282,8 +282,10 @@ tasks.test {
         }
 
         if (invalidGravitinoJars!!.isNotEmpty()) {
-          println("Found invalid gravitino jars in build/libs: ${invalidGravitinoJars.joinToString(", ") { it.name }}")
-          throw GradleException("Please clean the project and rebuild the project.")
+          val message = "Found mismatched versions of gravitino jars in trino-connector/build/libs:\n" +
+            "${invalidGravitinoJars.joinToString(", ") { it.name }}\n" +
+            "The current version of the project is $version. Please clean the project and rebuild it."
+          throw GradleException(message)
         }
       }
 

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -267,27 +267,26 @@ tasks.test {
   if (skipITs) {
     exclude("**/integration/test/**")
   } else {
-    // Get current project version
-    val version = project.version.toString()
-    println("Current project version: $version")
-    // Check whether this module has already built
-    val buildDir = project.buildDir
-    if (!buildDir.exists()) {
-      dependsOn(":trino-connector:jar")
-    } else {
-      // Check the version gravitino related jars in build equal to the current project version
-      val gravitinoJars = buildDir.resolve("libs").listFiles { _, name -> name.startsWith("gravitino") }?.filter {
-        val jarVersion = name.substringAfterLast("-").substringBeforeLast(".")
-        jarVersion != version
-      }
-
-      if (gravitinoJars != null && gravitinoJars.isNotEmpty()) {
-        delete(project(":trino-connector").buildDir)
-        dependsOn(":trino-connector:jar")
-      }
-    }
-
     doFirst {
+      // Get current project version
+      val version = project.version.toString()
+      println("Current project version: $version")
+
+      // Check whether this module has already built
+      val trinoConnectorBuildDir = project(":trino-connector").buildDir
+      if (trinoConnectorBuildDir.exists()) {
+        // Check the version gravitino related jars in build equal to the current project version
+        val invalidGravitinoJars = trinoConnectorBuildDir.resolve("libs").listFiles { _, name -> name.startsWith("gravitino") }?.filter {
+          val name = it.name
+          !name.endsWith(version + ".jar")
+        }
+
+        if (invalidGravitinoJars!!.isNotEmpty()) {
+          println("Found invalid gravitino jars in build/libs: ${invalidGravitinoJars.joinToString(", ") { it.name }}")
+          throw GradleException("Please clean the project and rebuild the project.")
+        }
+      }
+
       printDockerCheckInfo()
 
       copy {

--- a/trino-connector/build.gradle.kts
+++ b/trino-connector/build.gradle.kts
@@ -21,10 +21,7 @@ dependencies {
   implementation(libs.jackson.annotations)
   implementation(libs.jackson.databind)
   implementation(libs.commons.collections4)
-  implementation(libs.trino.spi) {
-    exclude("org.apache.logging.log4j")
-  }
-  implementation(libs.trino.toolkit) {
+  compileOnly(libs.trino.spi) {
     exclude("org.apache.logging.log4j")
   }
   testImplementation(libs.mockito.core)

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoConnector.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoConnector.java
@@ -9,7 +9,6 @@ import com.datastrato.gravitino.client.GravitinoMetaLake;
 import com.datastrato.gravitino.trino.connector.catalog.CatalogConnectorContext;
 import com.datastrato.gravitino.trino.connector.catalog.CatalogConnectorMetadata;
 import com.google.common.base.Preconditions;
-import io.trino.plugin.base.security.AllowAllAccessControl;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorCapabilities;
@@ -134,7 +133,7 @@ public class GravitinoConnector implements Connector {
 
   @Override
   public ConnectorAccessControl getAccessControl() {
-    return new AllowAllAccessControl();
+    return null;
   }
 
   @Override

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoConnector.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoConnector.java
@@ -133,7 +133,8 @@ public class GravitinoConnector implements Connector {
 
   @Override
   public ConnectorAccessControl getAccessControl() {
-    return null;
+    Connector internalConnector = catalogConnectorContext.getInternalConnector();
+    return internalConnector.getAccessControl();
   }
 
   @Override

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoMetadata.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoMetadata.java
@@ -168,7 +168,7 @@ public class GravitinoMetadata implements ConnectorMetadata {
     }
 
     GravitinoTableHandle gravitinoTableHandle = (GravitinoTableHandle) tableHandle;
-    return internalMetadata.getColumnMetadata(session, gravitinoTableHandle, columnHandle);
+    return internalMetadata.getColumnMetadata(session, gravitinoTableHandle.getInternalTableHandle(), columnHandle);
   }
 
   @Override

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoMetadata.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoMetadata.java
@@ -168,13 +168,7 @@ public class GravitinoMetadata implements ConnectorMetadata {
     }
 
     GravitinoTableHandle gravitinoTableHandle = (GravitinoTableHandle) tableHandle;
-    GravitinoTable table =
-        catalogConnectorMetadata.getTable(
-            gravitinoTableHandle.getSchemaName(), gravitinoTableHandle.getTableName());
-
-    String columnName = getColumnName(session, gravitinoTableHandle, columnHandle);
-    GravitinoColumn column = table.getColumn(columnName);
-    return metadataAdapter.getColumnMetadata(column);
+    return internalMetadata.getColumnMetadata(session, gravitinoTableHandle, columnHandle);
   }
 
   @Override

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoMetadata.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoMetadata.java
@@ -168,7 +168,8 @@ public class GravitinoMetadata implements ConnectorMetadata {
     }
 
     GravitinoTableHandle gravitinoTableHandle = (GravitinoTableHandle) tableHandle;
-    return internalMetadata.getColumnMetadata(session, gravitinoTableHandle.getInternalTableHandle(), columnHandle);
+    return internalMetadata.getColumnMetadata(
+        session, gravitinoTableHandle.getInternalTableHandle(), columnHandle);
   }
 
   @Override

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/hive/HiveConnectorAdapter.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/hive/HiveConnectorAdapter.java
@@ -41,6 +41,7 @@ public class HiveConnectorAdapter implements CatalogConnectorAdapter {
 
     Map<String, Object> properties = new HashMap<>();
     properties.put("hive.metastore.uri", catalog.getRequiredProperty("metastore.uris"));
+    properties.put("hive.security", "allow-all");
     Map<String, String> trinoProperty =
         catalogConverter.gravitinoToEngineProperties(catalog.getProperties());
 


### PR DESCRIPTION

### What changes were proposed in this pull request?

Remove the Trino runtime dependency to avoid version incompatibility.
Our Trino-connector uses Trino-426 for development. The AllowAllAccessControl dependency, trino-toolkit-426.jar, causes compatibility issues with Trino-426

### Why are the changes needed?
Fix: #2376

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

Manually testing in Trino-435
