### PR TITLE
[#2156] improvement: enable JavaUtilDate error-prone check

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -259,6 +259,7 @@ subprojects {
         "InvalidJavaTimeConstant",
         "InvalidPatternSyntax",
         "IsInstanceIncompatibleType",
+        "JavaUtilDate",
         "JUnit4ClassAnnotationNonStatic",
         "JUnit4SetUpNotRun",
         "JUnit4TearDownNotRun",

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/KerberosTokenProvider.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/KerberosTokenProvider.java
@@ -113,6 +113,7 @@ public final class KerberosTokenProvider implements AuthDataProvider {
         });
   }
 
+  @SuppressWarnings("JavaUtilDate")
   private boolean isLoginTicketExpired() {
     Set<KerberosTicket> tickets =
         loginContext.getSubject().getPrivateCredentials(KerberosTicket.class);

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestOAuth2TokenProvider.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestOAuth2TokenProvider.java
@@ -31,6 +31,7 @@ import org.mockserver.integration.ClientAndServer;
 import org.mockserver.matchers.Times;
 import org.mockserver.model.HttpResponse;
 
+@SuppressWarnings("JavaUtilDate")
 public class TestOAuth2TokenProvider {
 
   private static final int PORT = 1082;

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/rest/OAuth2OperationsIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/rest/OAuth2OperationsIT.java
@@ -33,6 +33,7 @@ public class OAuth2OperationsIT extends AbstractIT {
 
   private static String token;
 
+  @SuppressWarnings("JavaUtilDate")
   @BeforeAll
   public static void startIntegrationTest() throws Exception {
     Map<String, String> configs = Maps.newHashMap();

--- a/server-common/src/test/java/com/datastrato/gravitino/server/auth/TestOAuth2TokenAuthenticator.java
+++ b/server-common/src/test/java/com/datastrato/gravitino/server/auth/TestOAuth2TokenAuthenticator.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("JavaUtilDate")
 public class TestOAuth2TokenAuthenticator {
 
   @Test


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

- close #2156 

### Why are the changes needed?


Fix: #2156 

### Does this PR introduce _any_ user-facing change?

- no

### How was this patch tested?

- `./gradlew build`
