### PR TITLE
[#2162] improvement: enable ImmutableEnumChecker error-prone

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -252,6 +252,7 @@ subprojects {
         "IdentityBinaryExpression",
         "IdentityHashMapBoxing",
         "Immutable",
+        "ImmutableEnumChecker",
         "Incomparable",
         "IncompatibleArgumentType",
         "IndexOfChar",

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoErrorCode.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoErrorCode.java
@@ -36,6 +36,7 @@ public enum GravitinoErrorCode implements ErrorCodeSupplier {
   GRAVITINO_OPERATION_FAILED(22, EXTERNAL),
   ;
 
+  @SuppressWarnings("ImmutableEnumChecker")
   private final ErrorCode errorCode;
 
   GravitinoErrorCode(int code, ErrorType type) {

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoErrorCode.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoErrorCode.java
@@ -36,6 +36,7 @@ public enum GravitinoErrorCode implements ErrorCodeSupplier {
   GRAVITINO_OPERATION_FAILED(22, EXTERNAL),
   ;
 
+  // suppress ImmutableEnumChecker because ErrorCode is outside the project.
   @SuppressWarnings("ImmutableEnumChecker")
   private final ErrorCode errorCode;
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

ImmutableEnumChecker will check whether a Eunm is immutable.
Such cases will be recognized as an immutable object:

- All fields are final.
- The types of all fields of the enum are deeply immutable.
- The class annotated by `@com.google.errorprone.annotations.Immutable`.

See more details at https://errorprone.info/bugpattern/ImmutableEnumChecker.

In this MR, we suppress ImmutableEnumChecker on `io.trino.spi.ErrorCode`, because it is outside the project.

### Why are the changes needed?


- Fix: #2162 

### Does this PR introduce _any_ user-facing change?

- no

### How was this patch tested?

- `./gradlew build`
