### PR TITLE
[#2396] improvement(spark-connector): add new interface to load all catalog info from Gravitino

### DIFF
--- a/spark-connector/src/main/java/com/datastrato/gravitino/spark/catalog/GravitinoCatalog.java
+++ b/spark-connector/src/main/java/com/datastrato/gravitino/spark/catalog/GravitinoCatalog.java
@@ -105,7 +105,7 @@ public class GravitinoCatalog implements TableCatalog, SupportsNamespaces {
   @Override
   public void initialize(String name, CaseInsensitiveStringMap options) {
     this.catalogName = name;
-    this.gravitinoCatalogClient = gravitinoCatalogManager.getGravitinoCatalogInfo(name);
+    this.gravitinoCatalogClient = gravitinoCatalogManager.getCatalogInfo(name);
     String provider = gravitinoCatalogClient.provider();
     Preconditions.checkArgument(provider != null, name + " catalog provider is null");
     this.sparkCatalog = createAndInitSparkCatalog(provider, name, options);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Introduce `listCatalogInfos` to list all catalog infos under this catalog manager with specified metalake namespace. Meanwhile, rename `getGravitinoCatalogInfo` interface to `getCatalogInfo`.

### Why are the changes needed?

Gravitino provides `listCatalogs` to get all catalog names and `loadCatalog` to get one catalog info. If getting all catalog information from Gravitino like in Spark or trino connector, we must combine the two operations, it will cost more time and increase the error process if load one catalog failed. It's recommended to provide a new interface to get all catalog info.

Fix: #2396 

### Does this PR introduce _any_ user-facing change?

1. Introduce `listCatalogInfos` to list all catalog infos under this catalog manager with specified metalake namespace.
2. Rename `getGravitinoCatalogInfo` interface to `getCatalogInfo`.

### How was this patch tested?

CI