### PR TITLE
[#2479] Refactor: Refine the Java client interfaces to make it easier to use 

### DIFF
--- a/catalogs/catalog-hadoop/src/test/java/com/datastrato/gravitino/catalog/hadoop/integration/test/HadoopCatalogIT.java
+++ b/catalogs/catalog-hadoop/src/test/java/com/datastrato/gravitino/catalog/hadoop/integration/test/HadoopCatalogIT.java
@@ -7,6 +7,7 @@ package com.datastrato.gravitino.catalog.hadoop.integration.test;
 import com.datastrato.gravitino.Catalog;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
+import com.datastrato.gravitino.client.FilesetCatalog;
 import com.datastrato.gravitino.client.GravitinoMetaLake;
 import com.datastrato.gravitino.exceptions.FilesetAlreadyExistsException;
 import com.datastrato.gravitino.exceptions.NoSuchFilesetException;
@@ -48,7 +49,7 @@ public class HadoopCatalogIT extends AbstractIT {
   public static final String schemaName = GravitinoITUtils.genRandomName(SCHEMA_PREFIX);
   private static final String provider = "hadoop";
   private static GravitinoMetaLake metalake;
-  private static Catalog catalog;
+  private static FilesetCatalog catalog;
   private static FileSystem hdfs;
   private static String defaultBaseLocation;
 
@@ -100,7 +101,7 @@ public class HadoopCatalogIT extends AbstractIT {
         "comment",
         ImmutableMap.of());
 
-    catalog = metalake.loadCatalog(NameIdentifier.of(metalakeName, catalogName));
+    catalog = (FilesetCatalog) metalake.loadCatalog(NameIdentifier.of(metalakeName, catalogName));
   }
 
   private static void createSchema() {
@@ -111,8 +112,8 @@ public class HadoopCatalogIT extends AbstractIT {
     properties.put("location", defaultBaseLocation());
     String comment = "comment";
 
-    catalog.asSchemas().createSchema(ident, comment, properties);
-    Schema loadSchema = catalog.asSchemas().loadSchema(ident);
+    catalog.createSchema(ident.name(), comment, properties);
+    Schema loadSchema = catalog.loadSchema(ident.name());
     Assertions.assertEquals(schemaName, loadSchema.name());
     Assertions.assertEquals(comment, loadSchema.comment());
     Assertions.assertEquals("val1", loadSchema.properties().get("key1"));
@@ -121,9 +122,8 @@ public class HadoopCatalogIT extends AbstractIT {
   }
 
   private static void dropSchema() {
-    NameIdentifier ident = NameIdentifier.of(metalakeName, catalogName, schemaName);
-    catalog.asSchemas().dropSchema(ident, true);
-    Assertions.assertFalse(catalog.asSchemas().schemaExists(ident));
+    catalog.dropSchema(schemaName, true);
+    Assertions.assertFalse(catalog.schemaExists(schemaName));
   }
 
   @Test

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/integration/test/ProxyCatalogHiveIT.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/integration/test/ProxyCatalogHiveIT.java
@@ -13,7 +13,7 @@ import com.datastrato.gravitino.Configs;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.auth.AuthenticatorType;
 import com.datastrato.gravitino.catalog.hive.HiveClientPool;
-import com.datastrato.gravitino.client.GravitinoClient;
+import com.datastrato.gravitino.client.GravitinoAdminClient;
 import com.datastrato.gravitino.client.GravitinoMetaLake;
 import com.datastrato.gravitino.dto.rel.partitioning.Partitioning;
 import com.datastrato.gravitino.integration.test.container.ContainerSuite;
@@ -69,7 +69,7 @@ public class ProxyCatalogHiveIT extends AbstractIT {
   private static String HIVE_METASTORE_URIS;
   private static FileSystem hdfs;
   private static String originHadoopUser;
-  private static GravitinoClient anotherClient;
+  private static GravitinoAdminClient anotherClient;
   private static Catalog anotherCatalog;
 
   @BeforeAll
@@ -108,7 +108,7 @@ public class ProxyCatalogHiveIT extends AbstractIT {
 
     String uri = "http://" + jettyServerConfig.getHost() + ":" + jettyServerConfig.getHttpPort();
     System.setProperty("user.name", "test");
-    anotherClient = GravitinoClient.builder(uri).withSimpleAuth().build();
+    anotherClient = GravitinoAdminClient.builder(uri).withSimpleAuth().build();
     createMetalake();
     createCatalog();
     loadCatalogWithAnotherClient();

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/integration/test/ProxyCatalogHiveIT.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/integration/test/ProxyCatalogHiveIT.java
@@ -149,7 +149,8 @@ public class ProxyCatalogHiveIT extends AbstractIT {
             anotherSchemaName.toLowerCase()));
     Exception e =
         Assertions.assertThrows(
-            RuntimeException.class, () -> anotherCatalog.createSchema(anotherIdent.name(), comment, properties));
+            RuntimeException.class,
+            () -> anotherCatalog.createSchema(anotherIdent.name(), comment, properties));
     Assertions.assertTrue(e.getMessage().contains("AccessControlException Permission denied"));
   }
 
@@ -230,16 +231,17 @@ public class ProxyCatalogHiveIT extends AbstractIT {
     Column[] columns = createColumns();
 
     RelationalTable table =
-            (RelationalTable)catalog
-            .asTableCatalog()
-            .createTable(
-                nameIdentifier,
-                columns,
-                "comment",
-                createProperties(),
-                new Transform[] {
-                  Transforms.identity(columns[1].name()), Transforms.identity(columns[2].name())
-                });
+        (RelationalTable)
+            catalog
+                .asTableCatalog()
+                .createTable(
+                    nameIdentifier,
+                    columns,
+                    "comment",
+                    createProperties(),
+                    new Transform[] {
+                      Transforms.identity(columns[1].name()), Transforms.identity(columns[2].name())
+                    });
 
     // add partition "col2=2023-01-02/col3=gravitino_it_test2" by user datastrato
     String[] field1 = new String[] {"col2"};
@@ -271,9 +273,7 @@ public class ProxyCatalogHiveIT extends AbstractIT {
         Assertions.assertThrows(
             RuntimeException.class,
             () ->
-                tableCatalog
-                    .loadTable(nameIdentifier)
-                    .supportPartitions()
+                ((RelationalTable) tableCatalog.loadTable(nameIdentifier))
                     .addPartition(anotherIdentity));
     Assertions.assertTrue(e.getMessage().contains("AccessControlException Permission denied"));
   }
@@ -316,12 +316,14 @@ public class ProxyCatalogHiveIT extends AbstractIT {
         "comment",
         properties);
 
-    catalog = (RelationalCatalog)metalake.loadCatalog(NameIdentifier.of(METALAKE_NAME, CATALOG_NAME));
+    catalog =
+        (RelationalCatalog) metalake.loadCatalog(NameIdentifier.of(METALAKE_NAME, CATALOG_NAME));
   }
 
   private static void loadCatalogWithAnotherClient() {
     GravitinoMetaLake metaLake = anotherClient.loadMetalake(NameIdentifier.of(METALAKE_NAME));
-    anotherCatalog = (RelationalCatalog)metaLake.loadCatalog(NameIdentifier.of(METALAKE_NAME, CATALOG_NAME));
+    anotherCatalog =
+        (RelationalCatalog) metaLake.loadCatalog(NameIdentifier.of(METALAKE_NAME, CATALOG_NAME));
   }
 
   public static void setEnv(String key, String value) {

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/BaseSchemaCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/BaseSchemaCatalog.java
@@ -39,7 +39,7 @@ abstract class BaseSchemaCatalog extends CatalogDTO {
 
   /** The REST client to send the requests. */
   protected final RESTClient restClient;
-  /** the namespace of current catalog */
+  /** The namespace of current catalog, which is the metalake name. */
   protected final Namespace namespace;
 
   BaseSchemaCatalog(

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/BaseSchemaCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/BaseSchemaCatalog.java
@@ -192,6 +192,21 @@ abstract class BaseSchemaCatalog extends CatalogDTO {
     }
   }
 
+  /**
+   * Check if a schema exists.
+   *
+   * @param schemaName The name of the schema.
+   * @return True if the schema exists, false otherwise.
+   */
+  public boolean schemaExists(String schemaName) {
+    try {
+      loadSchema(schemaName);
+      return true;
+    } catch (NoSuchSchemaException e) {
+      return false;
+    }
+  }
+
   @VisibleForTesting
   static String formatSchemaRequestPath(Namespace ns) {
     return new StringBuilder()

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/BaseSchemaCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/BaseSchemaCatalog.java
@@ -65,9 +65,10 @@ abstract class BaseSchemaCatalog extends CatalogDTO {
    */
   public NameIdentifier[] listSchemas() throws NoSuchCatalogException {
 
+    Namespace namespaceForSchema = Namespace.ofSchema(namespace.level(0), this.name());
     EntityListResponse resp =
         restClient.get(
-            formatSchemaRequestPath(namespace),
+            formatSchemaRequestPath(namespaceForSchema),
             EntityListResponse.class,
             Collections.emptyMap(),
             ErrorHandlers.schemaErrorHandler());

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/DTOConverters.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/DTOConverters.java
@@ -7,6 +7,7 @@ package com.datastrato.gravitino.client;
 import com.datastrato.gravitino.Catalog;
 import com.datastrato.gravitino.CatalogChange;
 import com.datastrato.gravitino.MetalakeChange;
+import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.dto.AuditDTO;
 import com.datastrato.gravitino.dto.CatalogDTO;
 import com.datastrato.gravitino.dto.MetalakeDTO;
@@ -56,7 +57,8 @@ class DTOConverters {
     }
   }
 
-  static Catalog toCatalog(CatalogDTO catalog, RESTClient client) {
+  static Catalog toCatalog(String metalake, CatalogDTO catalog, RESTClient client) {
+    Namespace namespace = Namespace.ofCatalog(metalake);
     switch (catalog.type()) {
       case RELATIONAL:
         return RelationalCatalog.builder()
@@ -67,6 +69,7 @@ class DTOConverters {
             .withProperties(catalog.properties())
             .withAudit((AuditDTO) catalog.auditInfo())
             .withRestClient(client)
+            .withNamespace(namespace)
             .build();
 
       case FILESET:
@@ -78,6 +81,7 @@ class DTOConverters {
             .withProperties(catalog.properties())
             .withAudit((AuditDTO) catalog.auditInfo())
             .withRestClient(client)
+            .withNamespace(namespace)
             .build();
 
       case MESSAGING:

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/FilesetCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/FilesetCatalog.java
@@ -37,6 +37,7 @@ public class FilesetCatalog extends BaseSchemaCatalog
     implements com.datastrato.gravitino.file.FilesetCatalog {
 
   FilesetCatalog(
+      Namespace namespace,
       String name,
       Type type,
       String provider,
@@ -44,7 +45,7 @@ public class FilesetCatalog extends BaseSchemaCatalog
       Map<String, String> properties,
       AuditDTO auditDTO,
       RESTClient restClient) {
-    super(name, type, provider, comment, properties, auditDTO, restClient);
+    super(namespace, name, type, provider, comment, properties, auditDTO, restClient);
   }
 
   @Override
@@ -225,6 +226,9 @@ public class FilesetCatalog extends BaseSchemaCatalog
     /** The REST client to send the requests. */
     private RESTClient restClient;
 
+    /** The namespace of the catalog */
+    private Namespace namespace;
+
     private Builder() {}
 
     Builder withRestClient(RESTClient restClient) {
@@ -232,15 +236,22 @@ public class FilesetCatalog extends BaseSchemaCatalog
       return this;
     }
 
+    Builder withNamespace(Namespace namespace) {
+      this.namespace = namespace;
+      return this;
+    }
+
     @Override
     public FilesetCatalog build() {
+      Namespace.checkMetalake(namespace);
       Preconditions.checkArgument(restClient != null, "restClient must be set");
       Preconditions.checkArgument(StringUtils.isNotBlank(name), "name must not be blank");
       Preconditions.checkArgument(type != null, "type must not be null");
       Preconditions.checkArgument(StringUtils.isNotBlank(provider), "provider must not be blank");
       Preconditions.checkArgument(audit != null, "audit must not be null");
 
-      return new FilesetCatalog(name, type, provider, comment, properties, audit, restClient);
+      return new FilesetCatalog(
+          namespace, name, type, provider, comment, properties, audit, restClient);
     }
   }
 }

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/FilesetCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/FilesetCatalog.java
@@ -243,7 +243,7 @@ public class FilesetCatalog extends BaseSchemaCatalog
 
     @Override
     public FilesetCatalog build() {
-      Namespace.checkMetalake(namespace);
+      Namespace.checkCatalog(namespace);
       Preconditions.checkArgument(restClient != null, "restClient must be set");
       Preconditions.checkArgument(StringUtils.isNotBlank(name), "name must not be blank");
       Preconditions.checkArgument(type != null, "type must not be null");

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoAdminClient.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoAdminClient.java
@@ -163,64 +163,20 @@ public class GravitinoAdminClient extends GravitinoClientBase implements Support
    * @param uri The base URI for the Gravitino API.
    * @return A new instance of the Builder class for constructing a GravitinoClient.
    */
-  public static Builder builder(String uri) {
-    return new Builder(uri);
+  public static Builder<GravitinoAdminClient> builder(String uri) {
+    return new AdminClientBuilder(uri);
   }
 
-  /** Builder class for constructing a GravitinoClient. */
-  public static class Builder {
-
-    private String uri;
-    private AuthDataProvider authDataProvider;
+  /** Builder class for constructing a GravitinoAdminClient. */
+  static class AdminClientBuilder extends GravitinoClientBase.Builder<GravitinoAdminClient> {
 
     /**
      * The private constructor for the Builder class.
      *
      * @param uri The base URI for the Gravitino API.
      */
-    private Builder(String uri) {
-      this.uri = uri;
-    }
-
-    /**
-     * Sets the simple mode authentication for Gravitino
-     *
-     * @return This Builder instance for method chaining.
-     */
-    public Builder withSimpleAuth() {
-      this.authDataProvider = new SimpleTokenProvider();
-      return this;
-    }
-
-    /**
-     * Sets OAuth2TokenProvider for the GravitinoClient.
-     *
-     * @param dataProvider The OAuth2TokenProvider used as the provider of authentication data for
-     *     GravitinoClient.
-     * @return This Builder instance for method chaining.
-     */
-    public Builder withOAuth(OAuth2TokenProvider dataProvider) {
-      this.authDataProvider = dataProvider;
-      return this;
-    }
-
-    /**
-     * Sets KerberosTokenProvider for the GravitinoClient.
-     *
-     * @param dataProvider The KerberosTokenProvider used as the provider of authentication data for
-     *     GravitinoClient.
-     * @return This Builder instance for method chaining.
-     */
-    public Builder withKerberosAuth(KerberosTokenProvider dataProvider) {
-      try {
-        if (uri != null) {
-          dataProvider.setHost(new URI(uri).getHost());
-        }
-      } catch (URISyntaxException ue) {
-        throw new IllegalArgumentException("URI has the wrong format", ue);
-      }
-      this.authDataProvider = dataProvider;
-      return this;
+    protected AdminClientBuilder(String uri) {
+      super(uri);
     }
 
     /**
@@ -229,6 +185,7 @@ public class GravitinoAdminClient extends GravitinoClientBase implements Support
      * @return A new instance of GravitinoClient with the specified base URI.
      * @throws IllegalArgumentException If the base URI is null or empty.
      */
+    @Override
     public GravitinoAdminClient build() {
       Preconditions.checkArgument(
           uri != null && !uri.isEmpty(), "The argument 'uri' must be a valid URI");

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoAdminClient.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoAdminClient.java
@@ -7,7 +7,6 @@ package com.datastrato.gravitino.client;
 
 import com.datastrato.gravitino.MetalakeChange;
 import com.datastrato.gravitino.NameIdentifier;
-import com.datastrato.gravitino.SupportsMetalakes;
 import com.datastrato.gravitino.dto.requests.MetalakeCreateRequest;
 import com.datastrato.gravitino.dto.requests.MetalakeUpdateRequest;
 import com.datastrato.gravitino.dto.requests.MetalakeUpdatesRequest;
@@ -31,7 +30,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Normal users should use {@link GravitinoClient} to connect with the Gravitino server.
  */
-public class GravitinoAdminClient extends GravitinoClientBase implements SupportsMetalakes {
+public class GravitinoAdminClient extends GravitinoClientBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(GravitinoAdminClient.class);
 
@@ -50,7 +49,6 @@ public class GravitinoAdminClient extends GravitinoClientBase implements Support
    *
    * @return An array of GravitinoMetaLake objects representing the Metalakes.
    */
-  @Override
   public GravitinoMetaLake[] listMetalakes() {
     MetalakeListResponse resp =
         restClient.get(
@@ -75,7 +73,6 @@ public class GravitinoAdminClient extends GravitinoClientBase implements Support
    * @throws MetalakeAlreadyExistsException If a Metalake with the specified identifier already
    *     exists.
    */
-  @Override
   public GravitinoMetaLake createMetalake(
       NameIdentifier ident, String comment, Map<String, String> properties)
       throws MetalakeAlreadyExistsException {
@@ -105,7 +102,6 @@ public class GravitinoAdminClient extends GravitinoClientBase implements Support
    * @throws NoSuchMetalakeException If the specified Metalake does not exist.
    * @throws IllegalArgumentException If the provided changes are invalid or not applicable.
    */
-  @Override
   public GravitinoMetaLake alterMetalake(NameIdentifier ident, MetalakeChange... changes)
       throws NoSuchMetalakeException, IllegalArgumentException {
     NameIdentifier.checkMetalake(ident);
@@ -135,7 +131,6 @@ public class GravitinoAdminClient extends GravitinoClientBase implements Support
    * @param ident The identifier of the Metalake to be dropped.
    * @return True if the Metalake was successfully dropped, false otherwise.
    */
-  @Override
   public boolean dropMetalake(NameIdentifier ident) {
     NameIdentifier.checkMetalake(ident);
 

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoAdminClient.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoAdminClient.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+
+package com.datastrato.gravitino.client;
+
+import com.datastrato.gravitino.MetalakeChange;
+import com.datastrato.gravitino.NameIdentifier;
+import com.datastrato.gravitino.SupportsMetalakes;
+import com.datastrato.gravitino.dto.requests.MetalakeCreateRequest;
+import com.datastrato.gravitino.dto.requests.MetalakeUpdateRequest;
+import com.datastrato.gravitino.dto.requests.MetalakeUpdatesRequest;
+import com.datastrato.gravitino.dto.responses.DropResponse;
+import com.datastrato.gravitino.dto.responses.MetalakeListResponse;
+import com.datastrato.gravitino.dto.responses.MetalakeResponse;
+import com.datastrato.gravitino.exceptions.MetalakeAlreadyExistsException;
+import com.datastrato.gravitino.exceptions.NoSuchMetalakeException;
+import com.google.common.base.Preconditions;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Gravitino Client for administrator to interacte with the Gravitino API, allowing the client to
+ * list, load, create, and alter Metalakes.
+ *
+ * <p>Normal users should use {@link GravitinoClient} to connect with the Gravitino server.
+ */
+public class GravitinoAdminClient extends GravitinoClientBase implements SupportsMetalakes {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GravitinoAdminClient.class);
+
+  /**
+   * Constructs a new GravitinoClient with the given URI, authenticator and AuthDataProvider.
+   *
+   * @param uri The base URI for the Gravitino API.
+   * @param authDataProvider The provider of the data which is used for authentication.
+   */
+  private GravitinoAdminClient(String uri, AuthDataProvider authDataProvider) {
+    super(uri, authDataProvider);
+  }
+
+  /**
+   * Retrieves a list of Metalakes from the Gravitino API.
+   *
+   * @return An array of GravitinoMetaLake objects representing the Metalakes.
+   */
+  @Override
+  public GravitinoMetaLake[] listMetalakes() {
+    MetalakeListResponse resp =
+        restClient.get(
+            API_METALAKES_LIST_PATH,
+            MetalakeListResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.metalakeErrorHandler());
+    resp.validate();
+
+    return Arrays.stream(resp.getMetalakes())
+        .map(o -> DTOConverters.toMetaLake(o, restClient))
+        .toArray(GravitinoMetaLake[]::new);
+  }
+
+  /**
+   * Creates a new Metalake using the Gravitino API.
+   *
+   * @param ident The identifier of the new Metalake.
+   * @param comment The comment for the new Metalake.
+   * @param properties The properties of the new Metalake.
+   * @return A GravitinoMetaLake instance representing the newly created Metalake.
+   * @throws MetalakeAlreadyExistsException If a Metalake with the specified identifier already
+   *     exists.
+   */
+  @Override
+  public GravitinoMetaLake createMetalake(
+      NameIdentifier ident, String comment, Map<String, String> properties)
+      throws MetalakeAlreadyExistsException {
+    NameIdentifier.checkMetalake(ident);
+
+    MetalakeCreateRequest req = new MetalakeCreateRequest(ident.name(), comment, properties);
+    req.validate();
+
+    MetalakeResponse resp =
+        restClient.post(
+            API_METALAKES_LIST_PATH,
+            req,
+            MetalakeResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.metalakeErrorHandler());
+    resp.validate();
+
+    return DTOConverters.toMetaLake(resp.getMetalake(), restClient);
+  }
+
+  /**
+   * Alters a specific Metalake using the Gravitino API.
+   *
+   * @param ident The identifier of the Metalake to be altered.
+   * @param changes The changes to be applied to the Metalake.
+   * @return A GravitinoMetaLake instance representing the updated Metalake.
+   * @throws NoSuchMetalakeException If the specified Metalake does not exist.
+   * @throws IllegalArgumentException If the provided changes are invalid or not applicable.
+   */
+  @Override
+  public GravitinoMetaLake alterMetalake(NameIdentifier ident, MetalakeChange... changes)
+      throws NoSuchMetalakeException, IllegalArgumentException {
+    NameIdentifier.checkMetalake(ident);
+
+    List<MetalakeUpdateRequest> reqs =
+        Arrays.stream(changes)
+            .map(DTOConverters::toMetalakeUpdateRequest)
+            .collect(Collectors.toList());
+    MetalakeUpdatesRequest updatesRequest = new MetalakeUpdatesRequest(reqs);
+    updatesRequest.validate();
+
+    MetalakeResponse resp =
+        restClient.put(
+            API_METALAKES_IDENTIFIER_PATH + ident.name(),
+            updatesRequest,
+            MetalakeResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.metalakeErrorHandler());
+    resp.validate();
+
+    return DTOConverters.toMetaLake(resp.getMetalake(), restClient);
+  }
+
+  /**
+   * Drops a specific Metalake using the Gravitino API.
+   *
+   * @param ident The identifier of the Metalake to be dropped.
+   * @return True if the Metalake was successfully dropped, false otherwise.
+   */
+  @Override
+  public boolean dropMetalake(NameIdentifier ident) {
+    NameIdentifier.checkMetalake(ident);
+
+    try {
+      DropResponse resp =
+          restClient.delete(
+              API_METALAKES_IDENTIFIER_PATH + ident.name(),
+              DropResponse.class,
+              Collections.emptyMap(),
+              ErrorHandlers.metalakeErrorHandler());
+      resp.validate();
+      return resp.dropped();
+
+    } catch (Exception e) {
+      LOG.warn("Failed to drop metadata {}", ident, e);
+      return false;
+    }
+  }
+
+  /** Closes the GravitinoClient and releases any underlying resources. */
+  @Override
+  public void close() {
+    if (restClient != null) {
+      try {
+        restClient.close();
+      } catch (Exception e) {
+        // Swallow the exception
+        LOG.warn("Failed to close the HTTP REST client", e);
+      }
+    }
+  }
+
+  /**
+   * Creates a new builder for constructing a GravitinoClient.
+   *
+   * @param uri The base URI for the Gravitino API.
+   * @return A new instance of the Builder class for constructing a GravitinoClient.
+   */
+  public static Builder builder(String uri) {
+    return new Builder(uri);
+  }
+
+  /** Builder class for constructing a GravitinoClient. */
+  public static class Builder {
+
+    private String uri;
+    private AuthDataProvider authDataProvider;
+
+    /**
+     * The private constructor for the Builder class.
+     *
+     * @param uri The base URI for the Gravitino API.
+     */
+    private Builder(String uri) {
+      this.uri = uri;
+    }
+
+    /**
+     * Sets the simple mode authentication for Gravitino
+     *
+     * @return This Builder instance for method chaining.
+     */
+    public Builder withSimpleAuth() {
+      this.authDataProvider = new SimpleTokenProvider();
+      return this;
+    }
+
+    /**
+     * Sets OAuth2TokenProvider for the GravitinoClient.
+     *
+     * @param dataProvider The OAuth2TokenProvider used as the provider of authentication data for
+     *     GravitinoClient.
+     * @return This Builder instance for method chaining.
+     */
+    public Builder withOAuth(OAuth2TokenProvider dataProvider) {
+      this.authDataProvider = dataProvider;
+      return this;
+    }
+
+    /**
+     * Sets KerberosTokenProvider for the GravitinoClient.
+     *
+     * @param dataProvider The KerberosTokenProvider used as the provider of authentication data for
+     *     GravitinoClient.
+     * @return This Builder instance for method chaining.
+     */
+    public Builder withKerberosAuth(KerberosTokenProvider dataProvider) {
+      try {
+        if (uri != null) {
+          dataProvider.setHost(new URI(uri).getHost());
+        }
+      } catch (URISyntaxException ue) {
+        throw new IllegalArgumentException("URI has the wrong format", ue);
+      }
+      this.authDataProvider = dataProvider;
+      return this;
+    }
+
+    /**
+     * Builds a new GravitinoClient instance.
+     *
+     * @return A new instance of GravitinoClient with the specified base URI.
+     * @throws IllegalArgumentException If the base URI is null or empty.
+     */
+    public GravitinoAdminClient build() {
+      Preconditions.checkArgument(
+          uri != null && !uri.isEmpty(), "The argument 'uri' must be a valid URI");
+
+      return new GravitinoAdminClient(uri, authDataProvider);
+    }
+  }
+}

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoAdminClient.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoAdminClient.java
@@ -28,7 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Gravitino Client for administrator to interacte with the Gravitino API, allowing the client to
+ * Gravitino Client for the administrator to interact with the Gravitino API, allowing the client to
  * list, load, create, and alter Metalakes.
  *
  * <p>Normal users should use {@link GravitinoClient} to connect with the Gravitino server.

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoAdminClient.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoAdminClient.java
@@ -17,8 +17,6 @@ import com.datastrato.gravitino.dto.responses.MetalakeResponse;
 import com.datastrato.gravitino.exceptions.MetalakeAlreadyExistsException;
 import com.datastrato.gravitino.exceptions.NoSuchMetalakeException;
 import com.google.common.base.Preconditions;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoAdminClient.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoAdminClient.java
@@ -157,19 +157,6 @@ public class GravitinoAdminClient extends GravitinoClientBase implements Support
     }
   }
 
-  /** Closes the GravitinoClient and releases any underlying resources. */
-  @Override
-  public void close() {
-    if (restClient != null) {
-      try {
-        restClient.close();
-      } catch (Exception e) {
-        // Swallow the exception
-        LOG.warn("Failed to close the HTTP REST client", e);
-      }
-    }
-  }
-
   /**
    * Creates a new builder for constructing a GravitinoClient.
    *

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClient.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClient.java
@@ -14,8 +14,6 @@ import com.datastrato.gravitino.exceptions.CatalogAlreadyExistsException;
 import com.datastrato.gravitino.exceptions.NoSuchCatalogException;
 import com.datastrato.gravitino.exceptions.NoSuchMetalakeException;
 import com.google.common.base.Preconditions;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,16 +63,6 @@ public class GravitinoClient extends GravitinoClientBase implements SupportsCata
     return metaLake;
   }
 
-  /**
-   * Creates a new builder for constructing a GravitinoClient.
-   *
-   * @param uri The base URI for the Gravitino API.
-   * @return A new instance of the Builder class for constructing a GravitinoClient.
-   */
-  public static Builder builder(String uri) {
-    return new Builder(uri);
-  }
-
   @Override
   public NameIdentifier[] listCatalogs(Namespace namespace) throws NoSuchMetalakeException {
     return getMetaLake().listCatalogs(namespace);
@@ -107,80 +95,35 @@ public class GravitinoClient extends GravitinoClientBase implements SupportsCata
     return getMetaLake().dropCatalog(ident);
   }
 
-  /** Builder class for constructing a GravitinoClient. */
-  public static class Builder {
+  /**
+   * Creates a new builder for constructing a GravitinoClient.
+   *
+   * @param uri The base URI for the Gravitino API.
+   * @return A new instance of the Builder class for constructing a GravitinoClient.
+   */
+  public static Builder<GravitinoClient> builder(String uri) {
+    return new ClientBuilder(uri);
+  }
 
-    private String uri;
-    private AuthDataProvider authDataProvider;
-    private String metalakeName;
+  /** Builder class for constructing a GravitinoClient. */
+  static class ClientBuilder extends GravitinoClientBase.Builder<GravitinoClient> {
 
     /**
      * The private constructor for the Builder class.
      *
      * @param uri The base URI for the Gravitino API.
      */
-    private Builder(String uri) {
-      this.uri = uri;
-    }
-
-    /**
-     * Set the default metalake name for this client.
-     *
-     * @param metalakeName The name of the metalake that the client is working on.
-     * @return This Builder instance for method chaining.
-     */
-    public Builder withMetalake(String metalakeName) {
-      this.metalakeName = metalakeName;
-      return this;
-    }
-
-    /**
-     * Sets the simple mode authentication for Gravitino
-     *
-     * @return This Builder instance for method chaining.
-     */
-    public Builder withSimpleAuth() {
-      this.authDataProvider = new SimpleTokenProvider();
-      return this;
-    }
-
-    /**
-     * Sets OAuth2TokenProvider for the GravitinoClient.
-     *
-     * @param dataProvider The OAuth2TokenProvider used as the provider of authentication data for
-     *     GravitinoClient.
-     * @return This Builder instance for method chaining.
-     */
-    public Builder withOAuth(OAuth2TokenProvider dataProvider) {
-      this.authDataProvider = dataProvider;
-      return this;
-    }
-
-    /**
-     * Sets KerberosTokenProvider for the GravitinoClient.
-     *
-     * @param dataProvider The KerberosTokenProvider used as the provider of authentication data for
-     *     GravitinoClient.
-     * @return This Builder instance for method chaining.
-     */
-    public Builder withKerberosAuth(KerberosTokenProvider dataProvider) {
-      try {
-        if (uri != null) {
-          dataProvider.setHost(new URI(uri).getHost());
-        }
-      } catch (URISyntaxException ue) {
-        throw new IllegalArgumentException("URI has the wrong format", ue);
-      }
-      this.authDataProvider = dataProvider;
-      return this;
+    protected ClientBuilder(String uri) {
+      super(uri);
     }
 
     /**
      * Builds a new GravitinoClient instance.
      *
-     * @return A new instance of GravitinoClient with the specified base URI and metalake name.
-     * @throws IllegalArgumentException If the base URI or the metalake name is null or empty.
+     * @return A new instance of GravitinoClient with the specified base URI.
+     * @throws IllegalArgumentException If the base URI is null or empty.
      */
+    @Override
     public GravitinoClient build() {
       Preconditions.checkArgument(
           uri != null && !uri.isEmpty(), "The argument 'uri' must be a valid URI");

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClient.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClient.java
@@ -21,7 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Gravitino Client for an user to interacte with the Gravitino API, allowing the client to list,
+ * Gravitino Client for an user to interact with the Gravitino API, allowing the client to list,
  * load, create, and alter Catalog.
  *
  * <p>It uses an underlying {@link RESTClient} to send HTTP requests and receive responses from the
@@ -31,20 +31,20 @@ public class GravitinoClient extends GravitinoClientBase implements SupportsCata
 
   private static final Logger LOG = LoggerFactory.getLogger(GravitinoClient.class);
 
-  private final String metalake_name;
+  private final String metalakeName;
 
-  private GravitinoMetaLake metaLake = null;
+  private volatile GravitinoMetaLake metaLake = null;
 
   /**
    * Constructs a new GravitinoClient with the given URI, authenticator and AuthDataProvider.
    *
    * @param uri The base URI for the Gravitino API.
-   * @param metalake_name The specified metalake name.
+   * @param metalakeName The specified metalake name.
    * @param authDataProvider The provider of the data which is used for authentication.
    */
-  private GravitinoClient(String uri, String metalake_name, AuthDataProvider authDataProvider) {
+  private GravitinoClient(String uri, String metalakeName, AuthDataProvider authDataProvider) {
     super(uri, authDataProvider);
-    this.metalake_name = metalake_name;
+    this.metalakeName = metalakeName;
   }
 
   /**
@@ -57,7 +57,7 @@ public class GravitinoClient extends GravitinoClientBase implements SupportsCata
     if (this.metaLake == null) {
       synchronized (GravitinoClient.class) {
         if (this.metaLake == null) {
-          this.metaLake = loadMetalake(NameIdentifier.of(metalake_name));
+          this.metaLake = loadMetalake(NameIdentifier.of(metalakeName));
         }
       }
     }

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClient.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClient.java
@@ -5,220 +5,58 @@
 
 package com.datastrato.gravitino.client;
 
-import com.datastrato.gravitino.MetalakeChange;
+import com.datastrato.gravitino.Catalog;
+import com.datastrato.gravitino.CatalogChange;
 import com.datastrato.gravitino.NameIdentifier;
-import com.datastrato.gravitino.SupportsMetalakes;
-import com.datastrato.gravitino.dto.requests.MetalakeCreateRequest;
-import com.datastrato.gravitino.dto.requests.MetalakeUpdateRequest;
-import com.datastrato.gravitino.dto.requests.MetalakeUpdatesRequest;
-import com.datastrato.gravitino.dto.responses.DropResponse;
-import com.datastrato.gravitino.dto.responses.MetalakeListResponse;
-import com.datastrato.gravitino.dto.responses.MetalakeResponse;
-import com.datastrato.gravitino.dto.responses.VersionResponse;
-import com.datastrato.gravitino.exceptions.MetalakeAlreadyExistsException;
+import com.datastrato.gravitino.Namespace;
+import com.datastrato.gravitino.SupportsCatalogs;
+import com.datastrato.gravitino.exceptions.CatalogAlreadyExistsException;
+import com.datastrato.gravitino.exceptions.NoSuchCatalogException;
 import com.datastrato.gravitino.exceptions.NoSuchMetalakeException;
 import com.google.common.base.Preconditions;
-import java.io.Closeable;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Gravitino Client for interacting with the Gravitino API, allowing the client to list, load,
- * create, and alter Metalakes.
+ * Gravitino Client for an user to interacte with the Gravitino API, allowing the client to list,
+ * load, create, and alter Catalog.
  *
  * <p>It uses an underlying {@link RESTClient} to send HTTP requests and receive responses from the
  * API.
  */
-public class GravitinoClient implements SupportsMetalakes, Closeable {
+public class GravitinoClient extends GravitinoClientBase implements SupportsCatalogs {
 
   private static final Logger LOG = LoggerFactory.getLogger(GravitinoClient.class);
 
-  private final RESTClient restClient;
+  private final String metalake_name;
 
-  private static final String API_METALAKES_LIST_PATH = "api/metalakes";
-  private static final String API_METALAKES_IDENTIFIER_PATH = "api/metalakes/";
+  private GravitinoMetaLake metaLake = null;
 
   /**
    * Constructs a new GravitinoClient with the given URI, authenticator and AuthDataProvider.
    *
    * @param uri The base URI for the Gravitino API.
+   * @param metalake_name The specified metalake name.
    * @param authDataProvider The provider of the data which is used for authentication.
    */
-  private GravitinoClient(String uri, AuthDataProvider authDataProvider) {
-    this.restClient =
-        HTTPClient.builder(Collections.emptyMap())
-            .uri(uri)
-            .withAuthDataProvider(authDataProvider)
-            .build();
+  private GravitinoClient(String uri, String metalake_name, AuthDataProvider authDataProvider) {
+    super(uri, authDataProvider);
+    this.metalake_name = metalake_name;
   }
 
-  /**
-   * Retrieves a list of Metalakes from the Gravitino API.
-   *
-   * @return An array of GravitinoMetaLake objects representing the Metalakes.
-   */
-  @Override
-  public GravitinoMetaLake[] listMetalakes() {
-    MetalakeListResponse resp =
-        restClient.get(
-            API_METALAKES_LIST_PATH,
-            MetalakeListResponse.class,
-            Collections.emptyMap(),
-            ErrorHandlers.metalakeErrorHandler());
-    resp.validate();
-
-    return Arrays.stream(resp.getMetalakes())
-        .map(o -> DTOConverters.toMetaLake(o, restClient))
-        .toArray(GravitinoMetaLake[]::new);
-  }
-
-  /**
-   * Loads a specific Metalake from the Gravitino API.
-   *
-   * @param ident The identifier of the Metalake to be loaded.
-   * @return A GravitinoMetaLake instance representing the loaded Metalake.
-   * @throws NoSuchMetalakeException If the specified Metalake does not exist.
-   */
-  @Override
-  public GravitinoMetaLake loadMetalake(NameIdentifier ident) throws NoSuchMetalakeException {
-    NameIdentifier.checkMetalake(ident);
-
-    MetalakeResponse resp =
-        restClient.get(
-            API_METALAKES_IDENTIFIER_PATH + ident.name(),
-            MetalakeResponse.class,
-            Collections.emptyMap(),
-            ErrorHandlers.metalakeErrorHandler());
-    resp.validate();
-
-    return DTOConverters.toMetaLake(resp.getMetalake(), restClient);
-  }
-
-  /**
-   * Creates a new Metalake using the Gravitino API.
-   *
-   * @param ident The identifier of the new Metalake.
-   * @param comment The comment for the new Metalake.
-   * @param properties The properties of the new Metalake.
-   * @return A GravitinoMetaLake instance representing the newly created Metalake.
-   * @throws MetalakeAlreadyExistsException If a Metalake with the specified identifier already
-   *     exists.
-   */
-  @Override
-  public GravitinoMetaLake createMetalake(
-      NameIdentifier ident, String comment, Map<String, String> properties)
-      throws MetalakeAlreadyExistsException {
-    NameIdentifier.checkMetalake(ident);
-
-    MetalakeCreateRequest req = new MetalakeCreateRequest(ident.name(), comment, properties);
-    req.validate();
-
-    MetalakeResponse resp =
-        restClient.post(
-            API_METALAKES_LIST_PATH,
-            req,
-            MetalakeResponse.class,
-            Collections.emptyMap(),
-            ErrorHandlers.metalakeErrorHandler());
-    resp.validate();
-
-    return DTOConverters.toMetaLake(resp.getMetalake(), restClient);
-  }
-
-  /**
-   * Alters a specific Metalake using the Gravitino API.
-   *
-   * @param ident The identifier of the Metalake to be altered.
-   * @param changes The changes to be applied to the Metalake.
-   * @return A GravitinoMetaLake instance representing the updated Metalake.
-   * @throws NoSuchMetalakeException If the specified Metalake does not exist.
-   * @throws IllegalArgumentException If the provided changes are invalid or not applicable.
-   */
-  @Override
-  public GravitinoMetaLake alterMetalake(NameIdentifier ident, MetalakeChange... changes)
-      throws NoSuchMetalakeException, IllegalArgumentException {
-    NameIdentifier.checkMetalake(ident);
-
-    List<MetalakeUpdateRequest> reqs =
-        Arrays.stream(changes)
-            .map(DTOConverters::toMetalakeUpdateRequest)
-            .collect(Collectors.toList());
-    MetalakeUpdatesRequest updatesRequest = new MetalakeUpdatesRequest(reqs);
-    updatesRequest.validate();
-
-    MetalakeResponse resp =
-        restClient.put(
-            API_METALAKES_IDENTIFIER_PATH + ident.name(),
-            updatesRequest,
-            MetalakeResponse.class,
-            Collections.emptyMap(),
-            ErrorHandlers.metalakeErrorHandler());
-    resp.validate();
-
-    return DTOConverters.toMetaLake(resp.getMetalake(), restClient);
-  }
-
-  /**
-   * Drops a specific Metalake using the Gravitino API.
-   *
-   * @param ident The identifier of the Metalake to be dropped.
-   * @return True if the Metalake was successfully dropped, false otherwise.
-   */
-  @Override
-  public boolean dropMetalake(NameIdentifier ident) {
-    NameIdentifier.checkMetalake(ident);
-
-    try {
-      DropResponse resp =
-          restClient.delete(
-              API_METALAKES_IDENTIFIER_PATH + ident.name(),
-              DropResponse.class,
-              Collections.emptyMap(),
-              ErrorHandlers.metalakeErrorHandler());
-      resp.validate();
-      return resp.dropped();
-
-    } catch (Exception e) {
-      LOG.warn("Failed to drop metadata {}", ident, e);
-      return false;
-    }
-  }
-
-  /**
-   * Retrieves the version of the Gravitino API.
-   *
-   * @return A GravitinoVersion instance representing the version of the Gravitino API.
-   */
-  public GravitinoVersion getVersion() {
-    VersionResponse resp =
-        restClient.get(
-            "api/version",
-            VersionResponse.class,
-            Collections.emptyMap(),
-            ErrorHandlers.restErrorHandler());
-    resp.validate();
-
-    return new GravitinoVersion(resp.getVersion());
-  }
-
-  /** Closes the GravitinoClient and releases any underlying resources. */
-  @Override
-  public void close() {
-    if (restClient != null) {
-      try {
-        restClient.close();
-      } catch (Exception e) {
-        // Swallow the exception
-        LOG.warn("Failed to close the HTTP REST client", e);
+  public GravitinoMetaLake getMetaLake() {
+    if (this.metaLake == null) {
+      synchronized (GravitinoClient.class) {
+        if (this.metaLake == null) {
+          this.metaLake = loadMetalake(NameIdentifier.of(metalake_name));
+        }
       }
     }
+
+    return metaLake;
   }
 
   /**
@@ -231,11 +69,44 @@ public class GravitinoClient implements SupportsMetalakes, Closeable {
     return new Builder(uri);
   }
 
+  @Override
+  public NameIdentifier[] listCatalogs(Namespace namespace) throws NoSuchMetalakeException {
+    return getMetaLake().listCatalogs(namespace);
+  }
+
+  @Override
+  public Catalog loadCatalog(NameIdentifier ident) throws NoSuchCatalogException {
+    return getMetaLake().loadCatalog(ident);
+  }
+
+  @Override
+  public Catalog createCatalog(
+      NameIdentifier ident,
+      Catalog.Type type,
+      String provider,
+      String comment,
+      Map<String, String> properties)
+      throws NoSuchMetalakeException, CatalogAlreadyExistsException {
+    return getMetaLake().createCatalog(ident, type, provider, comment, properties);
+  }
+
+  @Override
+  public Catalog alterCatalog(NameIdentifier ident, CatalogChange... changes)
+      throws NoSuchCatalogException, IllegalArgumentException {
+    return getMetaLake().alterCatalog(ident, changes);
+  }
+
+  @Override
+  public boolean dropCatalog(NameIdentifier ident) {
+    return getMetaLake().dropCatalog(ident);
+  }
+
   /** Builder class for constructing a GravitinoClient. */
   public static class Builder {
 
     private String uri;
     private AuthDataProvider authDataProvider;
+    private String metalakeName;
 
     /**
      * The private constructor for the Builder class.
@@ -244,6 +115,11 @@ public class GravitinoClient implements SupportsMetalakes, Closeable {
      */
     private Builder(String uri) {
       this.uri = uri;
+    }
+
+    public Builder withMetalake(String metalakeName) {
+      this.metalakeName = metalakeName;
+      return this;
     }
 
     /**
@@ -296,8 +172,11 @@ public class GravitinoClient implements SupportsMetalakes, Closeable {
     public GravitinoClient build() {
       Preconditions.checkArgument(
           uri != null && !uri.isEmpty(), "The argument 'uri' must be a valid URI");
+      Preconditions.checkArgument(
+          metalakeName != null && !metalakeName.isEmpty(),
+          "The argument 'metalakeName' must be a valid name");
 
-      return new GravitinoClient(uri, authDataProvider);
+      return new GravitinoClient(uri, metalakeName, authDataProvider);
     }
   }
 }

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClient.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClient.java
@@ -47,6 +47,12 @@ public class GravitinoClient extends GravitinoClientBase implements SupportsCata
     this.metalake_name = metalake_name;
   }
 
+  /**
+   * Get the current metalake object
+   *
+   * @return the {@link GravitinoMetaLake} object
+   * @throws NoSuchMetalakeException if the metalake with specified name does not exist.
+   */
   public GravitinoMetaLake getMetaLake() {
     if (this.metaLake == null) {
       synchronized (GravitinoClient.class) {
@@ -117,6 +123,12 @@ public class GravitinoClient extends GravitinoClientBase implements SupportsCata
       this.uri = uri;
     }
 
+    /**
+     * Set the default metalake name for this client.
+     *
+     * @param metalakeName The name of the metalake that the client is working on.
+     * @return This Builder instance for method chaining.
+     */
     public Builder withMetalake(String metalakeName) {
       this.metalakeName = metalakeName;
       return this;
@@ -166,8 +178,8 @@ public class GravitinoClient extends GravitinoClientBase implements SupportsCata
     /**
      * Builds a new GravitinoClient instance.
      *
-     * @return A new instance of GravitinoClient with the specified base URI.
-     * @throws IllegalArgumentException If the base URI is null or empty.
+     * @return A new instance of GravitinoClient with the specified base URI and metalake name.
+     * @throws IllegalArgumentException If the base URI or the metalake name is null or empty.
      */
     public GravitinoClient build() {
       Preconditions.checkArgument(

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClient.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClient.java
@@ -29,9 +29,7 @@ public class GravitinoClient extends GravitinoClientBase implements SupportsCata
 
   private static final Logger LOG = LoggerFactory.getLogger(GravitinoClient.class);
 
-  private final String metalakeName;
-
-  private volatile GravitinoMetaLake metaLake = null;
+  private final GravitinoMetaLake metaLake;
 
   /**
    * Constructs a new GravitinoClient with the given URI, authenticator and AuthDataProvider.
@@ -39,10 +37,11 @@ public class GravitinoClient extends GravitinoClientBase implements SupportsCata
    * @param uri The base URI for the Gravitino API.
    * @param metalakeName The specified metalake name.
    * @param authDataProvider The provider of the data which is used for authentication.
+   * @throws NoSuchMetalakeException if the metalake with specified name does not exist.
    */
   private GravitinoClient(String uri, String metalakeName, AuthDataProvider authDataProvider) {
     super(uri, authDataProvider);
-    this.metalakeName = metalakeName;
+    this.metaLake = loadMetalake(NameIdentifier.of(metalakeName));
   }
 
   /**
@@ -52,14 +51,6 @@ public class GravitinoClient extends GravitinoClientBase implements SupportsCata
    * @throws NoSuchMetalakeException if the metalake with specified name does not exist.
    */
   public GravitinoMetaLake getMetaLake() {
-    if (this.metaLake == null) {
-      synchronized (GravitinoClient.class) {
-        if (this.metaLake == null) {
-          this.metaLake = loadMetalake(NameIdentifier.of(metalakeName));
-        }
-      }
-    }
-
     return metaLake;
   }
 
@@ -122,6 +113,7 @@ public class GravitinoClient extends GravitinoClientBase implements SupportsCata
      *
      * @return A new instance of GravitinoClient with the specified base URI.
      * @throws IllegalArgumentException If the base URI is null or empty.
+     * @throws NoSuchMetalakeException if the metalake with specified name does not exist.
      */
     @Override
     public GravitinoClient build() {

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClientBase.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClientBase.java
@@ -169,6 +169,7 @@ public abstract class GravitinoClientBase implements Closeable {
     /**
      * Builds a new instance. Subclasses should overwrite this method.
      *
+     * @return A new instance of Gravitino Client.
      * @throws IllegalArgumentException If the base URI is null or empty.
      * @throws UnsupportedOperationException If subclass has not implemented.
      */

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClientBase.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClientBase.java
@@ -23,9 +23,12 @@ import org.slf4j.LoggerFactory;
 public abstract class GravitinoClientBase implements Closeable {
 
   private static final Logger LOG = LoggerFactory.getLogger(GravitinoClientBase.class);
+  /** The REST client to communicate with the REST server */
   protected final RESTClient restClient;
+  /** The REST API path for listing metalakes */
   protected static final String API_METALAKES_LIST_PATH = "api/metalakes";
-  protected static final String API_METALAKES_IDENTIFIER_PATH = "api/metalakes/";
+  /** The REST API path prefix for load a specific metalake */
+  protected static final String API_METALAKES_IDENTIFIER_PATH = API_METALAKES_LIST_PATH + "/";
 
   /**
    * Constructs a new GravitinoClient with the given URI, authenticator and AuthDataProvider.

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClientBase.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClientBase.java
@@ -99,10 +99,11 @@ public abstract class GravitinoClientBase implements Closeable {
 
   /** Builder class for constructing a GravitinoClient. */
   public static class Builder<T> {
-
+    /** The base URI for the Gravitino API. */
     protected String uri;
-
+    /** The name of the metalake that the client is working on. */
     protected String metalakeName;
+    /** The authentication provider. */
     protected AuthDataProvider authDataProvider;
 
     /**

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClientBase.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClientBase.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+
+package com.datastrato.gravitino.client;
+
+import com.datastrato.gravitino.NameIdentifier;
+import com.datastrato.gravitino.dto.responses.MetalakeResponse;
+import com.datastrato.gravitino.dto.responses.VersionResponse;
+import com.datastrato.gravitino.exceptions.NoSuchMetalakeException;
+import java.io.Closeable;
+import java.util.Collections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base class for Gravitino Java client;
+ *
+ * <p>It uses an underlying {@link RESTClient} to send HTTP requests and receive responses from the
+ * API.
+ */
+public abstract class GravitinoClientBase implements Closeable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GravitinoClientBase.class);
+  protected final RESTClient restClient;
+  protected static final String API_METALAKES_LIST_PATH = "api/metalakes";
+  protected static final String API_METALAKES_IDENTIFIER_PATH = "api/metalakes/";
+
+  /**
+   * Constructs a new GravitinoClient with the given URI, authenticator and AuthDataProvider.
+   *
+   * @param uri The base URI for the Gravitino API.
+   * @param authDataProvider The provider of the data which is used for authentication.
+   */
+  protected GravitinoClientBase(String uri, AuthDataProvider authDataProvider) {
+    this.restClient =
+        HTTPClient.builder(Collections.emptyMap())
+            .uri(uri)
+            .withAuthDataProvider(authDataProvider)
+            .build();
+  }
+
+  /**
+   * Loads a specific Metalake from the Gravitino API.
+   *
+   * @param ident The identifier of the Metalake to be loaded.
+   * @return A GravitinoMetaLake instance representing the loaded Metalake.
+   * @throws NoSuchMetalakeException If the specified Metalake does not exist.
+   */
+  public GravitinoMetaLake loadMetalake(NameIdentifier ident) throws NoSuchMetalakeException {
+    NameIdentifier.checkMetalake(ident);
+
+    MetalakeResponse resp =
+        restClient.get(
+            API_METALAKES_IDENTIFIER_PATH + ident.name(),
+            MetalakeResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.metalakeErrorHandler());
+    resp.validate();
+
+    return DTOConverters.toMetaLake(resp.getMetalake(), restClient);
+  }
+
+  /**
+   * Retrieves the version of the Gravitino API.
+   *
+   * @return A GravitinoVersion instance representing the version of the Gravitino API.
+   */
+  public GravitinoVersion getVersion() {
+    VersionResponse resp =
+        restClient.get(
+            "api/version",
+            VersionResponse.class,
+            Collections.emptyMap(),
+            ErrorHandlers.restErrorHandler());
+    resp.validate();
+
+    return new GravitinoVersion(resp.getVersion());
+  }
+
+  /** Closes the GravitinoClient and releases any underlying resources. */
+  @Override
+  public void close() {
+    if (restClient != null) {
+      try {
+        restClient.close();
+      } catch (Exception e) {
+        // Swallow the exception
+        LOG.warn("Failed to close the HTTP REST client", e);
+      }
+    }
+  }
+}

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClientBase.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClientBase.java
@@ -68,6 +68,21 @@ public abstract class GravitinoClientBase implements Closeable {
   }
 
   /**
+   * Check if a metalake exists.
+   *
+   * @param ident The identifier of the metalake.
+   * @return True if the metalake exists, false otherwise.
+   */
+  public boolean metalakeExists(NameIdentifier ident) {
+    try {
+      loadMetalake(ident);
+      return true;
+    } catch (NoSuchMetalakeException e) {
+      return false;
+    }
+  }
+
+  /**
    * Retrieves the version of the Gravitino API.
    *
    * @return A GravitinoVersion instance representing the version of the Gravitino API.

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoMetaLake.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoMetaLake.java
@@ -94,7 +94,7 @@ public class GravitinoMetaLake extends MetalakeDTO implements SupportsCatalogs {
             ErrorHandlers.catalogErrorHandler());
     resp.validate();
 
-    return DTOConverters.toCatalog(resp.getCatalog(), restClient);
+    return DTOConverters.toCatalog(this.name(), resp.getCatalog(), restClient);
   }
 
   /**
@@ -132,7 +132,7 @@ public class GravitinoMetaLake extends MetalakeDTO implements SupportsCatalogs {
             ErrorHandlers.catalogErrorHandler());
     resp.validate();
 
-    return DTOConverters.toCatalog(resp.getCatalog(), restClient);
+    return DTOConverters.toCatalog(this.name(), resp.getCatalog(), restClient);
   }
 
   /**
@@ -165,7 +165,7 @@ public class GravitinoMetaLake extends MetalakeDTO implements SupportsCatalogs {
             ErrorHandlers.catalogErrorHandler());
     resp.validate();
 
-    return DTOConverters.toCatalog(resp.getCatalog(), restClient);
+    return DTOConverters.toCatalog(this.name(), resp.getCatalog(), restClient);
   }
 
   /**

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
@@ -291,7 +291,7 @@ public class RelationalCatalog extends BaseSchemaCatalog implements TableCatalog
 
     @Override
     public RelationalCatalog build() {
-      Namespace.checkMetalake(namespace);
+      Namespace.checkCatalog(namespace);
       Preconditions.checkArgument(restClient != null, "restClient must be set");
       Preconditions.checkArgument(StringUtils.isNotBlank(name), "name must not be blank");
       Preconditions.checkArgument(type != null, "type must not be null");

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
@@ -50,6 +50,7 @@ public class RelationalCatalog extends BaseSchemaCatalog implements TableCatalog
   private static final Logger LOG = LoggerFactory.getLogger(RelationalCatalog.class);
 
   RelationalCatalog(
+      Namespace namespace,
       String name,
       Type type,
       String provider,
@@ -57,7 +58,7 @@ public class RelationalCatalog extends BaseSchemaCatalog implements TableCatalog
       Map<String, String> properties,
       AuditDTO auditDTO,
       RESTClient restClient) {
-    super(name, type, provider, comment, properties, auditDTO, restClient);
+    super(namespace, name, type, provider, comment, properties, auditDTO, restClient);
   }
 
   @Override
@@ -273,6 +274,9 @@ public class RelationalCatalog extends BaseSchemaCatalog implements TableCatalog
     /** The REST client to send the requests. */
     private RESTClient restClient;
 
+    /** The namespace of the catalog */
+    private Namespace namespace;
+
     private Builder() {}
 
     Builder withRestClient(RESTClient restClient) {
@@ -280,15 +284,22 @@ public class RelationalCatalog extends BaseSchemaCatalog implements TableCatalog
       return this;
     }
 
+    Builder withNamespace(Namespace namespace) {
+      this.namespace = namespace;
+      return this;
+    }
+
     @Override
     public RelationalCatalog build() {
+      Namespace.checkMetalake(namespace);
       Preconditions.checkArgument(restClient != null, "restClient must be set");
       Preconditions.checkArgument(StringUtils.isNotBlank(name), "name must not be blank");
       Preconditions.checkArgument(type != null, "type must not be null");
       Preconditions.checkArgument(StringUtils.isNotBlank(provider), "provider must not be blank");
       Preconditions.checkArgument(audit != null, "audit must not be null");
 
-      return new RelationalCatalog(name, type, provider, comment, properties, audit, restClient);
+      return new RelationalCatalog(
+          namespace, name, type, provider, comment, properties, audit, restClient);
     }
   }
 }

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalTable.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalTable.java
@@ -17,7 +17,6 @@ import com.datastrato.gravitino.dto.responses.PartitionResponse;
 import com.datastrato.gravitino.exceptions.NoSuchPartitionException;
 import com.datastrato.gravitino.exceptions.PartitionAlreadyExistsException;
 import com.datastrato.gravitino.rel.Column;
-import com.datastrato.gravitino.rel.SupportsPartitions;
 import com.datastrato.gravitino.rel.Table;
 import com.datastrato.gravitino.rel.expressions.distributions.Distribution;
 import com.datastrato.gravitino.rel.expressions.sorts.SortOrder;
@@ -33,7 +32,7 @@ import javax.annotation.Nullable;
 import lombok.SneakyThrows;
 
 /** Represents a relational table. */
-public class RelationalTable implements Table, SupportsPartitions {
+public class RelationalTable implements Table {
 
   /**
    * Creates a new RelationalTable.
@@ -134,7 +133,6 @@ public class RelationalTable implements Table, SupportsPartitions {
   }
 
   /** @return The partition names of the table. */
-  @Override
   public String[] listPartitionNames() {
     PartitionNameListResponse resp =
         restClient.get(
@@ -160,7 +158,6 @@ public class RelationalTable implements Table, SupportsPartitions {
   }
 
   /** @return The partitions of the table. */
-  @Override
   public Partition[] listPartitions() {
     Map<String, String> params = new HashMap<>();
     params.put("details", "true");
@@ -181,7 +178,6 @@ public class RelationalTable implements Table, SupportsPartitions {
    * @return the partition with the given name
    * @throws NoSuchPartitionException if the partition does not exist, throws this exception.
    */
-  @Override
   public Partition getPartition(String partitionName) throws NoSuchPartitionException {
     PartitionResponse resp =
         restClient.get(
@@ -199,7 +195,6 @@ public class RelationalTable implements Table, SupportsPartitions {
    * @return The added partition.
    * @throws PartitionAlreadyExistsException If the partition already exists, throws this exception.
    */
-  @Override
   public Partition addPartition(Partition partition) throws PartitionAlreadyExistsException {
     AddPartitionsRequest req = new AddPartitionsRequest(new PartitionDTO[] {toDTO(partition)});
     req.validate();
@@ -222,19 +217,8 @@ public class RelationalTable implements Table, SupportsPartitions {
    * @param partitionName The identifier of the partition.
    * @return true if the partition is dropped, false otherwise.
    */
-  @Override
   public boolean dropPartition(String partitionName) {
     throw new UnsupportedOperationException();
-  }
-
-  /**
-   * Returns the partitioning strategy of the table.
-   *
-   * @return the partitioning strategy of the table.
-   */
-  @Override
-  public SupportsPartitions supportPartitions() throws UnsupportedOperationException {
-    return this;
   }
 
   /**

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestBase.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestBase.java
@@ -24,15 +24,15 @@ public abstract class TestBase {
 
   private static final ObjectMapper MAPPER = JsonUtils.objectMapper();
 
-  private static ClientAndServer mockServer;
+  protected static ClientAndServer mockServer;
 
-  protected static GravitinoClient client;
+  protected static GravitinoAdminClient client;
 
   @BeforeAll
   public static void setUp() throws Exception {
     mockServer = ClientAndServer.startClientAndServer(0);
     int port = mockServer.getLocalPort();
-    client = GravitinoClient.builder("http://127.0.0.1:" + port).build();
+    client = GravitinoAdminClient.builder("http://127.0.0.1:" + port).build();
   }
 
   @AfterAll

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestGravitinoMetalake.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestGravitinoMetalake.java
@@ -39,17 +39,33 @@ import org.junit.jupiter.api.Test;
 
 public class TestGravitinoMetalake extends TestBase {
 
-  private static GravitinoMetaLake metalake;
-
   private static final String metalakeName = "test";
 
   private static final String provider = "test";
 
+  protected static GravitinoClient gravitinoClient;
+
   @BeforeAll
   public static void setUp() throws Exception {
     TestBase.setUp();
+    createMetalake(client, metalakeName);
+    gravitinoClient =
+        GravitinoClient.builder("http://127.0.0.1:" + mockServer.getLocalPort())
+            .withMetalake(metalakeName)
+            .build();
 
-    metalake = createMetalake(client, metalakeName);
+    MetalakeDTO mockMetalake =
+        new MetalakeDTO.Builder()
+            .withName(metalakeName)
+            .withComment("comment")
+            .withAudit(
+                new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
+            .build();
+
+    MetalakeResponse resp = new MetalakeResponse(mockMetalake);
+    buildMockResource(Method.GET, "/api/metalakes/" + metalakeName, null, resp, HttpStatus.SC_OK);
+    NameIdentifier id = NameIdentifier.of(metalakeName);
+    Assertions.assertEquals(metalakeName, gravitinoClient.getMetaLake().name());
   }
 
   @Test
@@ -62,7 +78,7 @@ public class TestGravitinoMetalake extends TestBase {
 
     EntityListResponse resp = new EntityListResponse(new NameIdentifier[] {ident1, ident2});
     buildMockResource(Method.GET, path, null, resp, HttpStatus.SC_OK);
-    NameIdentifier[] catalogs = metalake.listCatalogs(namespace);
+    NameIdentifier[] catalogs = gravitinoClient.listCatalogs(namespace);
 
     Assertions.assertEquals(2, catalogs.length);
     Assertions.assertEquals(ident1, catalogs[0]);
@@ -71,20 +87,21 @@ public class TestGravitinoMetalake extends TestBase {
     // Test return empty catalog list
     EntityListResponse resp1 = new EntityListResponse(new NameIdentifier[] {});
     buildMockResource(Method.GET, path, null, resp1, HttpStatus.SC_OK);
-    NameIdentifier[] catalogs1 = metalake.listCatalogs(namespace);
+    NameIdentifier[] catalogs1 = gravitinoClient.listCatalogs(namespace);
     Assertions.assertEquals(0, catalogs1.length);
 
     // Test return internal error
     ErrorResponse errorResp = ErrorResponse.internalError("mock error");
     buildMockResource(Method.GET, path, null, errorResp, HttpStatus.SC_INTERNAL_SERVER_ERROR);
     Throwable ex =
-        Assertions.assertThrows(RuntimeException.class, () -> metalake.listCatalogs(namespace));
+        Assertions.assertThrows(
+            RuntimeException.class, () -> gravitinoClient.listCatalogs(namespace));
     Assertions.assertTrue(ex.getMessage().contains("mock error"));
 
     // Test return unparsed system error
     buildMockResource(Method.GET, path, null, "mock error", HttpStatus.SC_CONFLICT);
     Throwable ex1 =
-        Assertions.assertThrows(RESTException.class, () -> metalake.listCatalogs(namespace));
+        Assertions.assertThrows(RESTException.class, () -> gravitinoClient.listCatalogs(namespace));
     Assertions.assertTrue(ex1.getMessage().contains("Error code: " + HttpStatus.SC_CONFLICT));
   }
 
@@ -105,7 +122,7 @@ public class TestGravitinoMetalake extends TestBase {
     CatalogResponse resp = new CatalogResponse(mockCatalog);
 
     buildMockResource(Method.GET, path, null, resp, HttpStatus.SC_OK);
-    Catalog catalog = metalake.loadCatalog(NameIdentifier.of(metalakeName, catalogName));
+    Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of(metalakeName, catalogName));
 
     Assertions.assertEquals(catalogName, catalog.name());
     Assertions.assertEquals("comment", catalog.comment());
@@ -117,7 +134,8 @@ public class TestGravitinoMetalake extends TestBase {
     buildMockResource(Method.GET, path, null, errorResponse, HttpStatus.SC_NOT_FOUND);
     NameIdentifier id = NameIdentifier.of(metalakeName, catalogName);
     Throwable ex =
-        Assertions.assertThrows(NoSuchCatalogException.class, () -> metalake.loadCatalog(id));
+        Assertions.assertThrows(
+            NoSuchCatalogException.class, () -> gravitinoClient.loadCatalog(id));
     Assertions.assertTrue(ex.getMessage().contains("mock error"));
 
     // Test return unsupported catalog type
@@ -132,17 +150,20 @@ public class TestGravitinoMetalake extends TestBase {
             .build();
     CatalogResponse resp1 = new CatalogResponse(mockCatalog1);
     buildMockResource(Method.GET, path, null, resp1, HttpStatus.SC_OK);
-    Assertions.assertThrows(UnsupportedOperationException.class, () -> metalake.loadCatalog(id));
+    Assertions.assertThrows(
+        UnsupportedOperationException.class, () -> gravitinoClient.loadCatalog(id));
 
     // Test return internal error
     ErrorResponse errorResp = ErrorResponse.internalError("mock error");
     buildMockResource(Method.GET, path, null, errorResp, HttpStatus.SC_INTERNAL_SERVER_ERROR);
-    Throwable ex1 = Assertions.assertThrows(RuntimeException.class, () -> metalake.loadCatalog(id));
+    Throwable ex1 =
+        Assertions.assertThrows(RuntimeException.class, () -> gravitinoClient.loadCatalog(id));
     Assertions.assertTrue(ex1.getMessage().contains("mock error"));
 
     // Test return unparsed system error
     buildMockResource(Method.GET, path, null, "mock error", HttpStatus.SC_CONFLICT);
-    Throwable ex2 = Assertions.assertThrows(RESTException.class, () -> metalake.loadCatalog(id));
+    Throwable ex2 =
+        Assertions.assertThrows(RESTException.class, () -> gravitinoClient.loadCatalog(id));
     Assertions.assertTrue(ex2.getMessage().contains("Error code: " + HttpStatus.SC_CONFLICT));
   }
 
@@ -167,7 +188,7 @@ public class TestGravitinoMetalake extends TestBase {
     buildMockResource(Method.POST, path, req, resp, HttpStatus.SC_OK);
 
     Catalog catalog =
-        metalake.createCatalog(
+        gravitinoClient.createCatalog(
             NameIdentifier.of(metalakeName, catalogName),
             Catalog.Type.RELATIONAL,
             provider,
@@ -197,7 +218,9 @@ public class TestGravitinoMetalake extends TestBase {
 
     Assertions.assertThrows(
         UnsupportedOperationException.class,
-        () -> metalake.createCatalog(id, Catalog.Type.MESSAGING, provider, "comment", emptyMap));
+        () ->
+            gravitinoClient.createCatalog(
+                id, Catalog.Type.MESSAGING, provider, "comment", emptyMap));
 
     // Test return NoSuchMetalakeException
     ErrorResponse errorResponse =
@@ -207,7 +230,8 @@ public class TestGravitinoMetalake extends TestBase {
         Assertions.assertThrows(
             NoSuchMetalakeException.class,
             () ->
-                metalake.createCatalog(id, Catalog.Type.RELATIONAL, provider, "comment", emptyMap));
+                gravitinoClient.createCatalog(
+                    id, Catalog.Type.RELATIONAL, provider, "comment", emptyMap));
     Assertions.assertTrue(ex.getMessage().contains("mock error"));
 
     // Test return CatalogAlreadyExistsException
@@ -219,7 +243,8 @@ public class TestGravitinoMetalake extends TestBase {
         Assertions.assertThrows(
             CatalogAlreadyExistsException.class,
             () ->
-                metalake.createCatalog(id, Catalog.Type.RELATIONAL, provider, "comment", emptyMap));
+                gravitinoClient.createCatalog(
+                    id, Catalog.Type.RELATIONAL, provider, "comment", emptyMap));
     Assertions.assertTrue(ex1.getMessage().contains("mock error"));
 
     // Test return internal error
@@ -229,7 +254,8 @@ public class TestGravitinoMetalake extends TestBase {
         Assertions.assertThrows(
             RuntimeException.class,
             () ->
-                metalake.createCatalog(id, Catalog.Type.RELATIONAL, provider, "comment", emptyMap));
+                gravitinoClient.createCatalog(
+                    id, Catalog.Type.RELATIONAL, provider, "comment", emptyMap));
     Assertions.assertTrue(ex2.getMessage().contains("mock error"));
   }
 
@@ -259,7 +285,7 @@ public class TestGravitinoMetalake extends TestBase {
 
     buildMockResource(Method.PUT, path, updatesRequest, resp, HttpStatus.SC_OK);
     NameIdentifier id = NameIdentifier.of(metalakeName, catalogName);
-    Catalog catalog = metalake.alterCatalog(id, change1, change2);
+    Catalog catalog = gravitinoClient.alterCatalog(id, change1, change2);
     Assertions.assertEquals("mock1", catalog.name());
     Assertions.assertEquals("comment1", catalog.comment());
     Assertions.assertEquals(Catalog.Type.RELATIONAL, catalog.type());
@@ -270,7 +296,7 @@ public class TestGravitinoMetalake extends TestBase {
     buildMockResource(Method.PUT, path, updatesRequest, errorResponse, HttpStatus.SC_NOT_FOUND);
     Throwable ex =
         Assertions.assertThrows(
-            NoSuchCatalogException.class, () -> metalake.alterCatalog(id, change1, change2));
+            NoSuchCatalogException.class, () -> gravitinoClient.alterCatalog(id, change1, change2));
     Assertions.assertTrue(ex.getMessage().contains("mock error"));
 
     // Test return IllegalArgumentException
@@ -278,7 +304,8 @@ public class TestGravitinoMetalake extends TestBase {
     buildMockResource(Method.PUT, path, updatesRequest, errorResponse1, HttpStatus.SC_BAD_REQUEST);
     Throwable ex1 =
         Assertions.assertThrows(
-            IllegalArgumentException.class, () -> metalake.alterCatalog(id, change1, change2));
+            IllegalArgumentException.class,
+            () -> gravitinoClient.alterCatalog(id, change1, change2));
     Assertions.assertTrue(ex1.getMessage().contains("mock error"));
 
     // Test return internal error
@@ -287,7 +314,7 @@ public class TestGravitinoMetalake extends TestBase {
         Method.PUT, path, updatesRequest, errorResp, HttpStatus.SC_INTERNAL_SERVER_ERROR);
     Throwable ex2 =
         Assertions.assertThrows(
-            RuntimeException.class, () -> metalake.alterCatalog(id, change1, change2));
+            RuntimeException.class, () -> gravitinoClient.alterCatalog(id, change1, change2));
     Assertions.assertTrue(ex2.getMessage().contains("mock error"));
   }
 
@@ -298,17 +325,17 @@ public class TestGravitinoMetalake extends TestBase {
 
     DropResponse resp = new DropResponse(true);
     buildMockResource(Method.DELETE, path, null, resp, HttpStatus.SC_OK);
-    boolean dropped = metalake.dropCatalog(NameIdentifier.of(metalakeName, catalogName));
+    boolean dropped = gravitinoClient.dropCatalog(NameIdentifier.of(metalakeName, catalogName));
     Assertions.assertTrue(dropped);
 
     // Test return false
     DropResponse resp1 = new DropResponse(false);
     buildMockResource(Method.DELETE, path, null, resp1, HttpStatus.SC_OK);
-    boolean dropped1 = metalake.dropCatalog(NameIdentifier.of(metalakeName, catalogName));
+    boolean dropped1 = gravitinoClient.dropCatalog(NameIdentifier.of(metalakeName, catalogName));
     Assertions.assertFalse(dropped1);
   }
 
-  static GravitinoMetaLake createMetalake(GravitinoClient client, String metalakeName)
+  static GravitinoMetaLake createMetalake(GravitinoAdminClient client, String metalakeName)
       throws JsonProcessingException {
     MetalakeDTO mockMetalake =
         new MetalakeDTO.Builder()

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestGravitinoMetalake.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestGravitinoMetalake.java
@@ -49,10 +49,6 @@ public class TestGravitinoMetalake extends TestBase {
   public static void setUp() throws Exception {
     TestBase.setUp();
     createMetalake(client, metalakeName);
-    gravitinoClient =
-        GravitinoClient.builder("http://127.0.0.1:" + mockServer.getLocalPort())
-            .withMetalake(metalakeName)
-            .build();
 
     MetalakeDTO mockMetalake =
         new MetalakeDTO.Builder()
@@ -61,9 +57,14 @@ public class TestGravitinoMetalake extends TestBase {
             .withAudit(
                 new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
             .build();
-
     MetalakeResponse resp = new MetalakeResponse(mockMetalake);
     buildMockResource(Method.GET, "/api/metalakes/" + metalakeName, null, resp, HttpStatus.SC_OK);
+
+    gravitinoClient =
+        GravitinoClient.builder("http://127.0.0.1:" + mockServer.getLocalPort())
+            .withMetalake(metalakeName)
+            .build();
+
     NameIdentifier id = NameIdentifier.of(metalakeName);
     Assertions.assertEquals(metalakeName, gravitinoClient.getMetaLake().name());
   }

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestGravitinoMetalake.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestGravitinoMetalake.java
@@ -7,7 +7,6 @@ package com.datastrato.gravitino.client;
 import com.datastrato.gravitino.Catalog;
 import com.datastrato.gravitino.CatalogChange;
 import com.datastrato.gravitino.NameIdentifier;
-import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.dto.AuditDTO;
 import com.datastrato.gravitino.dto.CatalogDTO;
 import com.datastrato.gravitino.dto.MetalakeDTO;
@@ -75,11 +74,10 @@ public class TestGravitinoMetalake extends TestBase {
 
     NameIdentifier ident1 = NameIdentifier.of(metalakeName, "mock");
     NameIdentifier ident2 = NameIdentifier.of(metalakeName, "mock2");
-    Namespace namespace = Namespace.of(metalakeName);
 
     EntityListResponse resp = new EntityListResponse(new NameIdentifier[] {ident1, ident2});
     buildMockResource(Method.GET, path, null, resp, HttpStatus.SC_OK);
-    NameIdentifier[] catalogs = gravitinoClient.listCatalogs(namespace);
+    NameIdentifier[] catalogs = gravitinoClient.listCatalogs();
 
     Assertions.assertEquals(2, catalogs.length);
     Assertions.assertEquals(ident1, catalogs[0]);
@@ -88,21 +86,20 @@ public class TestGravitinoMetalake extends TestBase {
     // Test return empty catalog list
     EntityListResponse resp1 = new EntityListResponse(new NameIdentifier[] {});
     buildMockResource(Method.GET, path, null, resp1, HttpStatus.SC_OK);
-    NameIdentifier[] catalogs1 = gravitinoClient.listCatalogs(namespace);
+    NameIdentifier[] catalogs1 = gravitinoClient.listCatalogs();
     Assertions.assertEquals(0, catalogs1.length);
 
     // Test return internal error
     ErrorResponse errorResp = ErrorResponse.internalError("mock error");
     buildMockResource(Method.GET, path, null, errorResp, HttpStatus.SC_INTERNAL_SERVER_ERROR);
     Throwable ex =
-        Assertions.assertThrows(
-            RuntimeException.class, () -> gravitinoClient.listCatalogs(namespace));
+        Assertions.assertThrows(RuntimeException.class, () -> gravitinoClient.listCatalogs());
     Assertions.assertTrue(ex.getMessage().contains("mock error"));
 
     // Test return unparsed system error
     buildMockResource(Method.GET, path, null, "mock error", HttpStatus.SC_CONFLICT);
     Throwable ex1 =
-        Assertions.assertThrows(RESTException.class, () -> gravitinoClient.listCatalogs(namespace));
+        Assertions.assertThrows(RESTException.class, () -> gravitinoClient.listCatalogs());
     Assertions.assertTrue(ex1.getMessage().contains("Error code: " + HttpStatus.SC_CONFLICT));
   }
 
@@ -123,7 +120,7 @@ public class TestGravitinoMetalake extends TestBase {
     CatalogResponse resp = new CatalogResponse(mockCatalog);
 
     buildMockResource(Method.GET, path, null, resp, HttpStatus.SC_OK);
-    Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of(metalakeName, catalogName));
+    Catalog catalog = gravitinoClient.loadCatalog(catalogName);
 
     Assertions.assertEquals(catalogName, catalog.name());
     Assertions.assertEquals("comment", catalog.comment());
@@ -133,10 +130,9 @@ public class TestGravitinoMetalake extends TestBase {
     ErrorResponse errorResponse =
         ErrorResponse.notFound(NoSuchCatalogException.class.getSimpleName(), "mock error");
     buildMockResource(Method.GET, path, null, errorResponse, HttpStatus.SC_NOT_FOUND);
-    NameIdentifier id = NameIdentifier.of(metalakeName, catalogName);
     Throwable ex =
         Assertions.assertThrows(
-            NoSuchCatalogException.class, () -> gravitinoClient.loadCatalog(id));
+            NoSuchCatalogException.class, () -> gravitinoClient.loadCatalog(catalogName));
     Assertions.assertTrue(ex.getMessage().contains("mock error"));
 
     // Test return unsupported catalog type
@@ -152,19 +148,21 @@ public class TestGravitinoMetalake extends TestBase {
     CatalogResponse resp1 = new CatalogResponse(mockCatalog1);
     buildMockResource(Method.GET, path, null, resp1, HttpStatus.SC_OK);
     Assertions.assertThrows(
-        UnsupportedOperationException.class, () -> gravitinoClient.loadCatalog(id));
+        UnsupportedOperationException.class, () -> gravitinoClient.loadCatalog(catalogName));
 
     // Test return internal error
     ErrorResponse errorResp = ErrorResponse.internalError("mock error");
     buildMockResource(Method.GET, path, null, errorResp, HttpStatus.SC_INTERNAL_SERVER_ERROR);
     Throwable ex1 =
-        Assertions.assertThrows(RuntimeException.class, () -> gravitinoClient.loadCatalog(id));
+        Assertions.assertThrows(
+            RuntimeException.class, () -> gravitinoClient.loadCatalog(catalogName));
     Assertions.assertTrue(ex1.getMessage().contains("mock error"));
 
     // Test return unparsed system error
     buildMockResource(Method.GET, path, null, "mock error", HttpStatus.SC_CONFLICT);
     Throwable ex2 =
-        Assertions.assertThrows(RESTException.class, () -> gravitinoClient.loadCatalog(id));
+        Assertions.assertThrows(
+            RESTException.class, () -> gravitinoClient.loadCatalog(catalogName));
     Assertions.assertTrue(ex2.getMessage().contains("Error code: " + HttpStatus.SC_CONFLICT));
   }
 
@@ -190,11 +188,7 @@ public class TestGravitinoMetalake extends TestBase {
 
     Catalog catalog =
         gravitinoClient.createCatalog(
-            NameIdentifier.of(metalakeName, catalogName),
-            Catalog.Type.RELATIONAL,
-            provider,
-            "comment",
-            Collections.emptyMap());
+            catalogName, Catalog.Type.RELATIONAL, provider, "comment", Collections.emptyMap());
     Assertions.assertEquals(catalogName, catalog.name());
     Assertions.assertEquals("comment", catalog.comment());
     Assertions.assertEquals(Catalog.Type.RELATIONAL, catalog.type());
@@ -214,14 +208,13 @@ public class TestGravitinoMetalake extends TestBase {
             catalogName, Catalog.Type.MESSAGING, provider, "comment", Collections.emptyMap());
     CatalogResponse resp1 = new CatalogResponse(mockCatalog1);
     buildMockResource(Method.POST, path, req1, resp1, HttpStatus.SC_OK);
-    NameIdentifier id = NameIdentifier.of(metalakeName, catalogName);
     Map<String, String> emptyMap = Collections.emptyMap();
 
     Assertions.assertThrows(
         UnsupportedOperationException.class,
         () ->
             gravitinoClient.createCatalog(
-                id, Catalog.Type.MESSAGING, provider, "comment", emptyMap));
+                catalogName, Catalog.Type.MESSAGING, provider, "comment", emptyMap));
 
     // Test return NoSuchMetalakeException
     ErrorResponse errorResponse =
@@ -232,7 +225,7 @@ public class TestGravitinoMetalake extends TestBase {
             NoSuchMetalakeException.class,
             () ->
                 gravitinoClient.createCatalog(
-                    id, Catalog.Type.RELATIONAL, provider, "comment", emptyMap));
+                    catalogName, Catalog.Type.RELATIONAL, provider, "comment", emptyMap));
     Assertions.assertTrue(ex.getMessage().contains("mock error"));
 
     // Test return CatalogAlreadyExistsException
@@ -245,7 +238,7 @@ public class TestGravitinoMetalake extends TestBase {
             CatalogAlreadyExistsException.class,
             () ->
                 gravitinoClient.createCatalog(
-                    id, Catalog.Type.RELATIONAL, provider, "comment", emptyMap));
+                    catalogName, Catalog.Type.RELATIONAL, provider, "comment", emptyMap));
     Assertions.assertTrue(ex1.getMessage().contains("mock error"));
 
     // Test return internal error
@@ -256,7 +249,7 @@ public class TestGravitinoMetalake extends TestBase {
             RuntimeException.class,
             () ->
                 gravitinoClient.createCatalog(
-                    id, Catalog.Type.RELATIONAL, provider, "comment", emptyMap));
+                    catalogName, Catalog.Type.RELATIONAL, provider, "comment", emptyMap));
     Assertions.assertTrue(ex2.getMessage().contains("mock error"));
   }
 
@@ -286,7 +279,7 @@ public class TestGravitinoMetalake extends TestBase {
 
     buildMockResource(Method.PUT, path, updatesRequest, resp, HttpStatus.SC_OK);
     NameIdentifier id = NameIdentifier.of(metalakeName, catalogName);
-    Catalog catalog = gravitinoClient.alterCatalog(id, change1, change2);
+    Catalog catalog = gravitinoClient.alterCatalog(catalogName, change1, change2);
     Assertions.assertEquals("mock1", catalog.name());
     Assertions.assertEquals("comment1", catalog.comment());
     Assertions.assertEquals(Catalog.Type.RELATIONAL, catalog.type());
@@ -297,7 +290,8 @@ public class TestGravitinoMetalake extends TestBase {
     buildMockResource(Method.PUT, path, updatesRequest, errorResponse, HttpStatus.SC_NOT_FOUND);
     Throwable ex =
         Assertions.assertThrows(
-            NoSuchCatalogException.class, () -> gravitinoClient.alterCatalog(id, change1, change2));
+            NoSuchCatalogException.class,
+            () -> gravitinoClient.alterCatalog(catalogName, change1, change2));
     Assertions.assertTrue(ex.getMessage().contains("mock error"));
 
     // Test return IllegalArgumentException
@@ -306,7 +300,7 @@ public class TestGravitinoMetalake extends TestBase {
     Throwable ex1 =
         Assertions.assertThrows(
             IllegalArgumentException.class,
-            () -> gravitinoClient.alterCatalog(id, change1, change2));
+            () -> gravitinoClient.alterCatalog(catalogName, change1, change2));
     Assertions.assertTrue(ex1.getMessage().contains("mock error"));
 
     // Test return internal error
@@ -315,7 +309,8 @@ public class TestGravitinoMetalake extends TestBase {
         Method.PUT, path, updatesRequest, errorResp, HttpStatus.SC_INTERNAL_SERVER_ERROR);
     Throwable ex2 =
         Assertions.assertThrows(
-            RuntimeException.class, () -> gravitinoClient.alterCatalog(id, change1, change2));
+            RuntimeException.class,
+            () -> gravitinoClient.alterCatalog(catalogName, change1, change2));
     Assertions.assertTrue(ex2.getMessage().contains("mock error"));
   }
 
@@ -326,13 +321,13 @@ public class TestGravitinoMetalake extends TestBase {
 
     DropResponse resp = new DropResponse(true);
     buildMockResource(Method.DELETE, path, null, resp, HttpStatus.SC_OK);
-    boolean dropped = gravitinoClient.dropCatalog(NameIdentifier.of(metalakeName, catalogName));
+    boolean dropped = gravitinoClient.dropCatalog(catalogName);
     Assertions.assertTrue(dropped);
 
     // Test return false
     DropResponse resp1 = new DropResponse(false);
     buildMockResource(Method.DELETE, path, null, resp1, HttpStatus.SC_OK);
-    boolean dropped1 = gravitinoClient.dropCatalog(NameIdentifier.of(metalakeName, catalogName));
+    boolean dropped1 = gravitinoClient.dropCatalog(catalogName);
     Assertions.assertFalse(dropped1);
   }
 

--- a/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/util/AbstractIT.java
+++ b/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/util/AbstractIT.java
@@ -11,9 +11,9 @@ import static com.datastrato.gravitino.server.GravitinoServer.WEBSERVER_CONF_PRE
 import com.datastrato.gravitino.Config;
 import com.datastrato.gravitino.Configs;
 import com.datastrato.gravitino.auth.AuthenticatorType;
+import com.datastrato.gravitino.client.GravitinoAdminClient;
 import com.datastrato.gravitino.dto.rel.ColumnDTO;
 import com.datastrato.gravitino.dto.rel.expressions.LiteralDTO;
-import com.datastrato.gravitino.client.GravitinoAdminClient;
 import com.datastrato.gravitino.integration.test.MiniGravitino;
 import com.datastrato.gravitino.integration.test.MiniGravitinoContext;
 import com.datastrato.gravitino.rel.Column;

--- a/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/util/AbstractIT.java
+++ b/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/util/AbstractIT.java
@@ -11,9 +11,9 @@ import static com.datastrato.gravitino.server.GravitinoServer.WEBSERVER_CONF_PRE
 import com.datastrato.gravitino.Config;
 import com.datastrato.gravitino.Configs;
 import com.datastrato.gravitino.auth.AuthenticatorType;
-import com.datastrato.gravitino.client.GravitinoClient;
 import com.datastrato.gravitino.dto.rel.ColumnDTO;
 import com.datastrato.gravitino.dto.rel.expressions.LiteralDTO;
+import com.datastrato.gravitino.client.GravitinoAdminClient;
 import com.datastrato.gravitino.integration.test.MiniGravitino;
 import com.datastrato.gravitino.integration.test.MiniGravitinoContext;
 import com.datastrato.gravitino.rel.Column;
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
 @ExtendWith(PrintFuncNameExtension.class)
 public class AbstractIT {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractIT.class);
-  protected static GravitinoClient client;
+  protected static GravitinoAdminClient client;
 
   private static final OAuthMockDataProvider mockDataProvider = OAuthMockDataProvider.getInstance();
 
@@ -133,23 +133,23 @@ public class AbstractIT {
         .name()
         .toLowerCase()
         .equals(customConfigs.get(Configs.AUTHENTICATOR.getKey()))) {
-      client = GravitinoClient.builder(uri).withOAuth(mockDataProvider).build();
+      client = GravitinoAdminClient.builder(uri).withOAuth(mockDataProvider).build();
     } else if (AuthenticatorType.SIMPLE
         .name()
         .toLowerCase()
         .equals(customConfigs.get(Configs.AUTHENTICATOR.getKey()))) {
-      client = GravitinoClient.builder(uri).withSimpleAuth().build();
+      client = GravitinoAdminClient.builder(uri).withSimpleAuth().build();
     } else if (AuthenticatorType.KERBEROS
         .name()
         .toLowerCase()
         .equals(customConfigs.get(Configs.AUTHENTICATOR.getKey()))) {
       uri = "http://localhost:" + jettyServerConfig.getHttpPort();
       client =
-          GravitinoClient.builder(uri)
+          GravitinoAdminClient.builder(uri)
               .withKerberosAuth(KerberosProviderHelper.getProvider())
               .build();
     } else {
-      client = GravitinoClient.builder(uri).build();
+      client = GravitinoAdminClient.builder(uri).build();
     }
   }
 
@@ -168,7 +168,7 @@ public class AbstractIT {
     LOG.info("Tearing down Gravitino Server");
   }
 
-  public static GravitinoClient getGravitinoClient() {
+  public static GravitinoAdminClient getGravitinoClient() {
     return client;
   }
 

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoQueryITBase.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoQueryITBase.java
@@ -9,7 +9,7 @@ import static java.lang.Thread.sleep;
 import com.datastrato.gravitino.Catalog;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
-import com.datastrato.gravitino.client.GravitinoClient;
+import com.datastrato.gravitino.client.GravitinoAdminClient;
 import com.datastrato.gravitino.client.GravitinoMetaLake;
 import com.datastrato.gravitino.exceptions.RESTException;
 import com.datastrato.gravitino.integration.test.container.ContainerSuite;
@@ -47,7 +47,7 @@ public class TrinoQueryITBase {
   protected static String mysqlUri = "jdbc:mysql://127.0.0.1";
   protected static String postgresqlUri = "jdbc:postgresql://127.0.0.1";
 
-  protected static GravitinoClient gravitinoClient;
+  protected static GravitinoAdminClient gravitinoClient;
   protected static TrinoITContainers trinoITContainers;
   protected static TrinoQueryRunner trinoQueryRunner;
 
@@ -75,7 +75,7 @@ public class TrinoQueryITBase {
       gravitinoUri = String.format("http://127.0.0.1:%d", AbstractIT.getGravitinoServerPort());
 
     } else {
-      gravitinoClient = GravitinoClient.builder(gravitinoUri).build();
+      gravitinoClient = GravitinoAdminClient.builder(gravitinoUri).build();
     }
   }
 

--- a/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/catalog/GravitinoCatalogManager.java
+++ b/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/catalog/GravitinoCatalogManager.java
@@ -8,7 +8,7 @@ import com.datastrato.gravitino.Catalog;
 import com.datastrato.gravitino.Catalog.Type;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
-import com.datastrato.gravitino.client.GravitinoClient;
+import com.datastrato.gravitino.client.GravitinoAdminClient;
 import com.datastrato.gravitino.client.GravitinoMetaLake;
 import com.google.common.base.Preconditions;
 import com.google.common.cache.Cache;
@@ -29,11 +29,11 @@ public class GravitinoCatalogManager {
   private final Cache<String, Catalog> gravitinoCatalogs;
   private final String metalakeName;
   private final GravitinoMetaLake metalake;
-  private final GravitinoClient gravitinoClient;
+  private final GravitinoAdminClient gravitinoClient;
 
   private GravitinoCatalogManager(String gravitinoUri, String metalakeName) {
     this.metalakeName = metalakeName;
-    this.gravitinoClient = GravitinoClient.builder(gravitinoUri).build();
+    this.gravitinoClient = GravitinoAdminClient.builder(gravitinoUri).build();
     // Will not evict catalog by default
     this.gravitinoCatalogs = CacheBuilder.newBuilder().build();
     this.metalake = gravitinoClient.loadMetalake(NameIdentifier.ofMetalake(metalakeName));

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoPlugin.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoPlugin.java
@@ -4,7 +4,7 @@
  */
 package com.datastrato.gravitino.trino.connector;
 
-import com.datastrato.gravitino.client.GravitinoClient;
+import com.datastrato.gravitino.client.GravitinoAdminClient;
 import com.datastrato.gravitino.trino.connector.catalog.CatalogConnectorManager;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.Plugin;
@@ -15,7 +15,7 @@ public class GravitinoPlugin implements Plugin {
 
   // For testing.
   public static CatalogConnectorManager catalogConnectorManager;
-  public static GravitinoClient gravitinoClient;
+  public static GravitinoAdminClient gravitinoClient;
 
   @Override
   public Iterable<ConnectorFactory> getConnectorFactories() {

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/CatalogConnectorManager.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/CatalogConnectorManager.java
@@ -12,7 +12,7 @@ import static com.datastrato.gravitino.trino.connector.GravitinoErrorCode.GRAVIT
 import com.datastrato.gravitino.Catalog;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
-import com.datastrato.gravitino.client.GravitinoClient;
+import com.datastrato.gravitino.client.GravitinoAdminClient;
 import com.datastrato.gravitino.client.GravitinoMetaLake;
 import com.datastrato.gravitino.exceptions.CatalogAlreadyExistsException;
 import com.datastrato.gravitino.exceptions.NoSuchMetalakeException;
@@ -60,7 +60,7 @@ public class CatalogConnectorManager {
   private final ConcurrentHashMap<String, CatalogConnectorContext> catalogConnectors =
       new ConcurrentHashMap<>();
 
-  private GravitinoClient gravitinoClient;
+  private GravitinoAdminClient gravitinoClient;
   private GravitinoConfig config;
   private final Set<String> usedMetalakes = new HashSet<>();
 
@@ -88,13 +88,13 @@ public class CatalogConnectorManager {
   }
 
   @VisibleForTesting
-  public void setGravitinoClient(GravitinoClient gravitinoClient) {
+  public void setGravitinoClient(GravitinoAdminClient gravitinoClient) {
     this.gravitinoClient = gravitinoClient;
   }
 
   public void start() {
     if (gravitinoClient == null) {
-      gravitinoClient = GravitinoClient.builder(config.getURI()).build();
+      gravitinoClient = GravitinoAdminClient.builder(config.getURI()).build();
     }
 
     // Schedule a task to load catalog from gravitino server.

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/CatalogConnectorMetadata.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/CatalogConnectorMetadata.java
@@ -55,7 +55,7 @@ public class CatalogConnectorMetadata {
       this.metalake = metalake;
       Catalog catalog = metalake.loadCatalog(catalogIdentifier);
       // Make sure the catalog support schema operations.
-      this.tableCatalog = (RelationalCatalog) catalog;
+      this.tableCatalog = (RelationalCatalog) catalog.asTableCatalog();
     } catch (NoSuchCatalogException e) {
       throw new TrinoException(GRAVITINO_CATALOG_NOT_EXISTS, CATALOG_DOES_NOT_EXIST_MSG, e);
     } catch (UnsupportedOperationException e) {

--- a/trino-connector/src/test/java/com/datastrato/gravitino/trino/connector/GravitinoMockServer.java
+++ b/trino-connector/src/test/java/com/datastrato/gravitino/trino/connector/GravitinoMockServer.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.when;
 import com.datastrato.gravitino.Catalog;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
-import com.datastrato.gravitino.client.GravitinoClient;
+import com.datastrato.gravitino.client.GravitinoAdminClient;
 import com.datastrato.gravitino.client.GravitinoMetaLake;
 import com.datastrato.gravitino.exceptions.NoSuchCatalogException;
 import com.datastrato.gravitino.exceptions.NoSuchMetalakeException;
@@ -70,8 +70,8 @@ public class GravitinoMockServer implements AutoCloseable {
     this.catalogConnectorManager = catalogConnectorManager;
   }
 
-  public GravitinoClient createGravitinoClient() {
-    GravitinoClient client = mock(GravitinoClient.class);
+  public GravitinoAdminClient createGravitinoClient() {
+    GravitinoAdminClient client = mock(GravitinoAdminClient.class);
 
     when(client.createMetalake(any(NameIdentifier.class), anyString(), anyMap()))
         .thenAnswer(


### PR DESCRIPTION
### What changes were proposed in this pull request?

For client side API, it is not required to implement those server side API like SupportsCatalogs, SupportsSchemas. We need to refine those interfaces to make it clear and easy-to-use.

### Why are the changes needed?

Today the Java client class such as GravitinoMetaLake, RelationalCatalog, FilesetCatalog are not user-friendly, as they are implementing some server side interfaces, like SupportsCatalogs, SupportsSchemas. Which means, when user call a "listXXX" method on an object, he still need to pass in the NameIdentifier object to represent itself. This is redundant and mis-leading.

Fix: #2479

### Does this PR introduce _any_ user-facing change?

  1. Change in Java client interfaces.

### How was this patch tested?

This is just interface refactor; No new function is introduced. Will ensure all the UT and IT are passed.
