### PR TITLE
#2450 add RenameColumn support for spark-connector

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkIT.java
@@ -315,6 +315,28 @@ public class SparkIT extends SparkEnvIT {
     checkTableColumns(tableName, updateColumns, getTableInfo(tableName));
   }
 
+  @Test
+  void testAlterTableRenameColumn() {
+    String tableName = "test_rename_column";
+    dropTableIfExists(tableName);
+    List<SparkColumnInfo> simpleTableColumns = getSimpleTableColumn();
+    createSimpleTable(tableName);
+    checkTableColumns(tableName, simpleTableColumns, getTableInfo(tableName));
+
+    String oldColumnName = "col1";
+    String newColumnName = "col2";
+
+    sql(
+        String.format(
+            "ALTER TABLE %S ADD COLUMNS (col1 int)", tableName));
+    sql(
+        String.format(
+            "ALTER TABLE %S RENAME COLUMN %S TO %S", tableName, oldColumnName, newColumnName));
+    ArrayList<SparkColumnInfo> renameColumns = new ArrayList<>(simpleTableColumns);
+    renameColumns.add(SparkColumnInfo.of(newColumnName, DataTypes.IntegerType, null));
+    checkTableColumns(tableName, renameColumns, getTableInfo(tableName));
+  }
+
   private void checkTableColumns(
       String tableName, List<SparkColumnInfo> columnInfos, SparkTableInfo tableInfo) {
     SparkTableInfoChecker.create()

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkIT.java
@@ -326,9 +326,7 @@ public class SparkIT extends SparkEnvIT {
     String oldColumnName = "col1";
     String newColumnName = "col2";
 
-    sql(
-        String.format(
-            "ALTER TABLE %S ADD COLUMNS (col1 int)", tableName));
+    sql(String.format("ALTER TABLE %S ADD COLUMNS (col1 int)", tableName));
     sql(
         String.format(
             "ALTER TABLE %S RENAME COLUMN %S TO %S", tableName, oldColumnName, newColumnName));

--- a/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/catalog/GravitinoCatalog.java
+++ b/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/catalog/GravitinoCatalog.java
@@ -378,6 +378,10 @@ public class GravitinoCatalog implements TableCatalog, SupportsNamespaces {
       return com.datastrato.gravitino.rel.TableChange.updateColumnType(
           updateColumnType.fieldNames(),
           SparkTypeConverter.toGravitinoType(updateColumnType.newDataType()));
+    } else if (change instanceof TableChange.RenameColumn) {
+      TableChange.RenameColumn renameColumn = (TableChange.RenameColumn) change;
+      return com.datastrato.gravitino.rel.TableChange.renameColumn(
+          renameColumn.fieldNames(), renameColumn.newName());
     } else {
       throw new UnsupportedOperationException(
           String.format("Unsupported table change %s", change.getClass().getName()));

--- a/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/catalog/TestTransformTableChange.java
+++ b/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/catalog/TestTransformTableChange.java
@@ -40,6 +40,25 @@ public class TestTransformTableChange {
   }
 
   @Test
+  void testTransformRenameColumn() {
+    String[] oldFiledsName = new String[] {"default_name"};
+    String newFiledName = "new_name";
+
+    TableChange.RenameColumn sparkRenameColumn =
+        (TableChange.RenameColumn) TableChange.renameColumn(oldFiledsName, newFiledName);
+    com.datastrato.gravitino.rel.TableChange gravitinoChange =
+        GravitinoCatalog.transformTableChange(sparkRenameColumn);
+
+    Assertions.assertTrue(
+        gravitinoChange instanceof com.datastrato.gravitino.rel.TableChange.RenameColumn);
+    com.datastrato.gravitino.rel.TableChange.RenameColumn gravitinoRenameColumn =
+        (com.datastrato.gravitino.rel.TableChange.RenameColumn) gravitinoChange;
+
+    Assertions.assertEquals(oldFiledsName, gravitinoRenameColumn.getFieldName());
+    Assertions.assertEquals(newFiledName, gravitinoRenameColumn.getNewName());
+  }
+
+  @Test
   void testTransformAddColumn() {
 
     TableChange.ColumnPosition first = TableChange.ColumnPosition.first();


### PR DESCRIPTION
### What changes were proposed in this pull request?

support rename table column for spark-connector in RenameColumnCommand.

### Why are the changes needed?

Fix: # 2450

### Does this PR introduce _any_ user-facing change?

`alter table  default_catalog.default_db.default_table rename age to new_age;`

### How was this patch tested?
write new unit tests.