### PR TITLE
[#2513] fix: Fix thread pool leak in CachedClientPool

### DIFF
--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/CachedClientPool.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/CachedClientPool.java
@@ -54,19 +54,19 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
 
   private final Configuration conf;
   private final int clientPoolSize;
+  private final ScheduledThreadPoolExecutor scheduler;
 
   CachedClientPool(int clientPoolSize, Configuration conf, long evictionInterval) {
     this.conf = conf;
     this.clientPoolSize = clientPoolSize;
     // Since Caffeine does not ensure that removalListener will be involved after expiration
     // We use a scheduler with one thread to clean up expired clients.
+    scheduler = new ScheduledThreadPoolExecutor(1, newDaemonThreadFactory());
     this.clientPoolCache =
         Caffeine.newBuilder()
             .expireAfterAccess(evictionInterval, TimeUnit.MILLISECONDS)
             .removalListener((ignored, value, cause) -> ((HiveClientPool) value).close())
-            .scheduler(
-                Scheduler.forScheduledExecutorService(
-                    new ScheduledThreadPoolExecutor(1, newDaemonThreadFactory())))
+            .scheduler(Scheduler.forScheduledExecutorService(scheduler))
             .build();
   }
 
@@ -136,5 +136,6 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
 
   public void close() {
     clientPoolCache.invalidateAll();
+    scheduler.shutdownNow();
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Close the Caffeine Scheduler explicitly in method `close`.

### Why are the changes needed?

The scheduler thread can't be exited after we close the CachedClientPool. This problem will be triggered by `atlerCatalog` opertion.

Fix: #2513

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

N/A.
