### PR TITLE
[#2449] feat(spark-connector): support update column comment for spark-connector

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkIT.java
@@ -345,15 +345,15 @@ public class SparkIT extends SparkEnvIT {
     dropTableIfExists(tableName);
 
     List<SparkColumnInfo> simpleTableColumns =
-            Arrays.asList(
-                    SparkColumnInfo.of("id", DataTypes.StringType, ""),
-                    SparkColumnInfo.of("name", DataTypes.StringType, ""),
-                    SparkColumnInfo.of("age", DataTypes.StringType, ""));
+        Arrays.asList(
+            SparkColumnInfo.of("id", DataTypes.StringType, ""),
+            SparkColumnInfo.of("name", DataTypes.StringType, ""),
+            SparkColumnInfo.of("age", DataTypes.StringType, ""));
 
     sql(
-            String.format(
-                    "CREATE TABLE %s (id STRING COMMENT '', name STRING COMMENT '', age STRING COMMENT '') USING PARQUET",
-                    tableName));
+        String.format(
+            "CREATE TABLE %s (id STRING COMMENT '', name STRING COMMENT '', age STRING COMMENT '') USING PARQUET",
+            tableName));
     checkTableColumns(tableName, simpleTableColumns, getTableInfo(tableName));
 
     sql(String.format("ALTER TABLE %S ADD COLUMNS (col1 STRING COMMENT '')", tableName));

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkIT.java
@@ -345,15 +345,15 @@ public class SparkIT extends SparkEnvIT {
     dropTableIfExists(tableName);
 
     List<SparkColumnInfo> simpleTableColumns =
-        Arrays.asList(
-            SparkColumnInfo.of("id", DataTypes.StringType, ""),
-            SparkColumnInfo.of("name", DataTypes.StringType, ""),
-            SparkColumnInfo.of("age", DataTypes.StringType, ""));
+            Arrays.asList(
+                    SparkColumnInfo.of("id", DataTypes.StringType, ""),
+                    SparkColumnInfo.of("name", DataTypes.StringType, ""),
+                    SparkColumnInfo.of("age", DataTypes.StringType, ""));
 
     sql(
-        String.format(
-            "CREATE TABLE %s (id STRING COMMENT '', name STRING COMMENT '', age STRING COMMENT '') USING PARQUET",
-            tableName));
+            String.format(
+                    "CREATE TABLE %s (id STRING COMMENT '', name STRING COMMENT '', age STRING COMMENT '') USING PARQUET",
+                    tableName));
     checkTableColumns(tableName, simpleTableColumns, getTableInfo(tableName));
 
     sql(String.format("ALTER TABLE %S ADD COLUMNS (col1 STRING COMMENT '')", tableName));
@@ -380,6 +380,29 @@ public class SparkIT extends SparkEnvIT {
     updateColumnPositionAfter.add(SparkColumnInfo.of("col2", DataTypes.StringType, ""));
     updateColumnPositionAfter.addAll(simpleTableColumns);
     checkTableColumns(tableName, updateColumnPositionAfter, getTableInfo(tableName));
+  }
+
+  @Test
+  void testAlterTableUpdateColumnComment() {
+    String tableName = "test_update_column_comment";
+    dropTableIfExists(tableName);
+    List<SparkColumnInfo> simpleTableColumns = getSimpleTableColumn();
+    createSimpleTable(tableName);
+    checkTableColumns(tableName, simpleTableColumns, getTableInfo(tableName));
+
+    String oldColumnComment = "col1_comment";
+    String newColumnComment = "col1_new_comment";
+
+    sql(
+        String.format(
+            "ALTER TABLE %S ADD COLUMNS (col1 int comment '%s')", tableName, oldColumnComment));
+    sql(
+        String.format(
+            "ALTER TABLE %S CHANGE COLUMN col1 col1 int comment '%s'",
+            tableName, newColumnComment));
+    ArrayList<SparkColumnInfo> updateCommentColumns = new ArrayList<>(simpleTableColumns);
+    updateCommentColumns.add(SparkColumnInfo.of("col1", DataTypes.IntegerType, newColumnComment));
+    checkTableColumns(tableName, updateCommentColumns, getTableInfo(tableName));
   }
 
   private void checkTableColumns(

--- a/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/catalog/GravitinoCatalog.java
+++ b/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/catalog/GravitinoCatalog.java
@@ -395,6 +395,11 @@ public class GravitinoCatalog implements TableCatalog, SupportsNamespaces {
               instanceof com.datastrato.gravitino.rel.TableChange.Default),
           "Doesn't support alter column position without specifying position");
       return gravitinoUpdateColumnPosition;
+    } else if (change instanceof TableChange.UpdateColumnComment) {
+      TableChange.UpdateColumnComment updateColumnComment =
+          (TableChange.UpdateColumnComment) change;
+      return com.datastrato.gravitino.rel.TableChange.updateColumnComment(
+          updateColumnComment.fieldNames(), updateColumnComment.newComment());
     } else {
       throw new UnsupportedOperationException(
           String.format("Unsupported table change %s", change.getClass().getName()));

--- a/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/catalog/TestTransformTableChange.java
+++ b/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/catalog/TestTransformTableChange.java
@@ -54,8 +54,27 @@ public class TestTransformTableChange {
     com.datastrato.gravitino.rel.TableChange.RenameColumn gravitinoRenameColumn =
         (com.datastrato.gravitino.rel.TableChange.RenameColumn) gravitinoChange;
 
-    Assertions.assertEquals(oldFiledsName, gravitinoRenameColumn.getFieldName());
+    Assertions.assertArrayEquals(oldFiledsName, gravitinoRenameColumn.getFieldName());
     Assertions.assertEquals(newFiledName, gravitinoRenameColumn.getNewName());
+  }
+
+  @Test
+  void testTransformUpdateColumnComment() {
+    String[] fieldNames = new String[] {"default_name"};
+    String newComment = "default_comment";
+
+    TableChange.UpdateColumnComment updateColumnComment =
+        (TableChange.UpdateColumnComment) TableChange.updateColumnComment(fieldNames, newComment);
+    com.datastrato.gravitino.rel.TableChange gravitinoChange =
+        GravitinoCatalog.transformTableChange(updateColumnComment);
+
+    Assertions.assertTrue(
+        gravitinoChange instanceof com.datastrato.gravitino.rel.TableChange.UpdateColumnComment);
+    com.datastrato.gravitino.rel.TableChange.UpdateColumnComment gravitinoUpdateColumnComment =
+        (com.datastrato.gravitino.rel.TableChange.UpdateColumnComment) gravitinoChange;
+
+    Assertions.assertArrayEquals(fieldNames, gravitinoUpdateColumnComment.getFieldName());
+    Assertions.assertEquals(newComment, gravitinoUpdateColumnComment.getNewComment());
   }
 
   @Test
@@ -79,7 +98,8 @@ public class TestTransformTableChange {
     com.datastrato.gravitino.rel.TableChange.AddColumn gravitinoAddColumnFirst =
         (com.datastrato.gravitino.rel.TableChange.AddColumn) gravitinoChangeFirst;
 
-    Assertions.assertEquals(sparkAddColumnFirst.fieldNames(), gravitinoAddColumnFirst.fieldName());
+    Assertions.assertArrayEquals(
+        sparkAddColumnFirst.fieldNames(), gravitinoAddColumnFirst.fieldName());
     Assertions.assertTrue(
         "string".equalsIgnoreCase(gravitinoAddColumnFirst.getDataType().simpleString()));
     Assertions.assertTrue(
@@ -98,7 +118,8 @@ public class TestTransformTableChange {
     com.datastrato.gravitino.rel.TableChange.AddColumn gravitinoAddColumnAfter =
         (com.datastrato.gravitino.rel.TableChange.AddColumn) gravitinoChangeAfter;
 
-    Assertions.assertEquals(sparkAddColumnAfter.fieldNames(), gravitinoAddColumnAfter.fieldName());
+    Assertions.assertArrayEquals(
+        sparkAddColumnAfter.fieldNames(), gravitinoAddColumnAfter.fieldName());
     Assertions.assertTrue(
         "string".equalsIgnoreCase(gravitinoAddColumnAfter.getDataType().simpleString()));
     Assertions.assertTrue(
@@ -117,7 +138,7 @@ public class TestTransformTableChange {
     com.datastrato.gravitino.rel.TableChange.AddColumn gravitinoAddColumnDefault =
         (com.datastrato.gravitino.rel.TableChange.AddColumn) gravitinoChangeDefault;
 
-    Assertions.assertEquals(
+    Assertions.assertArrayEquals(
         sparkAddColumnDefault.fieldNames(), gravitinoAddColumnDefault.fieldName());
     Assertions.assertTrue(
         "string".equalsIgnoreCase(gravitinoAddColumnDefault.getDataType().simpleString()));
@@ -138,7 +159,7 @@ public class TestTransformTableChange {
     com.datastrato.gravitino.rel.TableChange.DeleteColumn gravitinoDeleteColumn =
         (com.datastrato.gravitino.rel.TableChange.DeleteColumn) gravitinoChange;
 
-    Assertions.assertEquals(sparkDeleteColumn.fieldNames(), gravitinoDeleteColumn.fieldName());
+    Assertions.assertArrayEquals(sparkDeleteColumn.fieldNames(), gravitinoDeleteColumn.fieldName());
     Assertions.assertEquals(sparkDeleteColumn.ifExists(), gravitinoDeleteColumn.getIfExists());
   }
 
@@ -155,7 +176,7 @@ public class TestTransformTableChange {
     com.datastrato.gravitino.rel.TableChange.UpdateColumnType gravitinoUpdateColumnType =
         (com.datastrato.gravitino.rel.TableChange.UpdateColumnType) gravitinoChange;
 
-    Assertions.assertEquals(
+    Assertions.assertArrayEquals(
         sparkUpdateColumnType.fieldNames(), gravitinoUpdateColumnType.fieldName());
     Assertions.assertTrue(
         "string".equalsIgnoreCase(gravitinoUpdateColumnType.getNewDataType().simpleString()));


### PR DESCRIPTION
### What changes were proposed in this pull request?

support update column comment for spark-connector

### Why are the changes needed?

Fix: #2449

### Does this PR introduce _any_ user-facing change?

`alter table  default_catalog.default_db.default_table change column col1 col1 int comment 'new_comment;'`

### How was this patch tested?

write new unit tests.