### PR TITLE
[#2462] fix(doc) Remove 'allow_pushdown_into_connectors=false'  in trino-connector/requirements doc 

### DIFF
--- a/docs/trino-connector/requirements.md
+++ b/docs/trino-connector/requirements.md
@@ -14,5 +14,3 @@ To install and deploy the Gravitino connector, The following environmental setup
 - Ensure that all nodes running Trino can access the real catalogs resources, such as Hive, Iceberg, MySQL, PostgreSQL, etc.
 - Ensure that you have installed the following connectors in Trino: Hive, Iceberg, MySQL, PostgreSQL.
 - Ensure that you have set the `catalog.management` to `static` in the Trino configuration.
-- Ensure that you have set the `allow_pushdown_into_connectors` to `false` in the Trino session configuration.
-


### PR DESCRIPTION

### What changes were proposed in this pull request?

The requirements document for the Trino connector need to remove the limitation that disabled the 'allow_pushdown_into_connectors' configuration

### Why are the changes needed?

Fix: #2462

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

NO
