### PR TITLE
[#2424] improvement(spark-connector): make all Spark SQL keywords uppercase for consistency

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkIT.java
@@ -21,7 +21,7 @@ public class SparkIT extends SparkEnvIT {
 
   @BeforeEach
   void init() {
-    sql("use " + hiveCatalogName);
+    sql("USE " + hiveCatalogName);
   }
 
   @Test
@@ -33,7 +33,7 @@ public class SparkIT extends SparkEnvIT {
   @Test
   void testCreateAndLoadSchema() {
     String testDatabaseName = "t_create1";
-    sql("create database " + testDatabaseName);
+    sql("CREATE DATABASE " + testDatabaseName);
     Map<String, String> databaseMeta = getDatabaseMetadata(testDatabaseName);
     Assertions.assertFalse(databaseMeta.containsKey("Comment"));
     Assertions.assertTrue(databaseMeta.containsKey("Location"));
@@ -63,15 +63,15 @@ public class SparkIT extends SparkEnvIT {
     Set<String> databases = getDatabases();
     Assertions.assertFalse(databases.contains(testDatabaseName));
 
-    sql("create database " + testDatabaseName);
+    sql("CREATE DATABASE " + testDatabaseName);
     databases = getDatabases();
     Assertions.assertTrue(databases.contains(testDatabaseName));
 
-    sql("drop database " + testDatabaseName);
+    sql("DROP DATABASE " + testDatabaseName);
     databases = getDatabases();
     Assertions.assertFalse(databases.contains(testDatabaseName));
 
     Assertions.assertThrowsExactly(
-        NoSuchNamespaceException.class, () -> sql("drop database notExists"));
+        NoSuchNamespaceException.class, () -> sql("DROP DATABASE notExists"));
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Make all Spark SQL keywords used in spark connector integration test uppercase

### Why are the changes needed?

Fix: #2424 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
`./gradlew build -PskipTests`

