### PR TITLE
[#1538] fix(web): fix table action button click event

### DIFF
--- a/web/app/ui/MetalakeList.js
+++ b/web/app/ui/MetalakeList.js
@@ -187,7 +187,7 @@ const MetalakeList = () => {
           key='details'
           label='Details'
           title='Details'
-          icon={<ViewIcon />}
+          icon={<ViewIcon viewBox='0 0 24 22' />}
           onClick={handleShowDetails(row)}
           sx={{
             '& svg': {

--- a/web/app/ui/MetalakeList.js
+++ b/web/app/ui/MetalakeList.js
@@ -9,6 +9,11 @@ import Link from 'next/link'
 
 import { Box, Grid, Card, Typography, Portal, Tooltip } from '@mui/material'
 import { DataGrid, GridActionsCellItem, GridToolbar } from '@mui/x-data-grid'
+import {
+  VisibilityOutlined as ViewIcon,
+  EditOutlined as EditIcon,
+  DeleteOutlined as DeleteIcon
+} from '@mui/icons-material'
 
 import Icon from '@/components/Icon'
 
@@ -182,7 +187,7 @@ const MetalakeList = () => {
           key='details'
           label='Details'
           title='Details'
-          icon={<Icon icon='bx:show-alt' />}
+          icon={<ViewIcon />}
           onClick={handleShowDetails(row)}
           sx={{
             '& svg': {
@@ -194,7 +199,7 @@ const MetalakeList = () => {
           key='edit'
           label='Edit'
           title='Edit'
-          icon={<Icon icon='mdi:square-edit-outline' />}
+          icon={<EditIcon />}
           onClick={handleShowEditDialog(row)}
           sx={{
             '& svg': {
@@ -204,7 +209,7 @@ const MetalakeList = () => {
         />,
         <GridActionsCellItem
           key='delete'
-          icon={<Icon icon='mdi:delete-outline' />}
+          icon={<DeleteIcon />}
           label='Delete'
           title='Delete'
           onClick={handleDeleteMetalake(row.name)}

--- a/web/app/ui/metalakes/TableView.js
+++ b/web/app/ui/metalakes/TableView.js
@@ -9,6 +9,12 @@ import Link from 'next/link'
 
 import { Box, Typography, IconButton } from '@mui/material'
 import { DataGrid } from '@mui/x-data-grid'
+import {
+  VisibilityOutlined as ViewIcon,
+  EditOutlined as EditIcon,
+  DeleteOutlined as DeleteIcon
+} from '@mui/icons-material'
+
 import Icon from '@/components/Icon'
 
 import ColumnTypeChip from '@/components/ColumnTypeChip'
@@ -144,7 +150,7 @@ const TableView = props => {
             sx={{ color: theme => theme.palette.text.secondary }}
             onClick={() => handleShowDetails({ row, type: 'catalog' })}
           >
-            <Icon icon='bx:show-alt' />
+            <ViewIcon />
           </IconButton>
 
           <IconButton
@@ -153,7 +159,7 @@ const TableView = props => {
             sx={{ color: theme => theme.palette.text.secondary }}
             onClick={() => handleShowEditDialog({ row, type: 'catalog' })}
           >
-            <Icon icon='mdi:square-edit-outline' />
+            <EditIcon />
           </IconButton>
 
           <IconButton
@@ -162,7 +168,7 @@ const TableView = props => {
             sx={{ color: theme => theme.palette.error.light }}
             onClick={() => handleDelete({ name: row.name, type: 'catalog' })}
           >
-            <Icon icon='mdi:delete-outline' />
+            <DeleteIcon />
           </IconButton>
         </>
       )

--- a/web/app/ui/metalakes/TableView.js
+++ b/web/app/ui/metalakes/TableView.js
@@ -150,7 +150,7 @@ const TableView = props => {
             sx={{ color: theme => theme.palette.text.secondary }}
             onClick={() => handleShowDetails({ row, type: 'catalog' })}
           >
-            <ViewIcon />
+            <ViewIcon viewBox='0 0 24 22' />
           </IconButton>
 
           <IconButton

--- a/web/package.json
+++ b/web/package.json
@@ -20,6 +20,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@hookform/resolvers": "^3.3.2",
+    "@mui/icons-material": "^5.15.11",
     "@mui/lab": "^5.0.0-alpha.153",
     "@mui/material": "^5.14.18",
     "@mui/x-data-grid": "^6.18.2",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -17,6 +17,9 @@ dependencies:
   '@hookform/resolvers':
     specifier: ^3.3.2
     version: 3.3.4(react-hook-form@7.49.3)
+  '@mui/icons-material':
+    specifier: ^5.15.11
+    version: 5.15.11(@mui/material@5.15.3)(@types/react@18.2.47)(react@18.2.0)
   '@mui/lab':
     specifier: ^5.0.0-alpha.153
     version: 5.0.0-alpha.159(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.15.3)(@types/react@18.2.47)(react-dom@18.2.0)(react@18.2.0)
@@ -235,6 +238,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.1
+
+  /@babel/runtime@7.24.0:
+    resolution: {integrity: sha512-Chk32uHMg6TnQdvw2e9IlqPpFX/6NLuK0Ys2PqLb7/gL5uFn9mXvK715FGLlOLQrcO4qIkNHkvPGktzzXexsFw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.14.1
+    dev: false
 
   /@babel/types@7.23.6:
     resolution: {integrity: sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==}
@@ -546,6 +556,23 @@ packages:
 
   /@mui/core-downloads-tracker@5.15.3:
     resolution: {integrity: sha512-sWeihiVyxdJjpLkp8SHkTy9kt2M/o11M60G1MzwljGL2BXdM3Ktzqv5QaQHdi00y7Y1ulvtI3GOSxP2xU8mQJw==}
+    dev: false
+
+  /@mui/icons-material@5.15.11(@mui/material@5.15.3)(@types/react@18.2.47)(react@18.2.0):
+    resolution: {integrity: sha512-R5ZoQqnKpd+5Ew7mBygTFLxgYsQHPhgR3TDXSgIHYIjGzYuyPLmGLSdcPUoMdi6kxiYqHlpPj4NJxlbaFD0UHA==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@mui/material': ^5.0.0
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.0
+      '@mui/material': 5.15.3(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@types/react@18.2.47)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.2.47
+      react: 18.2.0
     dev: false
 
   /@mui/lab@5.0.0-alpha.159(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.15.3)(@types/react@18.2.47)(react-dom@18.2.0)(react@18.2.0):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix table action button click event.

After testing, there is no problem with using the MUI built-in icons inside MuiButton, but using a custom icon will cause this issue.

Icon styles have been changed due to the use of MUI built-in icons.

Before: 
<img width="134" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/a889078d-b8eb-4ad1-a489-9e44ee1c686b">
After: 
<img width="121" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/30fb59fd-255a-4451-b128-d28e5d2a2565">


<img width="1022" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/d4f67efb-ade4-4a10-9def-43da78878af1">


<img width="1019" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/cb32366b-c43b-4af4-af8e-cab40c92f428">


### Why are the changes needed?

Fix: #1538 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
