### PR TITLE
[#2451] feat(spark-connector): support Float and Double type for spark-connector

### DIFF
--- a/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/SparkTypeConverter.java
+++ b/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/SparkTypeConverter.java
@@ -10,6 +10,8 @@ import com.datastrato.gravitino.rel.types.Types;
 import org.apache.spark.sql.types.BooleanType;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.DoubleType;
+import org.apache.spark.sql.types.FloatType;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.StringType;
 
@@ -22,6 +24,10 @@ public class SparkTypeConverter {
       return Types.BooleanType.get();
     } else if (sparkType instanceof IntegerType) {
       return Types.IntegerType.get();
+    } else if (sparkType instanceof FloatType) {
+      return Types.FloatType.get();
+    } else if (sparkType instanceof DoubleType) {
+      return Types.DoubleType.get();
     }
     throw new UnsupportedOperationException("Not support " + sparkType.toString());
   }
@@ -33,6 +39,10 @@ public class SparkTypeConverter {
       return DataTypes.BooleanType;
     } else if (gravitinoType instanceof Types.IntegerType) {
       return DataTypes.IntegerType;
+    } else if (gravitinoType instanceof Types.FloatType) {
+      return DataTypes.FloatType;
+    } else if (gravitinoType instanceof Types.DoubleType) {
+      return DataTypes.DoubleType;
     }
     throw new UnsupportedOperationException("Not support " + gravitinoType.toString());
   }

--- a/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/TestSparkTypeConverter.java
+++ b/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/TestSparkTypeConverter.java
@@ -7,6 +7,8 @@ package com.datastrato.gravitino.spark.connector;
 
 import com.datastrato.gravitino.rel.types.Type;
 import com.datastrato.gravitino.rel.types.Types.BooleanType;
+import com.datastrato.gravitino.rel.types.Types.DoubleType;
+import com.datastrato.gravitino.rel.types.Types.FloatType;
 import com.datastrato.gravitino.rel.types.Types.IntegerType;
 import com.datastrato.gravitino.rel.types.Types.NullType;
 import com.datastrato.gravitino.rel.types.Types.StringType;
@@ -34,6 +36,8 @@ public class TestSparkTypeConverter {
     gravitinoToSparkTypeMapper.put(IntegerType.get(), DataTypes.IntegerType);
     gravitinoToSparkTypeMapper.put(BooleanType.get(), DataTypes.BooleanType);
     gravitinoToSparkTypeMapper.put(StringType.get(), DataTypes.StringType);
+    gravitinoToSparkTypeMapper.put(FloatType.get(), DataTypes.FloatType);
+    gravitinoToSparkTypeMapper.put(DoubleType.get(), DataTypes.DoubleType);
   }
 
   @Test


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Support Float and Double type for spark-connector; add related test

### Why are the changes needed?

Fix: #2451 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
`./gradlew test -PskipITs`
