### PR TITLE
[#2436] feat(IT): Add catalogs page to web e2e test

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
@@ -85,6 +85,14 @@ public class CatalogsPageTest extends AbstractWebIT {
 
   @Test
   @Order(2)
+  public void testRefreshPage() {
+    driver.navigate().refresh();
+    Assertions.assertEquals(driver.getTitle(), "Gravitino");
+    Assertions.assertTrue(catalogsPage.verifyRefreshPage());
+  }
+
+  @Test
+  @Order(3)
   public void testViewTabMetalakeDetails() throws InterruptedException {
     clickAndWait(catalogsPage.tabDetailsBtn);
     Assertions.assertTrue(catalogsPage.verifyShowDetailsContent());
@@ -93,14 +101,14 @@ public class CatalogsPageTest extends AbstractWebIT {
   }
 
   @Test
-  @Order(3)
+  @Order(4)
   public void testViewCatalogDetails() throws InterruptedException {
     catalogsPage.clickViewCatalogBtn(catalogName);
     Assertions.assertTrue(catalogsPage.verifyShowCatalogDetails(catalogName));
   }
 
   @Test
-  @Order(4)
+  @Order(5)
   public void testEditCatalog() throws InterruptedException {
     catalogsPage.clickEditCatalogBtn(catalogName);
     catalogsPage.setCatalogNameField(modifiedCatalogName);
@@ -109,21 +117,21 @@ public class CatalogsPageTest extends AbstractWebIT {
   }
 
   @Test
-  @Order(5)
+  @Order(6)
   public void testClickCatalogLink() {
     catalogsPage.clickCatalogLink(metalakeName, modifiedCatalogName);
     Assertions.assertTrue(catalogsPage.verifyShowTableTitle("Schemas"));
   }
 
   @Test
-  @Order(6)
+  @Order(7)
   public void testClickSchemaLink() {
     catalogsPage.clickSchemaLink(metalakeName, modifiedCatalogName, schemaName);
     Assertions.assertTrue(catalogsPage.verifyShowTableTitle("Tables"));
   }
 
   @Test
-  @Order(7)
+  @Order(8)
   public void testClickTableLink() {
     catalogsPage.clickTableLink(metalakeName, modifiedCatalogName, schemaName, tableName);
     Assertions.assertTrue(catalogsPage.verifyShowTableTitle("Columns"));
@@ -131,7 +139,7 @@ public class CatalogsPageTest extends AbstractWebIT {
   }
 
   @Test
-  @Order(8)
+  @Order(9)
   public void testDeleteCatalog() throws InterruptedException {
     catalogsPage.clickBreadCrumbsToCatalogs();
     catalogsPage.clickDeleteCatalogBtn(modifiedCatalogName);
@@ -140,7 +148,7 @@ public class CatalogsPageTest extends AbstractWebIT {
   }
 
   @Test
-  @Order(9)
+  @Order(10)
   public void testBackHomePage() throws InterruptedException {
     clickAndWait(catalogsPage.backHomeBtn);
     Assertions.assertTrue(catalogsPage.verifyBackHomePage());

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
@@ -104,7 +104,12 @@ public class CatalogsPageTest extends AbstractWebIT {
   @Order(4)
   public void testViewCatalogDetails() throws InterruptedException {
     catalogsPage.clickViewCatalogBtn(catalogName);
-    Assertions.assertTrue(catalogsPage.verifyShowCatalogDetails(catalogName));
+    String hiveMetastoreUris =
+        String.format(
+            "thrift://%s:%d",
+            containerSuite.getHiveContainer().getContainerIpAddress(),
+            HiveContainer.HIVE_METASTORE_PORT);
+    Assertions.assertTrue(catalogsPage.verifyShowCatalogDetails(catalogName, hiveMetastoreUris));
   }
 
   @Test

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+
+package com.datastrato.gravitino.integration.test.web.ui;
+
+import com.datastrato.gravitino.integration.test.container.ContainerSuite;
+import com.datastrato.gravitino.integration.test.container.HiveContainer;
+import com.datastrato.gravitino.integration.test.web.ui.pages.CatalogsPage;
+import com.datastrato.gravitino.integration.test.web.ui.pages.MetalakePage;
+import com.datastrato.gravitino.integration.test.web.ui.utils.AbstractWebIT;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+@Tag("gravitino-docker-it")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class CatalogsPageTest extends AbstractWebIT {
+  private static final ContainerSuite containerSuite = ContainerSuite.getInstance();
+  MetalakePage metalakePage = new MetalakePage();
+  CatalogsPage catalogsPage = new CatalogsPage();
+
+  private static final String metalakeName = "metalake_name";
+  String catalogName = "catalog_name";
+  String modifiedCatalogName = catalogName + "_edited";
+  String schemaName = "default";
+  String tableName = "employee";
+
+  @BeforeAll
+  public static void before() {
+    containerSuite.startHiveContainer();
+
+    // Initial hive client
+    HiveConf hiveConf = new HiveConf();
+    String hiveMetastoreUris =
+        String.format(
+            "thrift://%s:%d",
+            containerSuite.getHiveContainer().getContainerIpAddress(),
+            HiveContainer.HIVE_METASTORE_PORT);
+    hiveConf.set(HiveConf.ConfVars.METASTOREURIS.varname, hiveMetastoreUris);
+  }
+
+  @AfterAll
+  public static void after() {
+    try {
+      closer.close();
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+    }
+  }
+
+  @Test
+  @Order(1)
+  public void testCreateHiveCatalog() throws InterruptedException {
+    // Create metalake first
+    clickAndWait(metalakePage.createMetalakeBtn);
+    metalakePage.setMetalakeNameField(metalakeName);
+    clickAndWait(metalakePage.submitHandleMetalakeBtn);
+    metalakePage.clickMetalakeLink(metalakeName);
+    // Create catalog
+    clickAndWait(catalogsPage.createCatalogBtn);
+    catalogsPage.setCatalogNameField(catalogName);
+    catalogsPage.setCatalogCommentField("catalog comment");
+    String hiveMetastoreUris =
+        String.format(
+            "thrift://%s:%d",
+            containerSuite.getHiveContainer().getContainerIpAddress(),
+            HiveContainer.HIVE_METASTORE_PORT);
+    catalogsPage.setHiveCatalogURI(hiveMetastoreUris);
+    catalogsPage.addCatalogPropsBtn.click();
+    catalogsPage.setCatalogProps(1, "key1", "value1");
+    catalogsPage.addCatalogPropsBtn.click();
+    catalogsPage.setCatalogProps(2, "key2", "value2");
+    clickAndWait(catalogsPage.handleSubmitCatalogBtn);
+
+    Assertions.assertTrue(catalogsPage.verifyCreateHiveCatalog(catalogName));
+  }
+
+  @Test
+  @Order(2)
+  public void testViewTabMetalakeDetails() throws InterruptedException {
+    clickAndWait(catalogsPage.tabDetailsBtn);
+    Assertions.assertTrue(catalogsPage.verifyShowDetailsContent());
+    clickAndWait(catalogsPage.tabTableBtn);
+    Assertions.assertTrue(catalogsPage.verifyShowTableContent());
+  }
+
+  @Test
+  @Order(3)
+  public void testViewCatalogDetails() throws InterruptedException {
+    catalogsPage.clickViewCatalogBtn(catalogName);
+    Assertions.assertTrue(catalogsPage.verifyShowCatalogDetails(catalogName));
+  }
+
+  @Test
+  @Order(4)
+  public void testEditCatalog() throws InterruptedException {
+    catalogsPage.clickEditCatalogBtn(catalogName);
+    catalogsPage.setCatalogNameField(modifiedCatalogName);
+    clickAndWait(catalogsPage.handleSubmitCatalogBtn);
+    Assertions.assertTrue(catalogsPage.verifyEditedCatalog(modifiedCatalogName));
+  }
+
+  @Test
+  @Order(5)
+  public void testClickCatalogLink() {
+    catalogsPage.clickCatalogLink(metalakeName, modifiedCatalogName);
+    Assertions.assertTrue(catalogsPage.verifyShowTableTitle("Schemas"));
+  }
+
+  @Test
+  @Order(6)
+  public void testClickSchemaLink() {
+    catalogsPage.clickSchemaLink(metalakeName, modifiedCatalogName, schemaName);
+    Assertions.assertTrue(catalogsPage.verifyShowTableTitle("Tables"));
+  }
+
+  @Test
+  @Order(7)
+  public void testClickTableLink() {
+    catalogsPage.clickTableLink(metalakeName, modifiedCatalogName, schemaName, tableName);
+    Assertions.assertTrue(catalogsPage.verifyShowTableTitle("Columns"));
+    Assertions.assertTrue(catalogsPage.verifyTableColumns());
+  }
+
+  @Test
+  @Order(8)
+  public void testDeleteCatalog() throws InterruptedException {
+    catalogsPage.clickBreadCrumbsToCatalogs();
+    catalogsPage.clickDeleteCatalogBtn(modifiedCatalogName);
+    clickAndWait(catalogsPage.confirmDeleteBtn);
+    Assertions.assertTrue(catalogsPage.verifyEmptyCatalog());
+  }
+
+  @Test
+  @Order(9)
+  public void testBackHomePage() throws InterruptedException {
+    clickAndWait(catalogsPage.backHomeBtn);
+    Assertions.assertTrue(catalogsPage.verifyBackHomePage());
+  }
+}

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+
+package com.datastrato.gravitino.integration.test.web.ui.pages;
+
+import com.datastrato.gravitino.integration.test.web.ui.utils.AbstractWebIT;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+public class CatalogsPage extends AbstractWebIT {
+
+  @FindBy(xpath = "//*[@data-refer='back-home-btn']")
+  public WebElement backHomeBtn;
+
+  @FindBy(xpath = "//div[@data-refer='table-grid']")
+  public WebElement tableGrid;
+
+  @FindBy(xpath = "//*[@data-refer='create-catalog-btn']")
+  public WebElement createCatalogBtn;
+
+  @FindBy(xpath = "//*[@data-refer='catalog-name-field']//input")
+  public WebElement catalogNameField;
+
+  @FindBy(xpath = "//*[@data-refer='catalog-comment-field']//textarea")
+  public WebElement catalogCommentField;
+
+  @FindBy(xpath = "//button[@data-refer='add-catalog-props']")
+  public WebElement addCatalogPropsBtn;
+
+  @FindBy(xpath = "//*[@data-refer='handle-submit-catalog']")
+  public WebElement handleSubmitCatalogBtn;
+
+  @FindBy(xpath = "//div[@data-refer='tree-view']")
+  public WebElement treeView;
+
+  @FindBy(xpath = "//button[@data-refer='tab-table']")
+  public WebElement tabTableBtn;
+
+  @FindBy(xpath = "//div[@data-refer='tab-table-panel']")
+  public WebElement tabTableContent;
+
+  @FindBy(xpath = "//button[@data-refer='tab-details']")
+  public WebElement tabDetailsBtn;
+
+  @FindBy(xpath = "//div[@data-refer='tab-details-panel']")
+  public WebElement tabDetailsContent;
+
+  @FindBy(xpath = "//div[@data-refer='details-drawer']")
+  public WebElement detailsDrawer;
+
+  @FindBy(xpath = "//h6[@data-refer='details-title']")
+  public WebElement detailsTitle;
+
+  @FindBy(xpath = "//button[@data-refer='close-details-btn']")
+  public WebElement closeDetailsBtn;
+
+  @FindBy(xpath = "//button[@data-refer='confirm-delete']")
+  public WebElement confirmDeleteBtn;
+
+  public CatalogsPage() {
+    PageFactory.initElements(driver, this);
+  }
+
+  public void setCatalogNameField(String nameField) {
+    try {
+      catalogNameField.sendKeys(
+          Keys.chord(Keys.HOME, Keys.chord(Keys.SHIFT, Keys.END), Keys.DELETE));
+      catalogNameField.clear();
+      catalogNameField.sendKeys(nameField);
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+    }
+  }
+
+  public void setCatalogCommentField(String nameField) {
+    try {
+      catalogCommentField.sendKeys(
+          Keys.chord(Keys.HOME, Keys.chord(Keys.SHIFT, Keys.END), Keys.DELETE));
+      catalogCommentField.clear();
+      catalogCommentField.sendKeys(nameField);
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+    }
+  }
+
+  public void setHiveCatalogURI(String value) {
+    try {
+      String xpath = "//div[@data-prev-refer='props-metastore.uris']//input[@name='value']";
+      WebElement keyInput = driver.findElement(By.xpath(xpath));
+      keyInput.sendKeys(value);
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+    }
+  }
+
+  public void setCatalogProps(int index, String key, String value) {
+    try {
+      // Set the indexed props key
+      String keyPath = "//div[@data-refer='props-key-" + index + "']//input[@name='key']";
+      WebElement keyInput = driver.findElement(By.xpath(keyPath));
+      keyInput.sendKeys(key);
+      // Set the indexed props value
+      String valuePath = "//div[@data-refer='props-value-" + index + "']//input[@name='value']";
+      WebElement valueInput = driver.findElement(By.xpath(valuePath));
+      valueInput.sendKeys(value);
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+    }
+  }
+
+  public void clickViewCatalogBtn(String name) {
+    try {
+      String xpath = "//button[@data-refer='view-catalog-" + name + "']";
+      WebElement btn = driver.findElement(By.xpath(xpath));
+      WebDriverWait wait = new WebDriverWait(driver, MAX_TIMEOUT);
+      wait.until(ExpectedConditions.elementToBeClickable(By.xpath(xpath)));
+      clickAndWait(btn);
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+    }
+  }
+
+  public void clickEditCatalogBtn(String name) {
+    try {
+      String xpath = "//button[@data-refer='edit-catalog-" + name + "']";
+      WebElement btn = driver.findElement(By.xpath(xpath));
+      WebDriverWait wait = new WebDriverWait(driver, MAX_TIMEOUT);
+      wait.until(ExpectedConditions.elementToBeClickable(By.xpath(xpath)));
+      clickAndWait(btn);
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+    }
+  }
+
+  public void clickDeleteCatalogBtn(String name) {
+    try {
+      String xpath = "//button[@data-refer='delete-catalog-" + name + "']";
+      WebElement btn = driver.findElement(By.xpath(xpath));
+      WebDriverWait wait = new WebDriverWait(driver, MAX_TIMEOUT);
+      wait.until(ExpectedConditions.elementToBeClickable(By.xpath(xpath)));
+      clickAndWait(btn);
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+    }
+  }
+
+  public void clickCatalogLink(String metalakeName, String catalogName) {
+    try {
+      String xpath = "//a[@href='?metalake=" + metalakeName + "&catalog=" + catalogName + "']";
+      WebElement link = tableGrid.findElement(By.xpath(xpath));
+      WebDriverWait wait = new WebDriverWait(driver, MAX_TIMEOUT);
+      wait.until(ExpectedConditions.elementToBeClickable(By.xpath(xpath)));
+      clickAndWait(link);
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+    }
+  }
+
+  public void clickSchemaLink(String metalakeName, String catalogName, String schemaName) {
+    try {
+      String xpath =
+          "//a[@href='?metalake="
+              + metalakeName
+              + "&catalog="
+              + catalogName
+              + "&schema="
+              + schemaName
+              + "']";
+      WebElement link = tableGrid.findElement(By.xpath(xpath));
+      WebDriverWait wait = new WebDriverWait(driver, MAX_TIMEOUT);
+      wait.until(ExpectedConditions.elementToBeClickable(By.xpath(xpath)));
+      clickAndWait(link);
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+    }
+  }
+
+  public void clickTableLink(
+      String metalakeName, String catalogName, String schemaName, String tableName) {
+    try {
+      String xpath =
+          "//a[@href='?metalake="
+              + metalakeName
+              + "&catalog="
+              + catalogName
+              + "&schema="
+              + schemaName
+              + "&table="
+              + tableName
+              + "']";
+      WebElement link = tableGrid.findElement(By.xpath(xpath));
+      WebDriverWait wait = new WebDriverWait(driver, MAX_TIMEOUT);
+      wait.until(ExpectedConditions.elementToBeClickable(By.xpath(xpath)));
+      clickAndWait(link);
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+    }
+  }
+
+  public void clickBreadCrumbsToCatalogs() {
+    try {
+      String xpath = "//a[@data-refer='metalake-name-link']";
+      WebElement link = tableGrid.findElement(By.xpath(xpath));
+      WebDriverWait wait = new WebDriverWait(driver, MAX_TIMEOUT);
+      wait.until(ExpectedConditions.elementToBeClickable(By.xpath(xpath)));
+      clickAndWait(link);
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+    }
+  }
+
+  public boolean verifyCreateHiveCatalog(String name) {
+    try {
+      String xpath =
+          "//div[contains(@class, 'ant-tree-treenode')]//span[@title='"
+              + name
+              + "']//p[@data-refer='tree-node']";
+      WebElement treeNode = treeView.findElement(By.xpath(xpath));
+      return Objects.equals(treeNode.getText(), name);
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      return false;
+    }
+  }
+
+  public boolean verifyShowTableContent() {
+    try {
+      String table = tabTableContent.getAttribute("hidden");
+      return Objects.equals(table, null);
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      return false;
+    }
+  }
+
+  public boolean verifyShowDetailsContent() {
+    try {
+      String details = tabDetailsContent.getAttribute("hidden");
+      return Objects.equals(details, null);
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      return false;
+    }
+  }
+
+  public boolean verifyShowCatalogDetails(String name) throws InterruptedException {
+    try {
+      // Check the drawer css property value
+      String xpath = "//div[@data-refer='details-drawer']";
+      detailsDrawer = driver.findElement(By.xpath(xpath));
+      WebDriverWait wait = new WebDriverWait(driver, MAX_TIMEOUT);
+      wait.until(ExpectedConditions.visibilityOf(detailsDrawer));
+      String drawerVisible = detailsDrawer.getCssValue("visibility");
+      boolean isVisible = Objects.equals(drawerVisible, "visible");
+      // Check the created catalog name
+      String drawerTitle = detailsTitle.getText();
+      boolean isText = Objects.equals(drawerTitle, name);
+
+      return isVisible && isText;
+    } catch (Exception e) {
+      return false;
+    } finally {
+      clickAndWait(closeDetailsBtn);
+    }
+  }
+
+  public boolean verifyEditedCatalog(String name) {
+    try {
+      String xpath =
+          "//div[contains(@class, 'ant-tree-treenode')]//span[@title='"
+              + name
+              + "']//p[@data-refer='tree-node']";
+      WebElement treeNode = treeView.findElement(By.xpath(xpath));
+      WebDriverWait wait = new WebDriverWait(driver, MAX_TIMEOUT);
+      wait.until(ExpectedConditions.visibilityOf(treeNode));
+
+      // Check if the link text is match with name
+      return Objects.equals(treeNode.getText(), name);
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  public boolean verifyEmptyCatalog() {
+    try {
+      Thread.sleep(ACTION_SLEEP_MILLIS);
+      // Check is empty table
+      String rowXpath =
+          "//div[@data-refer='table-grid']//div[contains(@class, 'MuiDataGrid-overlay')]";
+      WebElement noCatalogRows = tableGrid.findElement(By.xpath(rowXpath));
+      WebDriverWait wait = new WebDriverWait(driver, MAX_TIMEOUT);
+      wait.until(ExpectedConditions.visibilityOf(noCatalogRows));
+      boolean isEmptyTable = Objects.equals(noCatalogRows.getText(), "No rows");
+      Thread.sleep(ACTION_SLEEP_MILLIS);
+      return isEmptyTable;
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      return false;
+    }
+  }
+
+  public boolean verifyShowTableTitle(String title) {
+    try {
+      Thread.sleep(ACTION_SLEEP_MILLIS);
+      WebElement text = tabTableBtn.findElement(By.tagName("p"));
+      WebDriverWait wait = new WebDriverWait(driver, MAX_TIMEOUT);
+      wait.until(ExpectedConditions.visibilityOf(text));
+      return Objects.equals(text.getText(), title);
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      return false;
+    }
+  }
+
+  public boolean verifyTableColumns() {
+    try {
+      List<String> columns = Arrays.asList("Name", "Type", "Nullable", "AutoIncrement", "Comment");
+
+      String columnHeadersXpath =
+          "//div[contains(@class, 'MuiDataGrid-columnHeaders')]//div[@role='row']";
+      WebElement columnHeaders = driver.findElement(By.xpath(columnHeadersXpath));
+      List<WebElement> columnHeadersRows =
+          columnHeaders.findElements(By.xpath("./div[@role='columnheader']"));
+      if (columnHeadersRows.size() != columns.size()) {
+        LOG.error("Column headers count does not match expected: {}", columns.size());
+        return false;
+      }
+
+      for (int i = 0; i < columnHeadersRows.size(); i++) {
+        String headerText = columnHeadersRows.get(i).getText();
+        if (!headerText.equals(columns.get(i))) {
+          LOG.error("Column header '{}' does not match expected '{}'", headerText, columns.get(i));
+          return false;
+        }
+      }
+
+      return true;
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      return false;
+    }
+  }
+
+  public boolean verifyBackHomePage() {
+    try {
+      Thread.sleep(ACTION_SLEEP_MILLIS);
+      String xpath = "//p[@data-refer='metalake-page-title']";
+      WebElement title = driver.findElement(By.xpath(xpath));
+      WebDriverWait wait = new WebDriverWait(driver, MAX_TIMEOUT);
+      wait.until(ExpectedConditions.visibilityOf(title));
+      return Objects.equals(title.getText(), "Metalakes");
+    } catch (Exception e) {
+      return false;
+    }
+  }
+}

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
@@ -83,6 +83,9 @@ public class CatalogsPage extends AbstractWebIT {
   @FindBy(xpath = "//*[@data-refer='metalake-page-title']")
   public WebElement metalakePageTitle;
 
+  @FindBy(xpath = "//*[@data-refer='details-props-table']")
+  public WebElement detailsPropsTable;
+
   public CatalogsPage() {
     PageFactory.initElements(driver, this);
   }
@@ -268,7 +271,8 @@ public class CatalogsPage extends AbstractWebIT {
     }
   }
 
-  public boolean verifyShowCatalogDetails(String name) throws InterruptedException {
+  public boolean verifyShowCatalogDetails(String name, String hiveMetastoreUris)
+      throws InterruptedException {
     try {
       // Check the drawer css property value
       WebDriverWait wait = new WebDriverWait(driver, MAX_TIMEOUT);
@@ -279,7 +283,19 @@ public class CatalogsPage extends AbstractWebIT {
       String drawerTitle = detailsTitle.getText();
       boolean isText = Objects.equals(drawerTitle, name);
 
-      return isVisible && isText;
+      // Since the provided catalog attributes are known and fixed, validation is also performed on
+      // these values.
+      boolean isHiveURIS =
+          waitShowText(
+              hiveMetastoreUris,
+              By.xpath(".//*[@data-prev-refer='details-props-key-metastore.uris']"));
+      boolean isShowCheck =
+          waitShowText(
+              "false",
+              By.xpath(
+                  ".//*[@data-prev-refer='details-props-key-gravitino.bypass.hive.metastore.client.capability.check']"));
+
+      return isVisible && isText && isHiveURIS && isShowCheck;
     } catch (Exception e) {
       LOG.error(e.getMessage(), e);
       return false;

--- a/web/src/app/metalakes/layout.js
+++ b/web/src/app/metalakes/layout.js
@@ -20,7 +20,9 @@ const MetalakesView = ({ children }) => {
       ) : (
         <Grid container spacing={6}>
           <Grid item xs={12}>
-            <Typography className={'twc-mb-4 twc-text-[1.375rem] twc-font-bold'}>Metalakes</Typography>
+            <Typography className={'twc-mb-4 twc-text-[1.375rem] twc-font-bold'} data-refer='metalake-page-title'>
+              Metalakes
+            </Typography>
             <Typography sx={{ color: 'text.secondary' }}>
               A metalake is the top-level container for data in Gravitino. Within a metalake, Gravitino provides a
               3-level namespace for organizing data: catalog, schemas/databases, and tables/views.

--- a/web/src/app/metalakes/metalake/MetalakeTree.js
+++ b/web/src/app/metalakes/metalake/MetalakeTree.js
@@ -151,7 +151,11 @@ const MetalakeTree = props => {
 
   const renderNode = nodeData => {
     if (nodeData.path) {
-      return <Typography sx={{ color: theme => theme.palette.text.secondary }}>{nodeData.title}</Typography>
+      return (
+        <Typography sx={{ color: theme => theme.palette.text.secondary }} data-refer='tree-node'>
+          {nodeData.title}
+        </Typography>
+      )
     }
 
     return nodeData.title
@@ -206,6 +210,7 @@ const MetalakeTree = props => {
           '[&_.ant-tree-node-content-wrapper]:twc-items-center',
           '[&_.ant-tree-node-content-wrapper]:twc-leading-[28px]'
         ])}
+        data-refer='tree-view'
         icon={nodeProps => renderIcon(nodeProps)}
         titleRender={nodeData => renderNode(nodeData)}
       />

--- a/web/src/app/metalakes/metalake/rightContent/CreateCatalogDialog.js
+++ b/web/src/app/metalakes/metalake/rightContent/CreateCatalogDialog.js
@@ -382,6 +382,7 @@ const CreateCatalogDialog = props => {
                       onChange={onChange}
                       placeholder=''
                       error={Boolean(errors.name)}
+                      data-refer='catalog-name-field'
                     />
                   )}
                 />
@@ -463,13 +464,14 @@ const CreateCatalogDialog = props => {
                       onChange={onChange}
                       placeholder=''
                       error={Boolean(errors.comment)}
+                      data-refer='catalog-comment-field'
                     />
                   )}
                 />
               </FormControl>
             </Grid>
 
-            <Grid item xs={12}>
+            <Grid item xs={12} data-refer='catalog-props-layout'>
               <Typography sx={{ mb: 2 }} variant='body2'>
                 Properties
               </Typography>
@@ -480,7 +482,10 @@ const CreateCatalogDialog = props => {
                       <Grid item xs={12} sx={{ '& + &': { mt: 2 } }}>
                         <FormControl fullWidth>
                           <Box>
-                            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                            <Box
+                              sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}
+                              data-refer={`catalog-props-${index}`}
+                            >
                               <Box>
                                 <TextField
                                   size='small'
@@ -490,6 +495,7 @@ const CreateCatalogDialog = props => {
                                   disabled={item.required}
                                   onChange={event => handleFormChange({ index, event })}
                                   error={item.hasDuplicateKey}
+                                  data-refer={`props-key-${index}`}
                                 />
                               </Box>
                               <Box>
@@ -501,6 +507,8 @@ const CreateCatalogDialog = props => {
                                     sx={{ width: 195 }}
                                     disabled={item.disabled}
                                     onChange={event => handleFormChange({ index, event })}
+                                    data-refer={`props-value-${index}`}
+                                    data-prev-refer={`props-${item.key}`}
                                   >
                                     {item.select.map(selectItem => (
                                       <MenuItem key={selectItem} value={selectItem}>
@@ -517,6 +525,8 @@ const CreateCatalogDialog = props => {
                                     value={item.value}
                                     disabled={item.disabled}
                                     onChange={event => handleFormChange({ index, event })}
+                                    data-refer={`props-value-${index}`}
+                                    data-prev-refer={`props-${item.key}`}
                                   />
                                 )}
                               </Box>
@@ -563,6 +573,7 @@ const CreateCatalogDialog = props => {
                 onClick={addFields}
                 variant='outlined'
                 startIcon={<Icon icon='mdi:plus-circle-outline' />}
+                data-refer='add-catalog-props'
               >
                 Add Property
               </Button>
@@ -576,7 +587,7 @@ const CreateCatalogDialog = props => {
             pb: theme => [`${theme.spacing(5)} !important`, `${theme.spacing(12.5)} !important`]
           }}
         >
-          <Button variant='contained' sx={{ mr: 1 }} type='submit'>
+          <Button variant='contained' sx={{ mr: 1 }} type='submit' data-refer='handle-submit-catalog'>
             {type === 'create' ? 'Create' : 'Update'}
           </Button>
           <Button variant='outlined' onClick={handleClose}>

--- a/web/src/app/metalakes/metalake/rightContent/MetalakePath.js
+++ b/web/src/app/metalakes/metalake/rightContent/MetalakePath.js
@@ -71,7 +71,7 @@ const MetalakePath = props => {
             underline='hover'
           >
             <Icon icon='bx:book' fontSize={20} />
-            <Text>{catalog}</Text>
+            <Text data-refer={`nav-to-catalog-${catalog}`}>{catalog}</Text>
           </MUILink>
         </Tooltip>
       )}
@@ -79,7 +79,7 @@ const MetalakePath = props => {
         <Tooltip title={schema} placement='top'>
           <MUILink component={Link} href={schemaUrl} onClick={event => handleClick(event, schemaUrl)} underline='hover'>
             <Icon icon='bx:coin-stack' fontSize={20} />
-            <Text>{schema}</Text>
+            <Text data-refer={`nav-to-schema-${schema}`}>{schema}</Text>
           </MUILink>
         </Tooltip>
       )}
@@ -87,7 +87,7 @@ const MetalakePath = props => {
         <Tooltip title={table} placement='top'>
           <MUILink component={Link} href={tableUrl} onClick={event => handleClick(event, tableUrl)} underline='hover'>
             <Icon icon='bx:table' fontSize={20} />
-            <Text>{table}</Text>
+            <Text data-refer={`nav-to-table-${table}`}>{table}</Text>
           </MUILink>
         </Tooltip>
       )}

--- a/web/src/app/metalakes/metalake/rightContent/tabsContent/TabsContent.js
+++ b/web/src/app/metalakes/metalake/rightContent/tabsContent/TabsContent.js
@@ -80,14 +80,14 @@ const TabsContent = () => {
     <TabContext value={tab}>
       <Box sx={{ px: 6, py: 2, borderBottom: 1, borderColor: 'divider' }}>
         <TabList onChange={handleChangeTab} aria-label='tabs'>
-          <CustomTab icon='mdi:list-box-outline' label={tableTitle} value='table' />
-          <CustomTab icon='mdi:clipboard-text-outline' label='Details' value='details' />
+          <CustomTab icon='mdi:list-box-outline' label={tableTitle} value='table' data-refer='tab-table' />
+          <CustomTab icon='mdi:clipboard-text-outline' label='Details' value='details' data-refer='tab-details' />
         </TabList>
       </Box>
-      <CustomTabPanel value='table'>
+      <CustomTabPanel value='table' data-refer='tab-table-panel'>
         <TableView />
       </CustomTabPanel>
-      <CustomTabPanel value='details'>
+      <CustomTabPanel value='details' data-refer='tab-details-panel'>
         <DetailsView />
       </CustomTabPanel>
     </TabContext>

--- a/web/src/app/metalakes/metalake/rightContent/tabsContent/tableView/TableView.js
+++ b/web/src/app/metalakes/metalake/rightContent/tabsContent/tableView/TableView.js
@@ -151,6 +151,7 @@ const TableView = () => {
             size='small'
             sx={{ color: theme => theme.palette.text.secondary }}
             onClick={() => handleShowDetails({ row, type: 'catalog' })}
+            data-refer={`view-catalog-${row.name}`}
           >
             <ViewIcon viewBox='0 0 24 22' />
           </IconButton>
@@ -160,6 +161,7 @@ const TableView = () => {
             size='small'
             sx={{ color: theme => theme.palette.text.secondary }}
             onClick={() => handleShowEditDialog({ row, type: 'catalog' })}
+            data-refer={`edit-catalog-${row.name}`}
           >
             <EditIcon />
           </IconButton>
@@ -169,6 +171,7 @@ const TableView = () => {
             size='small'
             sx={{ color: theme => theme.palette.error.light }}
             onClick={() => handleDelete({ name: row.name, type: 'catalog' })}
+            data-refer={`delete-catalog-${row.name}`}
           >
             <DeleteIcon />
           </IconButton>
@@ -387,6 +390,7 @@ const TableView = () => {
             borderTop: 0
           }
         }}
+        data-refer='table-grid'
         loading={store.tableLoading}
         rows={store.tableData}
         getRowId={row => row?.name}

--- a/web/src/components/DetailsDrawer.js
+++ b/web/src/components/DetailsDrawer.js
@@ -183,12 +183,20 @@ const DetailsDrawer = props => {
                   <TableCell sx={{ py: 2 }}>Value</TableCell>
                 </TableRow>
               </TableHead>
-              <TableBody>
+              <TableBody data-refer='details-props-table'>
                 {properties.map((item, index) => {
                   return (
-                    <TableRow key={index}>
-                      <TableCell className={'twc-py-[0.7rem]'}>{item.key}</TableCell>
-                      <TableCell className={'twc-py-[0.7rem]'}>{item.value}</TableCell>
+                    <TableRow key={index} data-refer={`details-props-index-${index}`}>
+                      <TableCell className={'twc-py-[0.7rem]'} data-refer={`details-props-key-${item.key}`}>
+                        {item.key}
+                      </TableCell>
+                      <TableCell
+                        className={'twc-py-[0.7rem]'}
+                        data-refer={`details-props-value-${item.value}`}
+                        data-prev-refer={`details-props-key-${item.key}`}
+                      >
+                        {item.value}
+                      </TableCell>
                     </TableRow>
                   )
                 })}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add catalogs page to web e2e test.
- show parent details
- create a catalog
- view existed catalog details
- edit existed catalog
- delete existed catalog
- link to schemas
- link to tables
- back to homepage

### Why are the changes needed?

Fix: #2436

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
