### PR TITLE
[MINOR]: feat(spark-connector): use DataTypes to create spark datatype

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkIT.java
@@ -17,8 +17,7 @@ import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.types.DataType;
-import org.apache.spark.sql.types.IntegerType$;
-import org.apache.spark.sql.types.StringType$;
+import org.apache.spark.sql.types.DataTypes;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,7 +36,7 @@ public class SparkIT extends SparkEnvIT {
 
   // To generate test data for write&read table.
   private static final Map<DataType, String> typeConstant =
-      ImmutableMap.of(IntegerType$.MODULE$, "2", StringType$.MODULE$, "'gravitino_it_test'");
+      ImmutableMap.of(DataTypes.IntegerType, "2", DataTypes.StringType, "'gravitino_it_test'");
 
   // Use a custom database not the original default database because SparkIT couldn't read&write
   // data to tables in default database. The main reason is default database location is
@@ -305,9 +304,9 @@ public class SparkIT extends SparkEnvIT {
 
   private List<SparkColumnInfo> getSimpleTableColumn() {
     return Arrays.asList(
-        SparkColumnInfo.of("id", IntegerType$.MODULE$, "id comment"),
-        SparkColumnInfo.of("name", StringType$.MODULE$, ""),
-        SparkColumnInfo.of("age", IntegerType$.MODULE$, null));
+        SparkColumnInfo.of("id", DataTypes.IntegerType, "id comment"),
+        SparkColumnInfo.of("name", DataTypes.StringType, ""),
+        SparkColumnInfo.of("age", DataTypes.IntegerType, null));
   }
 
   // Helper method to create a simple table, and could use corresponding

--- a/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/SparkTypeConverter.java
+++ b/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/SparkTypeConverter.java
@@ -8,12 +8,10 @@ package com.datastrato.gravitino.spark.connector;
 import com.datastrato.gravitino.rel.types.Type;
 import com.datastrato.gravitino.rel.types.Types;
 import org.apache.spark.sql.types.BooleanType;
-import org.apache.spark.sql.types.BooleanType$;
 import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.IntegerType;
-import org.apache.spark.sql.types.IntegerType$;
 import org.apache.spark.sql.types.StringType;
-import org.apache.spark.sql.types.StringType$;
 
 /** Transform DataTypes between Gravitino and Spark. */
 public class SparkTypeConverter {
@@ -30,11 +28,11 @@ public class SparkTypeConverter {
 
   public static DataType toSparkType(Type gravitinoType) {
     if (gravitinoType instanceof Types.StringType) {
-      return StringType$.MODULE$;
+      return DataTypes.StringType;
     } else if (gravitinoType instanceof Types.BooleanType) {
-      return BooleanType$.MODULE$;
+      return DataTypes.BooleanType;
     } else if (gravitinoType instanceof Types.IntegerType) {
-      return IntegerType$.MODULE$;
+      return DataTypes.IntegerType;
     }
     throw new UnsupportedOperationException("Not support " + gravitinoType.toString());
   }

--- a/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/table/SparkBaseTable.java
+++ b/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/table/SparkBaseTable.java
@@ -25,11 +25,11 @@ import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.read.ScanBuilder;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
 import org.apache.spark.sql.connector.write.WriteBuilder;
+import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.MetadataBuilder;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.sql.types.StructType$;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 /**
@@ -82,7 +82,7 @@ public abstract class SparkBaseTable implements Table, SupportsRead, SupportsWri
                       metadata);
                 })
             .collect(Collectors.toList());
-    return StructType$.MODULE$.apply(structs);
+    return DataTypes.createStructType(structs);
   }
 
   @Override

--- a/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/TestSparkTypeConverter.java
+++ b/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/TestSparkTypeConverter.java
@@ -13,11 +13,8 @@ import com.datastrato.gravitino.rel.types.Types.StringType;
 import com.google.common.collect.ImmutableSet;
 import java.util.HashMap;
 import java.util.Set;
-import org.apache.spark.sql.types.BinaryType$;
-import org.apache.spark.sql.types.BooleanType$;
 import org.apache.spark.sql.types.DataType;
-import org.apache.spark.sql.types.IntegerType$;
-import org.apache.spark.sql.types.StringType$;
+import org.apache.spark.sql.types.DataTypes;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -30,13 +27,13 @@ public class TestSparkTypeConverter {
   private HashMap<Type, DataType> gravitinoToSparkTypeMapper = new HashMap<>();
   private Set<Type> notSupportGravitinoTypes = ImmutableSet.of(NullType.get());
 
-  private Set<DataType> notSupportSparkTypes = ImmutableSet.of(BinaryType$.MODULE$);
+  private Set<DataType> notSupportSparkTypes = ImmutableSet.of(DataTypes.BinaryType);
 
   @BeforeAll
   void init() {
-    gravitinoToSparkTypeMapper.put(IntegerType.get(), IntegerType$.MODULE$);
-    gravitinoToSparkTypeMapper.put(BooleanType.get(), BooleanType$.MODULE$);
-    gravitinoToSparkTypeMapper.put(StringType.get(), StringType$.MODULE$);
+    gravitinoToSparkTypeMapper.put(IntegerType.get(), DataTypes.IntegerType);
+    gravitinoToSparkTypeMapper.put(BooleanType.get(), DataTypes.BooleanType);
+    gravitinoToSparkTypeMapper.put(StringType.get(), DataTypes.StringType);
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?


### Why are the changes needed?
using DataTypes to replace  `StringType$.MODULE$` make code more simple

```java
public class DataTypes {
  /**
   * Gets the StringType object.
   */
  public static final DataType StringType = StringType$.MODULE$;
}
```


### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
existing UT
