### PR TITLE
[Backport] fix(lakehouse-iceberg): Fix the include core-site conf file name for lakehouse-iceberg gradle script

### DIFF
--- a/catalogs/catalog-lakehouse-iceberg/build.gradle.kts
+++ b/catalogs/catalog-lakehouse-iceberg/build.gradle.kts
@@ -92,7 +92,7 @@ tasks {
     into("$rootDir/distribution/package/catalogs/lakehouse-iceberg/conf")
 
     include("lakehouse-iceberg.conf")
-    include("hive-site.xml.template")
+    include("core-site.xml.template")
     include("hdfs-site.xml.template")
 
     rename { original ->


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix include correct name to be `core-site.xml.template` instead of `hive-site.xml.template`.
