### PR TITLE
[#2448] feat(spark-connector): support  alter table setProperty and removeProperty for spark-connector

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkIT.java
@@ -260,6 +260,35 @@ public class SparkIT extends SparkEnvIT {
     Assertions.assertThrows(NoSuchNamespaceException.class, () -> listTableNames("not_exists_db"));
   }
 
+  @Test
+  public void testAlterTableSetProperty() {
+    String tableName = "testSetProperty";
+    dropTableIfExists(tableName);
+
+    createSimpleTable(tableName);
+    SparkTableInfo oldProperties = getTableInfo(tableName);
+    Assertions.assertFalse(oldProperties.getTableProperties().containsKey("key1"));
+
+    sql(String.format("alter table %s SET TBLPROPERTIES('key1'='value1')", tableName));
+    SparkTableInfo newProperties = getTableInfo(tableName);
+    Assertions.assertEquals(newProperties.getTableProperties().get("key1"), "value1");
+  }
+
+  @Test
+  public void testAlterTableRemoveProperty() {
+    String tableName = "testRemoveProperty";
+    dropTableIfExists(tableName);
+
+    createSimpleTable(tableName);
+    sql(String.format("alter table %s SET TBLPROPERTIES('key1'='value1')", tableName));
+    SparkTableInfo oldProperties = getTableInfo(tableName);
+    Assertions.assertTrue(oldProperties.getTableProperties().containsKey("key1"));
+
+    sql(String.format("alter table %s UNSET TBLPROPERTIES('key1')", tableName));
+    SparkTableInfo newProperties = getTableInfo(tableName);
+    Assertions.assertFalse(newProperties.getTableProperties().containsKey("key1"));
+  }
+
   private void checkTableReadWrite(SparkTableInfo table) {
     String name = table.getTableIdentifier();
     String insertValues =

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkIT.java
@@ -261,32 +261,21 @@ public class SparkIT extends SparkEnvIT {
   }
 
   @Test
-  public void testAlterTableSetProperty() {
-    String tableName = "testSetProperty";
+  void testAlterTableSetAndRemoveProperty() {
+    String tableName = "test_property";
     dropTableIfExists(tableName);
 
     createSimpleTable(tableName);
-    SparkTableInfo oldProperties = getTableInfo(tableName);
-    Assertions.assertFalse(oldProperties.getTableProperties().containsKey("key1"));
+    sql(
+        String.format(
+            "ALTER TABLE %s SET TBLPROPERTIES('key1'='value1', 'key2'='value2')", tableName));
+    Map<String, String> oldProperties = getTableInfo(tableName).getTableProperties();
+    Assertions.assertTrue(oldProperties.containsKey("key1") && oldProperties.containsKey("key2"));
 
-    sql(String.format("alter table %s SET TBLPROPERTIES('key1'='value1')", tableName));
-    SparkTableInfo newProperties = getTableInfo(tableName);
-    Assertions.assertEquals(newProperties.getTableProperties().get("key1"), "value1");
-  }
-
-  @Test
-  public void testAlterTableRemoveProperty() {
-    String tableName = "testRemoveProperty";
-    dropTableIfExists(tableName);
-
-    createSimpleTable(tableName);
-    sql(String.format("alter table %s SET TBLPROPERTIES('key1'='value1')", tableName));
-    SparkTableInfo oldProperties = getTableInfo(tableName);
-    Assertions.assertTrue(oldProperties.getTableProperties().containsKey("key1"));
-
-    sql(String.format("alter table %s UNSET TBLPROPERTIES('key1')", tableName));
-    SparkTableInfo newProperties = getTableInfo(tableName);
-    Assertions.assertFalse(newProperties.getTableProperties().containsKey("key1"));
+    sql(String.format("ALTER TABLE %s UNSET TBLPROPERTIES('key1')", tableName));
+    Map<String, String> newProperties = getTableInfo(tableName).getTableProperties();
+    Assertions.assertFalse(newProperties.containsKey("key1"));
+    Assertions.assertTrue(newProperties.containsKey("key2"));
   }
 
   private void checkTableReadWrite(SparkTableInfo table) {

--- a/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/catalog/GravitinoCatalog.java
+++ b/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/catalog/GravitinoCatalog.java
@@ -355,23 +355,15 @@ public class GravitinoCatalog implements TableCatalog, SupportsNamespaces {
   @VisibleForTesting
   static com.datastrato.gravitino.rel.TableChange transformTableChange(TableChange change) {
     if (change instanceof TableChange.SetProperty) {
-      return transformSetProperty((TableChange.SetProperty) change);
+      TableChange.SetProperty setProperty = (TableChange.SetProperty) change;
+      return com.datastrato.gravitino.rel.TableChange.setProperty(
+          setProperty.property(), setProperty.value());
     } else if (change instanceof TableChange.RemoveProperty) {
-      return transformRemoveProperty((TableChange.RemoveProperty) change);
+      TableChange.RemoveProperty removeProperty = (TableChange.RemoveProperty) change;
+      return com.datastrato.gravitino.rel.TableChange.removeProperty(removeProperty.property());
     } else {
       throw new UnsupportedOperationException(
           String.format("Unsupported table change %s", change.getClass().getName()));
     }
-  }
-
-  private static com.datastrato.gravitino.rel.TableChange transformSetProperty(
-      TableChange.SetProperty sparkChange) {
-    return com.datastrato.gravitino.rel.TableChange.setProperty(
-        sparkChange.property(), sparkChange.value());
-  }
-
-  private static com.datastrato.gravitino.rel.TableChange transformRemoveProperty(
-      TableChange.RemoveProperty sparkChange) {
-    return com.datastrato.gravitino.rel.TableChange.removeProperty(sparkChange.property());
   }
 }

--- a/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/catalog/GravitinoCatalog.java
+++ b/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/catalog/GravitinoCatalog.java
@@ -353,7 +353,7 @@ public class GravitinoCatalog implements TableCatalog, SupportsNamespaces {
   }
 
   @VisibleForTesting
-  public static com.datastrato.gravitino.rel.TableChange transformTableChange(TableChange change) {
+  static com.datastrato.gravitino.rel.TableChange transformTableChange(TableChange change) {
     if (change instanceof TableChange.SetProperty) {
       return transformSetProperty((TableChange.SetProperty) change);
     } else if (change instanceof TableChange.RemoveProperty) {

--- a/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/catalog/GravitinoCatalog.java
+++ b/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/catalog/GravitinoCatalog.java
@@ -18,6 +18,7 @@ import com.datastrato.gravitino.spark.connector.GravitinoCatalogAdaptor;
 import com.datastrato.gravitino.spark.connector.GravitinoCatalogAdaptorFactory;
 import com.datastrato.gravitino.spark.connector.PropertiesConverter;
 import com.datastrato.gravitino.spark.connector.SparkTypeConverter;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -164,7 +165,21 @@ public class GravitinoCatalog implements TableCatalog, SupportsNamespaces {
 
   @Override
   public Table alterTable(Identifier ident, TableChange... changes) throws NoSuchTableException {
-    throw new NotSupportedException("Doesn't support altering table for now");
+    com.datastrato.gravitino.rel.TableChange[] gravitinoTableChanges =
+        Arrays.stream(changes)
+            .map(GravitinoCatalog::transformTableChange)
+            .toArray(com.datastrato.gravitino.rel.TableChange[]::new);
+    try {
+      com.datastrato.gravitino.rel.Table table =
+          gravitinoCatalogClient
+              .asTableCatalog()
+              .alterTable(
+                  NameIdentifier.of(metalakeName, catalogName, getDatabase(ident), ident.name()),
+                  gravitinoTableChanges);
+      return gravitinoAdaptor.createSparkTable(ident, table, sparkCatalog, propertiesConverter);
+    } catch (com.datastrato.gravitino.exceptions.NoSuchTableException e) {
+      throw new NoSuchTableException(ident);
+    }
   }
 
   @Override
@@ -335,5 +350,28 @@ public class GravitinoCatalog implements TableCatalog, SupportsNamespaces {
         gravitinoIdentifier.namespace().length() == 3,
         "Only support 3 level namespace," + gravitinoIdentifier.namespace());
     return gravitinoIdentifier.namespace().level(2);
+  }
+
+  @VisibleForTesting
+  public static com.datastrato.gravitino.rel.TableChange transformTableChange(TableChange change) {
+    if (change instanceof TableChange.SetProperty) {
+      return transformSetProperty((TableChange.SetProperty) change);
+    } else if (change instanceof TableChange.RemoveProperty) {
+      return transformRemoveProperty((TableChange.RemoveProperty) change);
+    } else {
+      throw new UnsupportedOperationException(
+          String.format("Unsupported table change %s", change.getClass().getName()));
+    }
+  }
+
+  private static com.datastrato.gravitino.rel.TableChange transformSetProperty(
+      TableChange.SetProperty sparkChange) {
+    return com.datastrato.gravitino.rel.TableChange.setProperty(
+        sparkChange.property(), sparkChange.value());
+  }
+
+  private static com.datastrato.gravitino.rel.TableChange transformRemoveProperty(
+      TableChange.RemoveProperty sparkChange) {
+    return com.datastrato.gravitino.rel.TableChange.removeProperty(sparkChange.property());
   }
 }

--- a/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/TestTransformTableChange.java
+++ b/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/TestTransformTableChange.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright 2024 Datastrato Pvt Ltd.
+ *  This software is licensed under the Apache License version 2.
+ */
+
+package com.datastrato.gravitino.spark.connector;
+
+import com.datastrato.gravitino.spark.connector.catalog.GravitinoCatalog;
+import org.apache.spark.sql.connector.catalog.TableChange;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestTransformTableChange {
+
+  @Test
+  public void testTransformSetProperty() {
+    TableChange sparkSetProperty = TableChange.setProperty("key", "value");
+    com.datastrato.gravitino.rel.TableChange tableChange =
+        GravitinoCatalog.transformTableChange(sparkSetProperty);
+    Assertions.assertTrue(
+        tableChange instanceof com.datastrato.gravitino.rel.TableChange.SetProperty);
+    com.datastrato.gravitino.rel.TableChange.SetProperty gravitinoSetProperty =
+        (com.datastrato.gravitino.rel.TableChange.SetProperty) tableChange;
+    Assertions.assertEquals("key", gravitinoSetProperty.getProperty());
+    Assertions.assertEquals("value", gravitinoSetProperty.getValue());
+  }
+
+  @Test
+  public void testTransformRemoveProperty() {
+    TableChange sparkRemoveProperty = TableChange.removeProperty("key");
+    com.datastrato.gravitino.rel.TableChange tableChange =
+        GravitinoCatalog.transformTableChange(sparkRemoveProperty);
+    Assertions.assertTrue(
+        tableChange instanceof com.datastrato.gravitino.rel.TableChange.RemoveProperty);
+    com.datastrato.gravitino.rel.TableChange.RemoveProperty gravitinoRemoveProperty =
+        (com.datastrato.gravitino.rel.TableChange.RemoveProperty) tableChange;
+    Assertions.assertEquals("key", gravitinoRemoveProperty.getProperty());
+  }
+}

--- a/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/catalog/TestTransformTableChange.java
+++ b/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/catalog/TestTransformTableChange.java
@@ -3,9 +3,8 @@
  *  This software is licensed under the Apache License version 2.
  */
 
-package com.datastrato.gravitino.spark.connector;
+package com.datastrato.gravitino.spark.connector.catalog;
 
-import com.datastrato.gravitino.spark.connector.catalog.GravitinoCatalog;
 import org.apache.spark.sql.connector.catalog.TableChange;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -13,7 +12,7 @@ import org.junit.jupiter.api.Test;
 public class TestTransformTableChange {
 
   @Test
-  public void testTransformSetProperty() {
+  void testTransformSetProperty() {
     TableChange sparkSetProperty = TableChange.setProperty("key", "value");
     com.datastrato.gravitino.rel.TableChange tableChange =
         GravitinoCatalog.transformTableChange(sparkSetProperty);
@@ -26,7 +25,7 @@ public class TestTransformTableChange {
   }
 
   @Test
-  public void testTransformRemoveProperty() {
+  void testTransformRemoveProperty() {
     TableChange sparkRemoveProperty = TableChange.removeProperty("key");
     com.datastrato.gravitino.rel.TableChange tableChange =
         GravitinoCatalog.transformTableChange(sparkRemoveProperty);


### PR DESCRIPTION
### What changes were proposed in this pull request?

support add table property and remove table property for spark-connector in AlterTableCommand.

### Why are the changes needed?
Implement setProperty and RemoveProperty ops for Spark AlterTableCommand.

Fix: [#2448](https://github.com/datastrato/gravitino/issues/2448)

### Does this PR introduce _any_ user-facing change?
Yes, users can run the following commands to modify the table properties using spark sql.

```
-- Alter TABLE property Using SET PROPERTIES
ALTER TABLE gravitino_catalog.dbx.tab1 SET TBLPROPERTIES ('key1' = 'value1');

-- DROP TABLE PROPERTIES
ALTER TABLE gravitino_catalog.dbx.tab1 UNSET TBLPROPERTIES ('key1');
```

### How was this patch tested?

new uts.
