### PR TITLE
[#2314] fix(postgresql): postgresql `public` schema should not be filtered in `listDatabases`

### DIFF
--- a/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlSchemaOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlSchemaOperations.java
@@ -34,7 +34,6 @@ public class PostgreSqlSchemaOperations extends JdbcDatabaseOperations {
             {
               add("pg_toast");
               add("pg_catalog");
-              add("public");
               add("information_schema");
             }
           });

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/TestMultipleJdbcLoad.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/TestMultipleJdbcLoad.java
@@ -122,7 +122,8 @@ public class TestMultipleJdbcLoad extends AbstractIT {
         postgreSqlCatalog
             .asSchemas()
             .listSchemas(Namespace.of(metalakeName, postgreSqlCatalogName));
-    Assertions.assertEquals(0, nameIdentifiers.length);
+    Assertions.assertEquals(1, nameIdentifiers.length);
+    Assertions.assertEquals("public", nameIdentifiers[0].name());
 
     String schemaName = GravitinoITUtils.genRandomName("it_schema");
     mysqlCatalog

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/catalog/jdbc/postgresql/CatalogPostgreSqlIT.java
@@ -566,6 +566,15 @@ public class CatalogPostgreSqlIT extends AbstractIT {
   }
 
   @Test
+  void testListSchema() {
+    NameIdentifier[] nameIdentifiers =
+        catalog.asSchemas().listSchemas(Namespace.of(metalakeName, catalogName));
+    Set<String> schemaNames =
+        Arrays.stream(nameIdentifiers).map(NameIdentifier::name).collect(Collectors.toSet());
+    Assertions.assertTrue(schemaNames.contains("public"));
+  }
+
+  @Test
   public void testBackQuoteTable() {
     Column col1 = Column.of("create", Types.LongType.get(), "id", false, false, null);
     Column col2 = Column.of("delete", Types.IntegerType.get(), "number", false, false, null);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove the `public` schema from the `SYS_PG_DATABASE_NAMES` attribute

### Why are the changes needed?

public schema is the default schema if not specifying schema names. we shouldn't filter it

Fix: #2314

### Does this PR introduce _any_ user-facing change?
N/A.

### How was this patch tested?
Existing tests can cover it.
