### PR TITLE
[#2504] build(signing): only apply signing for release versions or public publishings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -370,12 +370,18 @@ subprojects {
     }
   }
 
-  configure<SigningExtension> {
-    val gpgId = System.getenv("GPG_ID")
-    val gpgSecretKey = System.getenv("GPG_PRIVATE_KEY")
-    val gpgKeyPassword = System.getenv("GPG_PASSPHRASE")
-    useInMemoryPgpKeys(gpgId, gpgSecretKey, gpgKeyPassword)
-    sign(publishing.publications)
+  gradle.taskGraph.whenReady {
+    configure<SigningExtension> {
+      val isReleaseVersion = !version.toString().endsWith("SNAPSHOT")
+      val isPublicPublish = allTasks.any { it.name == "publishMavenJavaPublicationToSonatypeRepository" }
+
+      val gpgId = System.getenv("GPG_ID")
+      val gpgSecretKey = System.getenv("GPG_PRIVATE_KEY")
+      val gpgKeyPassword = System.getenv("GPG_PASSPHRASE")
+      isRequired = isReleaseVersion || isPublicPublish
+      useInMemoryPgpKeys(gpgId, gpgSecretKey, gpgKeyPassword)
+      sign(publishing.publications)
+    }
   }
 
   tasks.configureEach<Test> {


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

only apply signing for release versions or public publishings

### Why are the changes needed?

In the current publishing process, the content must be signed using the gradle signing plugin. While signing is not necessary for local use, conditionally skipping signing can help developers build and debug more easily with other systems.

Fix: #2504

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

NO
