### PR TITLE
[#2186] Improvement: Added more coverage for scan and deleteRange methods

### DIFF
--- a/core/src/test/java/com/datastrato/gravitino/storage/kv/TestRocksDBKvBackend.java
+++ b/core/src/test/java/com/datastrato/gravitino/storage/kv/TestRocksDBKvBackend.java
@@ -162,6 +162,79 @@ public class TestRocksDBKvBackend {
   }
 
   @Test
+  void testDeleteRange_isStartExclusiveTrue() throws IOException {
+    KvBackend kvBackend = getKvBackEnd();
+    kvBackend.put(
+        "abc".getBytes(StandardCharsets.UTF_8), "abc".getBytes(StandardCharsets.UTF_8), false);
+    kvBackend.put(
+        "abd".getBytes(StandardCharsets.UTF_8), "abd".getBytes(StandardCharsets.UTF_8), false);
+    kvBackend.put(
+        "abffff".getBytes(StandardCharsets.UTF_8),
+        "abffff".getBytes(StandardCharsets.UTF_8),
+        false);
+    kvBackend.put(
+        "abeee".getBytes(StandardCharsets.UTF_8), "abeee".getBytes(StandardCharsets.UTF_8), false);
+    kvBackend.put(
+        "acc".getBytes(StandardCharsets.UTF_8), "acc".getBytes(StandardCharsets.UTF_8), false);
+    kvBackend.put(
+        "acca".getBytes(StandardCharsets.UTF_8), "acca".getBytes(StandardCharsets.UTF_8), false);
+    kvBackend.put(
+        "accb".getBytes(StandardCharsets.UTF_8), "accb".getBytes(StandardCharsets.UTF_8), false);
+
+    // More test case please refer to TestTransactionalKvBackend
+    KvRange kvRange =
+        new KvRange.KvRangeBuilder()
+            .start("abc".getBytes(StandardCharsets.UTF_8))
+            .end("abc".getBytes(StandardCharsets.UTF_8))
+            .startInclusive(true)
+            .endInclusive(false)
+            .build();
+
+    Assertions.assertDoesNotThrow(() -> kvBackend.deleteRange(kvRange));
+    Assertions.assertNull(kvBackend.get("abc".getBytes(StandardCharsets.UTF_8)));
+
+    Assertions.assertNotNull(kvBackend.get("acc".getBytes(StandardCharsets.UTF_8)));
+    Assertions.assertNotNull(kvBackend.get("acca".getBytes(StandardCharsets.UTF_8)));
+    Assertions.assertNotNull(kvBackend.get("accb".getBytes(StandardCharsets.UTF_8)));
+  }
+
+  @Test
+  void testDeleteRange_isEndExclusiveTrue() throws IOException {
+    KvBackend kvBackend = getKvBackEnd();
+    kvBackend.put(
+        "abc".getBytes(StandardCharsets.UTF_8), "abc".getBytes(StandardCharsets.UTF_8), false);
+    kvBackend.put(
+        "abd".getBytes(StandardCharsets.UTF_8), "abd".getBytes(StandardCharsets.UTF_8), false);
+    kvBackend.put(
+        "abffff".getBytes(StandardCharsets.UTF_8),
+        "abffff".getBytes(StandardCharsets.UTF_8),
+        false);
+    kvBackend.put(
+        "abeee".getBytes(StandardCharsets.UTF_8), "abeee".getBytes(StandardCharsets.UTF_8), false);
+    kvBackend.put(
+        "acc".getBytes(StandardCharsets.UTF_8), "acc".getBytes(StandardCharsets.UTF_8), false);
+    kvBackend.put(
+        "acca".getBytes(StandardCharsets.UTF_8), "acca".getBytes(StandardCharsets.UTF_8), false);
+    kvBackend.put(
+        "accb".getBytes(StandardCharsets.UTF_8), "accb".getBytes(StandardCharsets.UTF_8), false);
+
+    // More test case please refer to TestTransactionalKvBackend
+    KvRange kvRange =
+        new KvRange.KvRangeBuilder()
+            .start("ab".getBytes(StandardCharsets.UTF_8))
+            .end("abc".getBytes(StandardCharsets.UTF_8))
+            .startInclusive(false)
+            .endInclusive(true)
+            .build();
+
+    Assertions.assertDoesNotThrow(() -> kvBackend.deleteRange(kvRange));
+
+    Assertions.assertNotNull(kvBackend.get("acc".getBytes(StandardCharsets.UTF_8)));
+    Assertions.assertNotNull(kvBackend.get("acca".getBytes(StandardCharsets.UTF_8)));
+    Assertions.assertNotNull(kvBackend.get("accb".getBytes(StandardCharsets.UTF_8)));
+  }
+
+  @Test
   void testScanWithBrokenRocksDB() throws IOException {
     KvBackend kvBackend = getKvBackEnd();
     kvBackend.put(
@@ -196,6 +269,102 @@ public class TestRocksDBKvBackend {
 
     List<Pair<byte[], byte[]>> data = kvBackend.scan(kvRange);
     Assertions.assertEquals(4, data.size());
+
+    RocksDBKvBackend rocksDBKvBackend = (RocksDBKvBackend) kvBackend;
+    RocksDB db = rocksDBKvBackend.getDb();
+    RocksDB spyDb = Mockito.spy(db);
+
+    Mockito.when(spyDb.newIterator()).thenThrow(new RuntimeException("Mock: RocksDB is broken"));
+    rocksDBKvBackend.setDb(spyDb);
+
+    Exception e =
+        Assertions.assertThrowsExactly(RuntimeException.class, () -> kvBackend.scan(kvRange));
+    Assertions.assertTrue(e.getMessage().contains("Mock: RocksDB is broken"));
+  }
+
+  @Test
+  void testScanWithBrokenRocksDB_isStartExclusiveTrue() throws IOException {
+    KvBackend kvBackend = getKvBackEnd();
+    kvBackend.put(
+        "abc".getBytes(StandardCharsets.UTF_8), "abc".getBytes(StandardCharsets.UTF_8), false);
+    kvBackend.put(
+        "abd".getBytes(StandardCharsets.UTF_8), "abd".getBytes(StandardCharsets.UTF_8), false);
+    kvBackend.put(
+        "abffff".getBytes(StandardCharsets.UTF_8),
+        "abffff".getBytes(StandardCharsets.UTF_8),
+        false);
+    kvBackend.put(
+        "abeee".getBytes(StandardCharsets.UTF_8), "abeee".getBytes(StandardCharsets.UTF_8), false);
+    kvBackend.put(
+        "acc".getBytes(StandardCharsets.UTF_8), "acc".getBytes(StandardCharsets.UTF_8), false);
+    kvBackend.put(
+        "acca".getBytes(StandardCharsets.UTF_8), "acca".getBytes(StandardCharsets.UTF_8), false);
+    kvBackend.put(
+        "accb".getBytes(StandardCharsets.UTF_8), "accb".getBytes(StandardCharsets.UTF_8), false);
+    kvBackend.put(
+        "accg".getBytes(StandardCharsets.UTF_8), "accg".getBytes(StandardCharsets.UTF_8), false);
+    kvBackend.put(
+        "acf".getBytes(StandardCharsets.UTF_8), "acf".getBytes(StandardCharsets.UTF_8), false);
+
+    // More test case please refer to TestTransactionalKvBackend
+    KvRange kvRange =
+        new KvRange.KvRangeBuilder()
+            .start("abc".getBytes(StandardCharsets.UTF_8))
+            .end("ac".getBytes(StandardCharsets.UTF_8))
+            .startInclusive(true)
+            .endInclusive(false)
+            .build();
+
+    List<Pair<byte[], byte[]>> data = kvBackend.scan(kvRange);
+    Assertions.assertEquals(4, data.size());
+
+    RocksDBKvBackend rocksDBKvBackend = (RocksDBKvBackend) kvBackend;
+    RocksDB db = rocksDBKvBackend.getDb();
+    RocksDB spyDb = Mockito.spy(db);
+
+    Mockito.when(spyDb.newIterator()).thenThrow(new RuntimeException("Mock: RocksDB is broken"));
+    rocksDBKvBackend.setDb(spyDb);
+
+    Exception e =
+        Assertions.assertThrowsExactly(RuntimeException.class, () -> kvBackend.scan(kvRange));
+    Assertions.assertTrue(e.getMessage().contains("Mock: RocksDB is broken"));
+  }
+
+  @Test
+  void testScanWithBrokenRocksDB_isEndExclusiveTrue() throws IOException {
+    KvBackend kvBackend = getKvBackEnd();
+    kvBackend.put(
+        "abc".getBytes(StandardCharsets.UTF_8), "abc".getBytes(StandardCharsets.UTF_8), false);
+    kvBackend.put(
+        "abd".getBytes(StandardCharsets.UTF_8), "abd".getBytes(StandardCharsets.UTF_8), false);
+    kvBackend.put(
+        "abffff".getBytes(StandardCharsets.UTF_8),
+        "abffff".getBytes(StandardCharsets.UTF_8),
+        false);
+    kvBackend.put(
+        "abeee".getBytes(StandardCharsets.UTF_8), "abeee".getBytes(StandardCharsets.UTF_8), false);
+    kvBackend.put(
+        "acc".getBytes(StandardCharsets.UTF_8), "acc".getBytes(StandardCharsets.UTF_8), false);
+    kvBackend.put(
+        "acca".getBytes(StandardCharsets.UTF_8), "acca".getBytes(StandardCharsets.UTF_8), false);
+    kvBackend.put(
+        "accb".getBytes(StandardCharsets.UTF_8), "accb".getBytes(StandardCharsets.UTF_8), false);
+    kvBackend.put(
+        "accg".getBytes(StandardCharsets.UTF_8), "accg".getBytes(StandardCharsets.UTF_8), false);
+    kvBackend.put(
+        "acf".getBytes(StandardCharsets.UTF_8), "acf".getBytes(StandardCharsets.UTF_8), false);
+
+    // More test case please refer to TestTransactionalKvBackend
+    KvRange kvRange =
+        new KvRange.KvRangeBuilder()
+            .start("ab".getBytes(StandardCharsets.UTF_8))
+            .end("abc".getBytes(StandardCharsets.UTF_8))
+            .startInclusive(false)
+            .endInclusive(true)
+            .build();
+
+    List<Pair<byte[], byte[]>> data = kvBackend.scan(kvRange);
+    Assertions.assertEquals(1, data.size());
 
     RocksDBKvBackend rocksDBKvBackend = (RocksDBKvBackend) kvBackend;
     RocksDB db = rocksDBKvBackend.getDb();

--- a/core/src/test/java/com/datastrato/gravitino/storage/kv/TestRocksDBKvBackend.java
+++ b/core/src/test/java/com/datastrato/gravitino/storage/kv/TestRocksDBKvBackend.java
@@ -162,7 +162,7 @@ public class TestRocksDBKvBackend {
   }
 
   @Test
-  void testDeleteRange_isStartExclusiveTrue() throws IOException {
+  void testDeleteRangeWhenIsStartExclusiveTrue() throws IOException {
     KvBackend kvBackend = getKvBackEnd();
     kvBackend.put(
         "abc".getBytes(StandardCharsets.UTF_8), "abc".getBytes(StandardCharsets.UTF_8), false);
@@ -199,7 +199,7 @@ public class TestRocksDBKvBackend {
   }
 
   @Test
-  void testDeleteRange_isEndExclusiveTrue() throws IOException {
+  void testDeleteRangeWhenIsEndExclusiveTrue() throws IOException {
     KvBackend kvBackend = getKvBackEnd();
     kvBackend.put(
         "abc".getBytes(StandardCharsets.UTF_8), "abc".getBytes(StandardCharsets.UTF_8), false);
@@ -283,7 +283,7 @@ public class TestRocksDBKvBackend {
   }
 
   @Test
-  void testScanWithBrokenRocksDB_isStartExclusiveTrue() throws IOException {
+  void testScanWithBrokenRocksDWhenIsStartExclusiveTrue() throws IOException {
     KvBackend kvBackend = getKvBackEnd();
     kvBackend.put(
         "abc".getBytes(StandardCharsets.UTF_8), "abc".getBytes(StandardCharsets.UTF_8), false);
@@ -331,7 +331,7 @@ public class TestRocksDBKvBackend {
   }
 
   @Test
-  void testScanWithBrokenRocksDB_isEndExclusiveTrue() throws IOException {
+  void testScanWithBrokenRocksDBWhenIsEndExclusiveTrue() throws IOException {
     KvBackend kvBackend = getKvBackEnd();
     kvBackend.put(
         "abc".getBytes(StandardCharsets.UTF_8), "abc".getBytes(StandardCharsets.UTF_8), false);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added coverage for scan and deleteRange methods.

### Why are the changes needed?

Fix: https://github.com/datastrato/gravitino/issues/2186

### Does this PR introduce any user-facing change?

No

### How was this patch tested?

./gradlew clean build 