### PR TITLE
[#1640] [Improvement] Standardize the invocation method for the Builder pattern 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,6 @@
 [![Last Committed](https://img.shields.io/github/last-commit/datastrato/gravitino)](https://github.com/datastrato/gravitino/commits/main/)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8358/badge)](https://www.bestpractices.dev/projects/8358)
 
-
-[![License](https://img.shields.io/github/license/datastrato/gravitino)](https://github.com/datastrato/gravitino/blob/main/LICENSE)
-[![Contributors](https://img.shields.io/github/contributors/datastrato/gravitino)](https://github.com/datastrato/gravitino/graphs/contributors)
-[![Release](https://img.shields.io/github/v/release/datastrato/gravitino)](https://github.com/datastrato/gravitino/releases)
-[![Open Issues](https://img.shields.io/github/issues-raw/datastrato/gravitino)](https://github.com/datastrato/gravitino/issues)
-[![Last Committed](https://img.shields.io/github/last-commit/datastrato/gravitino)](https://github.com/datastrato/gravitino/commits/main/)
-
 ## Introduction
 
 Gravitino is a high-performance, geo-distributed, and federated metadata lake. It manages the metadata directly in different sources, types, and regions. It also provides users with unified metadata access for data and AI assets.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@
 [![Last Committed](https://img.shields.io/github/last-commit/datastrato/gravitino)](https://github.com/datastrato/gravitino/commits/main/)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8358/badge)](https://www.bestpractices.dev/projects/8358)
 
+
+[![License](https://img.shields.io/github/license/datastrato/gravitino)](https://github.com/datastrato/gravitino/blob/main/LICENSE)
+[![Contributors](https://img.shields.io/github/contributors/datastrato/gravitino)](https://github.com/datastrato/gravitino/graphs/contributors)
+[![Release](https://img.shields.io/github/v/release/datastrato/gravitino)](https://github.com/datastrato/gravitino/releases)
+[![Open Issues](https://img.shields.io/github/issues-raw/datastrato/gravitino)](https://github.com/datastrato/gravitino/issues)
+[![Last Committed](https://img.shields.io/github/last-commit/datastrato/gravitino)](https://github.com/datastrato/gravitino/commits/main/)
+
 ## Introduction
 
 Gravitino is a high-performance, geo-distributed, and federated metadata lake. It manages the metadata directly in different sources, types, and regions. It also provides users with unified metadata access for data and AI assets.
@@ -96,8 +103,10 @@ Gravitino provides a Trino connector to access the metadata in Gravitino. To use
 2. [How to test Gravitino](docs/how-to-test.md)
 3. [How to publish Docker images](docs/publish-docker-images.md)
 
+
 ## License
 
 Gravitino is under the Apache License Version 2.0, See the [LICENSE](LICENSE) for the details.
 
 <sub>Apache®, Apache Hadoop&reg;, Apache Hive&trade;, Apache Iceberg&trade;, Apache Kafka&reg;, Apache Spark&trade;, Apache Submarine&trade;, Apache Thrift&trade; and Apache Zeppelin&trade; are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries.</sub>
+

--- a/README.md
+++ b/README.md
@@ -103,10 +103,8 @@ Gravitino provides a Trino connector to access the metadata in Gravitino. To use
 2. [How to test Gravitino](docs/how-to-test.md)
 3. [How to publish Docker images](docs/publish-docker-images.md)
 
-
 ## License
 
 Gravitino is under the Apache License Version 2.0, See the [LICENSE](LICENSE) for the details.
 
 <sub>Apache®, Apache Hadoop&reg;, Apache Hive&trade;, Apache Iceberg&trade;, Apache Kafka&reg;, Apache Spark&trade;, Apache Submarine&trade;, Apache Thrift&trade; and Apache Zeppelin&trade; are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries.</sub>
-

--- a/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogOperations.java
@@ -130,7 +130,7 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
       FilesetEntity filesetEntity =
           store.get(ident, Entity.EntityType.FILESET, FilesetEntity.class);
 
-      return new HadoopFileset.Builder()
+      return HadoopFileset.builder()
           .withName(ident.name())
           .withType(filesetEntity.filesetType())
           .withComment(filesetEntity.comment())
@@ -218,7 +218,7 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
     Preconditions.checkArgument(stringId != null, "Property String identifier should not be null");
 
     FilesetEntity filesetEntity =
-        new FilesetEntity.Builder()
+        FilesetEntity.builder()
             .withName(ident.name())
             .withId(stringId.id())
             .withNamespace(ident.namespace())
@@ -242,7 +242,7 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
       throw new RuntimeException("Failed to create fileset " + ident, ioe);
     }
 
-    return new HadoopFileset.Builder()
+    return HadoopFileset.builder()
         .withName(ident.name())
         .withComment(comment)
         .withType(type)
@@ -271,7 +271,7 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
               Entity.EntityType.FILESET,
               e -> updateFilesetEntity(ident, e, changes));
 
-      return new HadoopFileset.Builder()
+      return HadoopFileset.builder()
           .withName(updatedFilesetEntity.name())
           .withComment(updatedFilesetEntity.comment())
           .withType(updatedFilesetEntity.filesetType())
@@ -370,7 +370,7 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
     Preconditions.checkNotNull(stringId, "Property String identifier should not be null");
 
     SchemaEntity schemaEntity =
-        new SchemaEntity.Builder()
+        SchemaEntity.builder()
             .withName(ident.name())
             .withId(stringId.id())
             .withNamespace(ident.namespace())
@@ -388,7 +388,7 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
       throw new RuntimeException("Failed to create schema " + ident, ioe);
     }
 
-    return new HadoopSchema.Builder()
+    return HadoopSchema.builder()
         .withName(ident.name())
         .withComment(comment)
         .withProperties(schemaEntity.properties())
@@ -401,7 +401,7 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
     try {
       SchemaEntity schemaEntity = store.get(ident, Entity.EntityType.SCHEMA, SchemaEntity.class);
 
-      return new HadoopSchema.Builder()
+      return HadoopSchema.builder()
           .withName(ident.name())
           .withComment(schemaEntity.comment())
           .withProperties(schemaEntity.properties())
@@ -434,7 +434,7 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
               Entity.EntityType.SCHEMA,
               schemaEntity -> updateSchemaEntity(ident, schemaEntity, changes));
 
-      return new HadoopSchema.Builder()
+      return HadoopSchema.builder()
           .withName(ident.name())
           .withComment(entity.comment())
           .withProperties(entity.properties())
@@ -545,7 +545,7 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
       }
     }
 
-    return new SchemaEntity.Builder()
+    return SchemaEntity.builder()
         .withName(schemaEntity.name())
         .withNamespace(ident.namespace())
         .withId(schemaEntity.id())
@@ -587,7 +587,7 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
       }
     }
 
-    return new FilesetEntity.Builder()
+    return FilesetEntity.builder()
         .withName(newName)
         .withNamespace(ident.namespace())
         .withId(filesetEntity.id())

--- a/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopFileset.java
+++ b/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopFileset.java
@@ -9,6 +9,8 @@ import com.datastrato.gravitino.connector.BaseFileset;
 public class HadoopFileset extends BaseFileset {
 
   public static class Builder extends BaseFilesetBuilder<Builder, HadoopFileset> {
+    /** Creates a new instance of {@link Builder}. */
+    private Builder() {}
 
     @Override
     protected HadoopFileset internalBuild() {
@@ -21,5 +23,14 @@ public class HadoopFileset extends BaseFileset {
       fileset.auditInfo = auditInfo;
       return fileset;
     }
+  }
+
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopSchema.java
+++ b/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopSchema.java
@@ -9,6 +9,8 @@ import com.datastrato.gravitino.connector.BaseSchema;
 public class HadoopSchema extends BaseSchema {
 
   public static class Builder extends BaseSchemaBuilder<Builder, HadoopSchema> {
+    /** Creates a new instance of {@link Builder}. */
+    private Builder() {}
 
     @Override
     protected HadoopSchema internalBuild() {
@@ -19,5 +21,14 @@ public class HadoopSchema extends BaseSchema {
       schema.auditInfo = auditInfo;
       return schema;
     }
+  }
+
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
@@ -308,7 +308,7 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
       throws NoSuchCatalogException, SchemaAlreadyExistsException {
     try {
       HiveSchema hiveSchema =
-          new HiveSchema.Builder()
+          HiveSchema.builder()
               .withName(ident.name())
               .withComment(comment)
               .withProperties(properties)
@@ -701,7 +701,7 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
       }
 
       HiveTable hiveTable =
-          new HiveTable.Builder()
+          HiveTable.builder()
               .withName(tableIdent.name())
               .withSchemaName(schemaIdent.name())
               .withClientPool(clientPool)

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveColumn.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveColumn.java
@@ -16,6 +16,9 @@ public class HiveColumn extends BaseColumn {
   /** A builder class for constructing HiveColumn instances. */
   public static class Builder extends BaseColumnBuilder<Builder, HiveColumn> {
 
+    /** Creates a new instance of {@link Builder}. */
+    private Builder() {}
+
     /**
      * Internal method to build a HiveColumn instance using the provided values.
      *
@@ -32,5 +35,14 @@ public class HiveColumn extends BaseColumn {
       hiveColumn.defaultValue = defaultValue == null ? DEFAULT_VALUE_NOT_SET : defaultValue;
       return hiveColumn;
     }
+  }
+
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveSchema.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveSchema.java
@@ -38,7 +38,7 @@ public class HiveSchema extends BaseSchema {
     AuditInfo.Builder auditInfoBuilder = AuditInfo.builder();
     Optional.ofNullable(db.getOwnerName()).ifPresent(auditInfoBuilder::withCreator);
 
-    return new HiveSchema.Builder()
+    return HiveSchema.builder()
         .withName(db.getName())
         .withComment(db.getDescription())
         .withProperties(properties)
@@ -98,6 +98,9 @@ public class HiveSchema extends BaseSchema {
       return this;
     }
 
+    /** Creates a new instance of {@link Builder}. */
+    private Builder() {}
+
     /**
      * Internal method to build a HiveSchema instance using the provided values.
      *
@@ -114,5 +117,13 @@ public class HiveSchema extends BaseSchema {
 
       return hiveSchema;
     }
+  }
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveTable.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveTable.java
@@ -109,7 +109,7 @@ public class HiveTable extends BaseTable {
                 sd.getCols().stream()
                     .map(
                         f ->
-                            new HiveColumn.Builder()
+                            HiveColumn.builder()
                                 .withName(f.getName())
                                 .withType(FromHiveType.convert(f.getType()))
                                 .withComment(f.getComment())
@@ -117,14 +117,14 @@ public class HiveTable extends BaseTable {
                 table.getPartitionKeys().stream()
                     .map(
                         p ->
-                            new HiveColumn.Builder()
+                            HiveColumn.builder()
                                 .withName(p.getName())
                                 .withType(FromHiveType.convert(p.getType()))
                                 .withComment(p.getComment())
                                 .build()))
             .toArray(Column[]::new);
 
-    return new HiveTable.Builder()
+    return HiveTable.builder()
         .withName(table.getTableName())
         .withComment(table.getParameters().get(COMMENT))
         .withProperties(buildTableProperties(table))
@@ -359,6 +359,9 @@ public class HiveTable extends BaseTable {
       return this;
     }
 
+    /** Creates a new instance of {@link Builder}. */
+    private Builder() {}
+
     /**
      * Internal method to build a HiveTable instance using the provided values.
      *
@@ -387,5 +390,14 @@ public class HiveTable extends BaseTable {
 
       return hiveTable;
     }
+  }
+
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/dyn/DynConstructors.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/dyn/DynConstructors.java
@@ -176,7 +176,7 @@ public class DynConstructors {
       this.baseClass = baseClass;
     }
 
-    public Builder() {
+    private Builder() {
       this.baseClass = null;
     }
 

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/dyn/DynMethods.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/dyn/DynMethods.java
@@ -320,7 +320,7 @@ public class DynMethods {
       }
 
       try {
-        this.method = new DynConstructors.Builder().impl(targetClass, argClasses).buildChecked();
+        this.method = DynConstructors.builder().impl(targetClass, argClasses).buildChecked();
       } catch (NoSuchMethodException e) {
         // not the right implementation
       }
@@ -334,7 +334,7 @@ public class DynMethods {
       }
 
       try {
-        this.method = new DynConstructors.Builder().impl(className, argClasses).buildChecked();
+        this.method = DynConstructors.builder().impl(className, argClasses).buildChecked();
       } catch (NoSuchMethodException e) {
         // not the right implementation
       }

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveTable.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveTable.java
@@ -130,13 +130,13 @@ public class TestHiveTable extends MiniHiveMetastoreService {
     properties.put("key2", "val2");
 
     HiveColumn col1 =
-        new HiveColumn.Builder()
+        HiveColumn.builder()
             .withName("col_1")
             .withType(Types.ByteType.get())
             .withComment(HIVE_COMMENT)
             .build();
     HiveColumn col2 =
-        new HiveColumn.Builder()
+        HiveColumn.builder()
             .withName("col_2")
             .withType(Types.DateType.get())
             .withComment(HIVE_COMMENT)
@@ -203,7 +203,7 @@ public class TestHiveTable extends MiniHiveMetastoreService {
     Assertions.assertTrue(exception.getMessage().contains("Table already exists"));
 
     HiveColumn illegalColumn =
-        new HiveColumn.Builder()
+        HiveColumn.builder()
             .withName("col_3")
             .withType(Types.ByteType.get())
             .withComment(HIVE_COMMENT)
@@ -230,7 +230,7 @@ public class TestHiveTable extends MiniHiveMetastoreService {
                     + "but the current Gravitino Hive catalog only supports Hive 2.x"));
 
     HiveColumn withDefault =
-        new HiveColumn.Builder()
+        HiveColumn.builder()
             .withName("col_3")
             .withType(Types.ByteType.get())
             .withComment(HIVE_COMMENT)
@@ -267,13 +267,13 @@ public class TestHiveTable extends MiniHiveMetastoreService {
     properties.put("key2", "val2");
 
     HiveColumn col1 =
-        new HiveColumn.Builder()
+        HiveColumn.builder()
             .withName("city")
             .withType(Types.ByteType.get())
             .withComment(HIVE_COMMENT)
             .build();
     HiveColumn col2 =
-        new HiveColumn.Builder()
+        HiveColumn.builder()
             .withName("dt")
             .withType(Types.DateType.get())
             .withComment(HIVE_COMMENT)
@@ -350,13 +350,13 @@ public class TestHiveTable extends MiniHiveMetastoreService {
     properties.put("key2", "val2");
 
     HiveColumn col1 =
-        new HiveColumn.Builder()
+        HiveColumn.builder()
             .withName("col_1")
             .withType(Types.ByteType.get())
             .withComment(HIVE_COMMENT)
             .build();
     HiveColumn col2 =
-        new HiveColumn.Builder()
+        HiveColumn.builder()
             .withName("col_2")
             .withType(Types.DateType.get())
             .withComment(HIVE_COMMENT)
@@ -399,13 +399,13 @@ public class TestHiveTable extends MiniHiveMetastoreService {
     properties.put("key2", "val2");
 
     HiveColumn col1 =
-        new HiveColumn.Builder()
+        HiveColumn.builder()
             .withName("col_1")
             .withType(Types.ByteType.get())
             .withComment(HIVE_COMMENT)
             .build();
     HiveColumn col2 =
-        new HiveColumn.Builder()
+        HiveColumn.builder()
             .withName("col_2")
             .withType(Types.DateType.get())
             .withComment(HIVE_COMMENT)
@@ -535,17 +535,17 @@ public class TestHiveTable extends MiniHiveMetastoreService {
 
     Column[] expected =
         new Column[] {
-          new HiveColumn.Builder()
+          HiveColumn.builder()
               .withName("col_3_new")
               .withType(Types.StringType.get())
               .withComment(null)
               .build(),
-          new HiveColumn.Builder()
+          HiveColumn.builder()
               .withName("col_1")
               .withType(Types.IntegerType.get())
               .withComment(HIVE_COMMENT + "_new")
               .build(),
-          new HiveColumn.Builder()
+          HiveColumn.builder()
               .withName("col_2")
               .withType(Types.DateType.get())
               .withComment(HIVE_COMMENT)
@@ -586,13 +586,13 @@ public class TestHiveTable extends MiniHiveMetastoreService {
     properties.put("key2", "val2");
 
     HiveColumn col1 =
-        new HiveColumn.Builder()
+        HiveColumn.builder()
             .withName("col_1")
             .withType(Types.ByteType.get())
             .withComment(HIVE_COMMENT)
             .build();
     HiveColumn col2 =
-        new HiveColumn.Builder()
+        HiveColumn.builder()
             .withName("col_2")
             .withType(Types.DateType.get())
             .withComment(HIVE_COMMENT)
@@ -626,13 +626,13 @@ public class TestHiveTable extends MiniHiveMetastoreService {
     properties.put(TABLE_TYPE, EXTERNAL_TABLE.name().toLowerCase(Locale.ROOT));
 
     HiveColumn col1 =
-        new HiveColumn.Builder()
+        HiveColumn.builder()
             .withName("col_1")
             .withType(Types.ByteType.get())
             .withComment(HIVE_COMMENT)
             .build();
     HiveColumn col2 =
-        new HiveColumn.Builder()
+        HiveColumn.builder()
             .withName("col_2")
             .withType(Types.DateType.get())
             .withComment(HIVE_COMMENT)

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveTableOperations.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveTableOperations.java
@@ -65,11 +65,9 @@ public class TestHiveTableOperations extends MiniHiveMetastoreService {
     properties.put("key2", "val2");
 
     HiveColumn col0 =
-        new HiveColumn.Builder().withName("name").withType(Types.StringType.get()).build();
-    HiveColumn col1 =
-        new HiveColumn.Builder().withName("city").withType(Types.ByteType.get()).build();
-    HiveColumn col2 =
-        new HiveColumn.Builder().withName("dt").withType(Types.DateType.get()).build();
+        HiveColumn.builder().withName("name").withType(Types.StringType.get()).build();
+    HiveColumn col1 = HiveColumn.builder().withName("city").withType(Types.ByteType.get()).build();
+    HiveColumn col2 = HiveColumn.builder().withName("dt").withType(Types.DateType.get()).build();
 
     columns = new Column[] {col0, col1, col2};
 

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
@@ -185,7 +185,7 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
     resultProperties.remove(StringIdentifier.ID_KEY);
     databaseOperation.create(
         ident.name(), StringIdentifier.addToComment(identifier, comment), resultProperties);
-    return new JdbcSchema.Builder()
+    return JdbcSchema.builder()
         .withName(ident.name())
         .withProperties(resultProperties)
         .withComment(comment)
@@ -212,7 +212,7 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
     }
     Map<String, String> properties =
         load.properties() == null ? Maps.newHashMap() : Maps.newHashMap(load.properties());
-    return new JdbcSchema.Builder()
+    return JdbcSchema.builder()
         .withAuditInfo(load.auditInfo())
         .withName(load.name())
         .withComment(StringIdentifier.removeIdFromComment(load.comment()))
@@ -289,7 +289,7 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
       // Remove id from comment
       comment = StringIdentifier.removeIdFromComment(comment);
     }
-    return new JdbcTable.Builder()
+    return JdbcTable.builder()
         .withAuditInfo(load.auditInfo())
         .withName(tableName)
         .withColumns(load.columns())
@@ -387,7 +387,7 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
         Arrays.stream(columns)
             .map(
                 column ->
-                    new JdbcColumn.Builder()
+                    JdbcColumn.builder()
                         .withName(column.name())
                         .withType(column.dataType())
                         .withComment(column.comment())
@@ -408,7 +408,7 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
         partitioning,
         indexes);
 
-    return new JdbcTable.Builder()
+    return JdbcTable.builder()
         .withAuditInfo(
             AuditInfo.builder().withCreator(currentUser()).withCreateTime(Instant.now()).build())
         .withName(tableName)

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcColumn.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcColumn.java
@@ -15,7 +15,8 @@ public class JdbcColumn extends BaseColumn {
 
   /** A builder class for constructing JdbcColumn instances. */
   public static class Builder extends BaseColumnBuilder<Builder, JdbcColumn> {
-
+    /** Creates a new instance of {@link Builder}. */
+    private Builder() {}
     /**
      * Internal method to build a JdbcColumn instance using the provided values.
      *
@@ -35,5 +36,14 @@ public class JdbcColumn extends BaseColumn {
       jdbcColumn.autoIncrement = autoIncrement;
       return jdbcColumn;
     }
+  }
+
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcSchema.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcSchema.java
@@ -14,6 +14,8 @@ public class JdbcSchema extends BaseSchema {
   private JdbcSchema() {}
 
   public static class Builder extends BaseSchemaBuilder<Builder, JdbcSchema> {
+    /** Creates a new instance of {@link Builder}. */
+    private Builder() {}
 
     @Override
     protected JdbcSchema internalBuild() {
@@ -24,5 +26,14 @@ public class JdbcSchema extends BaseSchema {
       jdbcSchema.auditInfo = auditInfo;
       return jdbcSchema;
     }
+  }
+
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcTable.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcTable.java
@@ -26,7 +26,8 @@ public class JdbcTable extends BaseTable {
 
   /** A builder class for constructing JdbcTable instances. */
   public static class Builder extends BaseTableBuilder<Builder, JdbcTable> {
-
+    /** Creates a new instance of {@link Builder}. */
+    private Builder() {}
     /**
      * Internal method to build a JdbcTable instance using the provided values.
      *
@@ -53,5 +54,14 @@ public class JdbcTable extends BaseTable {
     public Map<String, String> properties() {
       return properties;
     }
+  }
+
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/operation/JdbcTableOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/operation/JdbcTableOperations.java
@@ -134,7 +134,7 @@ public abstract class JdbcTableOperations implements TableOperation {
       ResultSet table = getTable(connection, databaseName, tableName);
       // The result of tables may be more than one due to the reason above, so we need to check the
       // result
-      JdbcTable.Builder jdbcTableBuilder = new JdbcTable.Builder();
+      JdbcTable.Builder jdbcTableBuilder = JdbcTable.builder();
       boolean found = false;
       // Handle case-sensitive issues.
       while (table.next() && !found) {
@@ -402,7 +402,7 @@ public abstract class JdbcTableOperations implements TableOperation {
   }
 
   protected JdbcTable.Builder getBasicJdbcTableInfo(ResultSet table) throws SQLException {
-    return new JdbcTable.Builder()
+    return JdbcTable.builder()
         .withName(table.getString("TABLE_NAME"))
         .withComment(table.getString("REMARKS"))
         .withAuditInfo(AuditInfo.EMPTY);
@@ -421,7 +421,7 @@ public abstract class JdbcTableOperations implements TableOperation {
     Expression defaultValue =
         columnDefaultValueConverter.toGravitino(typeBean, columnDef, isExpression, nullable);
 
-    return new JdbcColumn.Builder()
+    return JdbcColumn.builder()
         .withName(column.getString("COLUMN_NAME"))
         .withType(typeConverter.toGravitinoType(typeBean))
         .withComment(StringUtils.isEmpty(comment) ? null : comment)

--- a/catalogs/catalog-jdbc-common/src/test/java/com/datastrato/gravitino/catalog/jdbc/operation/SqliteDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/com/datastrato/gravitino/catalog/jdbc/operation/SqliteDatabaseOperations.java
@@ -67,7 +67,7 @@ public class SqliteDatabaseOperations extends JdbcDatabaseOperations {
   @Override
   public JdbcSchema load(String databaseName) throws NoSuchSchemaException {
     if (exist(databaseName)) {
-      return new JdbcSchema.Builder().withName(databaseName).withAuditInfo(AuditInfo.EMPTY).build();
+      return JdbcSchema.builder().withName(databaseName).withAuditInfo(AuditInfo.EMPTY).build();
     }
     return null;
   }

--- a/catalogs/catalog-jdbc-common/src/test/java/com/datastrato/gravitino/catalog/jdbc/operation/TestJdbcTableOperations.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/com/datastrato/gravitino/catalog/jdbc/operation/TestJdbcTableOperations.java
@@ -111,7 +111,7 @@ public class TestJdbcTableOperations {
     JdbcColumn[] columns = generateRandomColumn(1, 4);
     // Sqlite does not support the comment and default value attribute, so it is not set here
     JdbcColumn col_a =
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_a")
             .withNullable(true)
             .withType(Types.IntegerType.get())
@@ -119,7 +119,7 @@ public class TestJdbcTableOperations {
             .withDefaultValue(null)
             .build();
     JdbcColumn col_b =
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_b")
             .withNullable(false)
             .withType(Types.StringType.get())
@@ -190,7 +190,7 @@ public class TestJdbcTableOperations {
     JdbcColumn[] columns = new JdbcColumn[r.nextInt(maxSize - minSize) + minSize];
     for (int j = 0; j < columns.length; j++) {
       columns[j] =
-          new JdbcColumn.Builder()
+          JdbcColumn.builder()
               .withName(prefixColName + (j + 1))
               .withNullable(r.nextBoolean())
               .withType(getRandomGravitinoType())

--- a/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlDatabaseOperations.java
@@ -112,7 +112,7 @@ public class MysqlDatabaseOperations extends JdbcDatabaseOperations {
           properties.put("COLLATE", collationName);
 
           JdbcSchema.Builder builder =
-              new JdbcSchema.Builder()
+              JdbcSchema.builder()
                   .withName(schemaName)
                   .withProperties(properties)
                   .withAuditInfo(AuditInfo.EMPTY);

--- a/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlTableOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlTableOperations.java
@@ -383,7 +383,7 @@ public class MysqlTableOperations extends JdbcTableOperations {
           "Auto increment is not allowed, type: " + column.dataType());
     }
     JdbcColumn updateColumn =
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName(col)
             .withDefaultValue(column.defaultValue())
             .withNullable(column.nullable())
@@ -416,7 +416,7 @@ public class MysqlTableOperations extends JdbcTableOperations {
     String col = change.fieldName()[0];
     JdbcColumn column = getJdbcColumnFromTable(table, col);
     JdbcColumn updateColumn =
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName(col)
             .withDefaultValue(column.defaultValue())
             .withNullable(change.nullable())
@@ -480,7 +480,7 @@ public class MysqlTableOperations extends JdbcTableOperations {
     String col = updateColumnComment.fieldName()[0];
     JdbcColumn column = getJdbcColumnFromTable(jdbcTable, col);
     JdbcColumn updateColumn =
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName(col)
             .withDefaultValue(column.defaultValue())
             .withNullable(column.nullable())
@@ -565,7 +565,7 @@ public class MysqlTableOperations extends JdbcTableOperations {
                 + newColumnName
                 + BACK_QUOTE);
     JdbcColumn newColumn =
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName(newColumnName)
             .withType(column.dataType())
             .withComment(column.comment())
@@ -631,7 +631,7 @@ public class MysqlTableOperations extends JdbcTableOperations {
     JdbcColumn column = getJdbcColumnFromTable(jdbcTable, col);
     StringBuilder sqlBuilder = new StringBuilder(MODIFY_COLUMN + col);
     JdbcColumn newColumn =
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName(col)
             .withType(updateColumnType.getNewDataType())
             .withComment(column.comment())

--- a/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
@@ -432,7 +432,7 @@ public class CatalogMysqlIT extends AbstractIT {
     Assertions.assertEquals(toFunctionArg(Literals.NULL), createdTable.columns()[2].defaultValue());
     Assertions.assertEquals(Column.DEFAULT_VALUE_NOT_SET, createdTable.columns()[3].defaultValue());
     Assertions.assertEquals(
-        new LiteralDTO.Builder()
+        LiteralDTO.builder()
             .withValue("current_timestamp")
             .withDataType(Types.VarCharType.of(255))
             .build(),

--- a/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/CatalogMysqlVersion5IT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/CatalogMysqlVersion5IT.java
@@ -82,7 +82,7 @@ public class CatalogMysqlVersion5IT extends CatalogMysqlIT {
     Assertions.assertEquals(toFunctionArg(Literals.NULL), createdTable.columns()[1].defaultValue());
     Assertions.assertEquals(Column.DEFAULT_VALUE_NOT_SET, createdTable.columns()[2].defaultValue());
     Assertions.assertEquals(
-        new LiteralDTO.Builder()
+        LiteralDTO.builder()
             .withValue("current_timestamp")
             .withDataType(Types.VarCharType.of(255))
             .build(),

--- a/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/MysqlTableOperationsIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/MysqlTableOperationsIT.java
@@ -47,28 +47,28 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
     String tableComment = "test_comment";
     List<JdbcColumn> columns = new ArrayList<>();
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_1")
             .withType(VARCHAR)
             .withComment("test_comment")
             .withNullable(true)
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_2")
             .withType(INT)
             .withNullable(false)
             .withComment("set primary key")
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_3")
             .withType(INT)
             .withNullable(true)
             .withDefaultValue(Literals.NULL)
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_4")
             .withType(VARCHAR)
             .withDefaultValue(Literals.of("hello world", VARCHAR))
@@ -103,7 +103,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
 
     // alter table
     JdbcColumn newColumn =
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_5")
             .withType(VARCHAR)
             .withComment("new_add")
@@ -176,7 +176,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
     String tableComment = "test_comment";
     List<JdbcColumn> columns = new ArrayList<>();
     JdbcColumn col_1 =
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_1")
             .withType(INT)
             .withComment("id")
@@ -184,7 +184,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
             .build();
     columns.add(col_1);
     JdbcColumn col_2 =
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_2")
             .withType(VARCHAR)
             .withComment("name")
@@ -193,7 +193,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
             .build();
     columns.add(col_2);
     JdbcColumn col_3 =
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_3")
             .withType(VARCHAR)
             .withComment("name")
@@ -232,7 +232,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
     // After modifying the type, some attributes of the corresponding column are not supported.
     columns.clear();
     col_1 =
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName(col_1.name())
             .withType(VARCHAR)
             .withComment(col_1.comment())
@@ -258,7 +258,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
 
     columns.clear();
     col_1 =
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName(col_1.name())
             .withType(INT)
             .withComment(col_1.comment())
@@ -267,7 +267,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
             .withDefaultValue(col_1.defaultValue())
             .build();
     col_2 =
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName(col_2.name())
             .withType(col_2.dataType())
             .withComment(newComment)
@@ -297,7 +297,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
 
     columns.clear();
     col_1 =
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName(newColName_1)
             .withType(col_1.dataType())
             .withComment(col_1.comment())
@@ -306,7 +306,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
             .withDefaultValue(col_1.defaultValue())
             .build();
     col_2 =
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName(newColName_2)
             .withType(col_2.dataType())
             .withComment(col_2.comment())
@@ -339,7 +339,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
     columns.clear();
 
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName(col_2.name())
             .withType(col_2.dataType())
             .withComment(newCol2Comment)
@@ -350,7 +350,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
     columns.add(col_1);
     columns.add(col_3);
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_4")
             .withType(VARCHAR)
             .withComment("txt4")
@@ -377,7 +377,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
     columns.clear();
 
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("new_col_2")
             .withType(VARCHAR)
             .withNullable(false)
@@ -386,7 +386,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
             .build());
     columns.add(col3);
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName(col_4.name())
             .withType(col_4.dataType())
             .withNullable(!col_4.nullable())
@@ -413,7 +413,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
     String tableComment = "test_comment";
     List<JdbcColumn> columns = new ArrayList<>();
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_1")
             .withType(Types.DecimalType.of(10, 2))
             .withComment("test_decimal")
@@ -421,7 +421,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
             .withDefaultValue(Literals.decimalLiteral(Decimal.of("0.00", 10, 2)))
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_2")
             .withType(Types.LongType.get())
             .withNullable(false)
@@ -429,7 +429,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
             .withComment("long type")
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_3")
             .withType(Types.TimestampType.withoutTimeZone())
             // MySQL 5.7 doesn't support nullable timestamp
@@ -438,7 +438,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
             .withDefaultValue(Literals.timestampLiteral(LocalDateTime.parse("2013-01-01T00:00:00")))
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_4")
             .withType(Types.DateType.get())
             .withNullable(true)
@@ -472,79 +472,78 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
     String tableComment = "test_comment";
     List<JdbcColumn> columns = new ArrayList<>();
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_1")
             .withType(Types.ByteType.get())
             .withNullable(false)
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_2")
             .withType(Types.ShortType.get())
             .withNullable(true)
             .build());
+    columns.add(JdbcColumn.builder().withName("col_3").withType(INT).withNullable(false).build());
     columns.add(
-        new JdbcColumn.Builder().withName("col_3").withType(INT).withNullable(false).build());
-    columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_4")
             .withType(Types.LongType.get())
             .withNullable(false)
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_5")
             .withType(Types.FloatType.get())
             .withNullable(false)
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_6")
             .withType(Types.DoubleType.get())
             .withNullable(false)
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_7")
             .withType(Types.DateType.get())
             .withNullable(false)
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_8")
             .withType(Types.TimeType.get())
             .withNullable(false)
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_9")
             .withType(Types.TimestampType.withoutTimeZone())
             .withNullable(false)
             .build());
     columns.add(
-        new JdbcColumn.Builder().withName("col_10").withType(Types.DecimalType.of(10, 2)).build());
+        JdbcColumn.builder().withName("col_10").withType(Types.DecimalType.of(10, 2)).build());
     columns.add(
-        new JdbcColumn.Builder().withName("col_11").withType(VARCHAR).withNullable(false).build());
+        JdbcColumn.builder().withName("col_11").withType(VARCHAR).withNullable(false).build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_12")
             .withType(Types.FixedCharType.of(10))
             .withNullable(false)
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_13")
             .withType(Types.StringType.get())
             .withNullable(false)
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_14")
             .withType(Types.BinaryType.get())
             .withNullable(false)
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_15")
             .withType(Types.FixedCharType.of(10))
             .withNullable(false)
@@ -586,7 +585,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
     for (Type type : notSupportType) {
       columns.clear();
       columns.add(
-          new JdbcColumn.Builder().withName("col_1").withType(type).withNullable(false).build());
+          JdbcColumn.builder().withName("col_1").withType(type).withNullable(false).build());
 
       JdbcColumn[] jdbcCols = columns.toArray(new JdbcColumn[0]);
       Map<String, String> emptyMap = Collections.emptyMap();
@@ -619,7 +618,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
         TEST_DB_NAME,
         test_table_1,
         new JdbcColumn[] {
-          new JdbcColumn.Builder()
+          JdbcColumn.builder()
               .withName("col_1")
               .withType(Types.DecimalType.of(10, 2))
               .withComment("test_decimal")
@@ -643,7 +642,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
         testDb,
         test_table_2,
         new JdbcColumn[] {
-          new JdbcColumn.Builder()
+          JdbcColumn.builder()
               .withName("col_1")
               .withType(Types.DecimalType.of(10, 2))
               .withComment("test_decimal")
@@ -667,7 +666,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
         TEST_DB_NAME,
         test_table_1,
         new JdbcColumn[] {
-          new JdbcColumn.Builder()
+          JdbcColumn.builder()
               .withName("col_1")
               .withType(Types.DecimalType.of(10, 2))
               .withComment("test_decimal")
@@ -693,20 +692,20 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
           }
         };
     JdbcColumn[] columns = {
-      new JdbcColumn.Builder()
+      JdbcColumn.builder()
           .withName("col_1")
           .withType(Types.LongType.get())
           .withComment("id")
           .withAutoIncrement(true)
           .withNullable(false)
           .build(),
-      new JdbcColumn.Builder()
+      JdbcColumn.builder()
           .withName("col_2")
           .withType(Types.VarCharType.of(255))
           .withComment("city")
           .withNullable(false)
           .build(),
-      new JdbcColumn.Builder()
+      JdbcColumn.builder()
           .withName("col_3")
           .withType(Types.VarCharType.of(255))
           .withComment("name")
@@ -786,7 +785,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
       columns[0],
       columns[1],
       columns[2],
-      new JdbcColumn.Builder()
+      JdbcColumn.builder()
           .withName("col_4")
           .withType(Types.IntegerType.get())
           .withComment("test_id")

--- a/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/service/MysqlService.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/service/MysqlService.java
@@ -69,7 +69,7 @@ public class MysqlService {
               "Database %s could not be found in information_schema.SCHEMATA", databaseName);
         }
         String schemaName = resultSet.getString("SCHEMA_NAME");
-        return new JdbcSchema.Builder().withName(schemaName).withAuditInfo(AuditInfo.EMPTY).build();
+        return JdbcSchema.builder().withName(schemaName).withAuditInfo(AuditInfo.EMPTY).build();
       }
     } catch (final SQLException se) {
       throw new RuntimeException(se);

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlSchemaOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlSchemaOperations.java
@@ -61,7 +61,7 @@ public class PostgreSqlSchemaOperations extends JdbcDatabaseOperations {
           }
           String schemaName = resultSet.getString(1);
           String comment = getSchemaComment(schema, connection);
-          return new JdbcSchema.Builder()
+          return JdbcSchema.builder()
               .withName(schemaName)
               .withComment(comment)
               .withAuditInfo(AuditInfo.EMPTY)

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/PostgreSqlTableOperationsIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/PostgreSqlTableOperationsIT.java
@@ -47,7 +47,7 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
     String tableComment = "test_comment";
     List<JdbcColumn> columns = new ArrayList<>();
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_1")
             .withType(Types.LongType.get())
             .withComment("increment key")
@@ -55,16 +55,15 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
             .withAutoIncrement(true)
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_2")
             .withType(INT)
             .withNullable(false)
             .withComment("set test key")
             .build());
+    columns.add(JdbcColumn.builder().withName("col_3").withType(INT).withNullable(true).build());
     columns.add(
-        new JdbcColumn.Builder().withName("col_3").withType(INT).withNullable(true).build());
-    columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_4")
             .withType(VARCHAR)
             // TODO: uncomment this line when default value is supported
@@ -97,7 +96,7 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
 
     // alter table
     JdbcColumn newColumn =
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_5")
             .withType(VARCHAR)
             .withComment("new_add")
@@ -115,7 +114,7 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
     load = TABLE_OPERATIONS.load(TEST_DB_NAME, newName);
     List<JdbcColumn> alterColumns = new ArrayList<JdbcColumn>();
     alterColumns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_1")
             .withType(Types.LongType.get())
             .withComment("test_new_comment")
@@ -123,7 +122,7 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
             .withAutoIncrement(true)
             .build());
     alterColumns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_2")
             .withType(Types.DecimalType.of(10, 2))
             .withNullable(false)
@@ -141,7 +140,7 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
     load = TABLE_OPERATIONS.load(TEST_DB_NAME, newName);
     alterColumns.clear();
     alterColumns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_1_new")
             .withType(Types.LongType.get())
             .withComment("test_new_comment")
@@ -149,7 +148,7 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
             .withAutoIncrement(true)
             .build());
     alterColumns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_2")
             .withType(Types.DoubleType.get())
             .withNullable(false)
@@ -165,7 +164,7 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
     load = TABLE_OPERATIONS.load(TEST_DB_NAME, newName);
     alterColumns.clear();
     alterColumns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_1_new")
             .withType(Types.LongType.get())
             .withComment("test_new_comment")
@@ -173,7 +172,7 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
             .withAutoIncrement(true)
             .build());
     alterColumns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_2")
             .withType(Types.DoubleType.get())
             .withNullable(true)
@@ -216,83 +215,82 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
     String tableComment = "test_comment";
     List<JdbcColumn> columns = new ArrayList<>();
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_1")
             .withType(Types.BooleanType.get())
             .withNullable(true)
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_2")
             .withType(Types.ShortType.get())
             .withNullable(false)
             .build());
+    columns.add(JdbcColumn.builder().withName("col_3").withType(INT).withNullable(true).build());
     columns.add(
-        new JdbcColumn.Builder().withName("col_3").withType(INT).withNullable(true).build());
-    columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_4")
             .withType(Types.LongType.get())
             .withNullable(false)
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_5")
             .withType(Types.FloatType.get())
             .withNullable(false)
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_6")
             .withType(Types.DoubleType.get())
             .withNullable(false)
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_7")
             .withType(Types.DateType.get())
             .withNullable(false)
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_8")
             .withType(Types.TimeType.get())
             .withNullable(false)
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_9")
             .withType(Types.TimestampType.withoutTimeZone())
             .withNullable(false)
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_10")
             .withType(Types.TimestampType.withTimeZone())
             .withNullable(false)
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_11")
             .withType(Types.DecimalType.of(10, 2))
             .withNullable(false)
             .build());
     columns.add(
-        new JdbcColumn.Builder().withName("col_12").withType(VARCHAR).withNullable(false).build());
+        JdbcColumn.builder().withName("col_12").withType(VARCHAR).withNullable(false).build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_13")
             .withType(Types.FixedCharType.of(10))
             .withNullable(false)
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_14")
             .withType(Types.StringType.get())
             .withNullable(false)
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_15")
             .withType(Types.BinaryType.get())
             .withNullable(false)
@@ -350,7 +348,7 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
         TEST_DB_NAME,
         table_1,
         new JdbcColumn[] {
-          new JdbcColumn.Builder()
+          JdbcColumn.builder()
               .withName("col_1")
               .withType(VARCHAR)
               .withComment("test_comment_col1")
@@ -378,7 +376,7 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
         TEST_DB_NAME,
         table_2,
         new JdbcColumn[] {
-          new JdbcColumn.Builder()
+          JdbcColumn.builder()
               .withName("col_1")
               .withType(VARCHAR)
               .withComment("test_comment_col1")
@@ -416,7 +414,7 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
     String tableComment = "test_comment";
     List<JdbcColumn> columns = new ArrayList<>();
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_1")
             .withType(Types.LongType.get())
             .withComment("increment key")
@@ -424,7 +422,7 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
             .withAutoIncrement(true)
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_2")
             .withType(INT)
             .withNullable(false)
@@ -451,7 +449,7 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
 
     columns.clear();
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_1")
             .withType(Types.ShortType.get())
             .withComment("increment key")
@@ -459,7 +457,7 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
             .withAutoIncrement(true)
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_2")
             .withType(INT)
             .withNullable(false)
@@ -493,7 +491,7 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
     String tableComment = "test_comment";
     List<JdbcColumn> columns = new ArrayList<>();
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_1")
             .withType(Types.LongType.get())
             .withComment("increment key")
@@ -501,21 +499,21 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
             .withAutoIncrement(true)
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_2")
             .withType(INT)
             .withNullable(false)
             .withComment("id-1")
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_3")
             .withType(VARCHAR)
             .withNullable(false)
             .withComment("name")
             .build());
     columns.add(
-        new JdbcColumn.Builder()
+        JdbcColumn.builder()
             .withName("col_4")
             .withType(VARCHAR)
             .withNullable(false)

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/service/PostgreSqlService.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/service/PostgreSqlService.java
@@ -73,7 +73,7 @@ public class PostgreSqlService {
           throw new NoSuchSchemaException("No such schema: %s", schema);
         }
         String schemaName = resultSet.getString(1);
-        return new JdbcSchema.Builder().withName(schemaName).build();
+        return JdbcSchema.builder().withName(schemaName).build();
       }
     } catch (SQLException e) {
       throw new RuntimeException(e);

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
@@ -156,7 +156,7 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
     try {
       String currentUser = currentUser();
       IcebergSchema createdSchema =
-          new IcebergSchema.Builder()
+          IcebergSchema.builder()
               .withName(ident.name())
               .withComment(comment)
               .withProperties(properties)
@@ -201,7 +201,7 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
       GetNamespaceResponse response =
           icebergTableOps.loadNamespace(IcebergTableOpsHelper.getIcebergNamespace(ident.name()));
       IcebergSchema icebergSchema =
-          new IcebergSchema.Builder()
+          IcebergSchema.builder()
               .withName(ident.name())
               .withComment(
                   Optional.of(response)
@@ -257,7 +257,7 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
               .map(map -> map.get(IcebergSchemaPropertiesMetadata.COMMENT))
               .orElse(null);
       IcebergSchema icebergSchema =
-          new IcebergSchema.Builder()
+          IcebergSchema.builder()
               .withName(ident.name())
               .withComment(comment)
               .withAuditInfo(AuditInfo.EMPTY)

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
@@ -486,7 +486,7 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
                         column.defaultValue().equals(Column.DEFAULT_VALUE_NOT_SET),
                         "Iceberg does not support column default value. Illegal column: "
                             + column.name());
-                    return new IcebergColumn.Builder()
+                    return IcebergColumn.builder()
                         .withName(column.name())
                         .withType(column.dataType())
                         .withComment(column.comment())
@@ -496,7 +496,7 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
               .toArray(IcebergColumn[]::new);
 
       IcebergTable createdTable =
-          new IcebergTable.Builder()
+          IcebergTable.builder()
               .withName(tableIdent.name())
               .withColumns(icebergColumns)
               .withComment(comment)

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergColumn.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergColumn.java
@@ -15,7 +15,8 @@ public class IcebergColumn extends BaseColumn {
 
   /** A builder class for constructing IcebergColumn instances. */
   public static class Builder extends BaseColumnBuilder<Builder, IcebergColumn> {
-
+    /** Creates a new instance of {@link Builder}. */
+    private Builder() {}
     /**
      * Internal method to build a IcebergColumn instance using the provided values.
      *
@@ -31,5 +32,14 @@ public class IcebergColumn extends BaseColumn {
       icebergColumn.defaultValue = defaultValue == null ? DEFAULT_VALUE_NOT_SET : defaultValue;
       return icebergColumn;
     }
+  }
+
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergSchema.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergSchema.java
@@ -31,6 +31,8 @@ public class IcebergSchema extends BaseSchema {
 
   /** A builder class for constructing IcebergSchema instances. */
   public static class Builder extends BaseSchemaBuilder<Builder, IcebergSchema> {
+    /** Creates a new instance of {@link Builder}. */
+    private Builder() {}
 
     @Override
     protected IcebergSchema internalBuild() {
@@ -46,5 +48,14 @@ public class IcebergSchema extends BaseSchema {
       icebergSchema.auditInfo = auditInfo;
       return icebergSchema;
     }
+  }
+
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergTable.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergTable.java
@@ -130,7 +130,7 @@ public class IcebergTable extends BaseTable {
     }
     IcebergColumn[] icebergColumns =
         schema.columns().stream().map(ConvertUtil::fromNestedField).toArray(IcebergColumn[]::new);
-    return new IcebergTable.Builder()
+    return IcebergTable.builder()
         .withComment(table.property(IcebergTablePropertiesMetadata.COMMENT, null))
         .withLocation(table.location())
         .withProperties(properties)
@@ -151,6 +151,8 @@ public class IcebergTable extends BaseTable {
 
   /** A builder class for constructing IcebergTable instances. */
   public static class Builder extends BaseTableBuilder<Builder, IcebergTable> {
+    /** Creates a new instance of {@link Builder}. */
+    private Builder() {}
 
     private String location;
 
@@ -190,5 +192,13 @@ public class IcebergTable extends BaseTable {
       }
       return icebergTable;
     }
+  }
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/ConvertUtil.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/ConvertUtil.java
@@ -57,7 +57,7 @@ public class ConvertUtil {
    * @return Gravitino iceberg column
    */
   public static IcebergColumn fromNestedField(Types.NestedField nestedField) {
-    return new IcebergColumn.Builder()
+    return IcebergColumn.builder()
         .withName(nestedField.name())
         .withNullable(nestedField.isOptional())
         .withComment(nestedField.doc())

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergTable.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergTable.java
@@ -130,14 +130,14 @@ public class TestIcebergTable {
     properties.put("key2", "val2");
 
     IcebergColumn col1 =
-        new IcebergColumn.Builder()
+        IcebergColumn.builder()
             .withName("col_1")
             .withType(Types.IntegerType.get())
             .withComment(ICEBERG_COMMENT)
             .withNullable(true)
             .build();
     IcebergColumn col2 =
-        new IcebergColumn.Builder()
+        IcebergColumn.builder()
             .withName("col_2")
             .withType(Types.DateType.get())
             .withComment(ICEBERG_COMMENT)
@@ -155,7 +155,7 @@ public class TestIcebergTable {
                 "string_field", Types.StringType.get(), "string field"),
             Types.StructType.Field.nullableField("struct_field", structTypeInside, "struct field"));
     IcebergColumn col3 =
-        new IcebergColumn.Builder()
+        IcebergColumn.builder()
             .withName("col_3")
             .withType(structType)
             .withComment(ICEBERG_COMMENT)
@@ -218,7 +218,7 @@ public class TestIcebergTable {
     Assertions.assertTrue(exception.getMessage().contains("Table already exists"));
 
     IcebergColumn withDefaultValue =
-        new IcebergColumn.Builder()
+        IcebergColumn.builder()
             .withName("col")
             .withType(Types.DateType.get())
             .withComment(ICEBERG_COMMENT)
@@ -253,13 +253,13 @@ public class TestIcebergTable {
     properties.put("key2", "val2");
 
     IcebergColumn col1 =
-        new IcebergColumn.Builder()
+        IcebergColumn.builder()
             .withName("city")
             .withType(Types.IntegerType.get())
             .withComment(ICEBERG_COMMENT)
             .build();
     IcebergColumn col2 =
-        new IcebergColumn.Builder()
+        IcebergColumn.builder()
             .withName("date")
             .withType(Types.DateType.get())
             .withComment(ICEBERG_COMMENT)
@@ -333,13 +333,13 @@ public class TestIcebergTable {
     properties.put("key2", "val2");
 
     IcebergColumn col1 =
-        new IcebergColumn.Builder()
+        IcebergColumn.builder()
             .withName("col_1")
             .withType(Types.IntegerType.get())
             .withComment(ICEBERG_COMMENT)
             .build();
     IcebergColumn col2 =
-        new IcebergColumn.Builder()
+        IcebergColumn.builder()
             .withName("col_2")
             .withType(Types.DateType.get())
             .withComment(ICEBERG_COMMENT)
@@ -383,13 +383,13 @@ public class TestIcebergTable {
     properties.put("key2", "val2");
 
     IcebergColumn col1 =
-        new IcebergColumn.Builder()
+        IcebergColumn.builder()
             .withName("col_1")
             .withType(Types.IntegerType.get())
             .withComment(ICEBERG_COMMENT)
             .build();
     IcebergColumn col2 =
-        new IcebergColumn.Builder()
+        IcebergColumn.builder()
             .withName("col_2")
             .withType(Types.DateType.get())
             .withComment(ICEBERG_COMMENT)
@@ -463,17 +463,17 @@ public class TestIcebergTable {
 
     Column[] expected =
         new Column[] {
-          new IcebergColumn.Builder()
+          IcebergColumn.builder()
               .withName("col_2_new")
               .withType(Types.DateType.get())
               .withComment(ICEBERG_COMMENT)
               .build(),
-          new IcebergColumn.Builder()
+          IcebergColumn.builder()
               .withName("col_1")
               .withType(Types.IntegerType.get())
               .withComment(ICEBERG_COMMENT + "_new")
               .build(),
-          new IcebergColumn.Builder()
+          IcebergColumn.builder()
               .withName("col_3")
               .withType(Types.StringType.get())
               .withComment(null)
@@ -548,13 +548,13 @@ public class TestIcebergTable {
   @Test
   public void testTableDistribution() {
     IcebergColumn col_1 =
-        new IcebergColumn.Builder()
+        IcebergColumn.builder()
             .withName("col_1")
             .withType(Types.LongType.get())
             .withComment("test")
             .build();
     IcebergColumn col_2 =
-        new IcebergColumn.Builder()
+        IcebergColumn.builder()
             .withName("col_2")
             .withType(Types.IntegerType.get())
             .withComment("test2")
@@ -567,7 +567,7 @@ public class TestIcebergTable {
           }
         };
     IcebergTable icebergTable =
-        new IcebergTable.Builder()
+        IcebergTable.builder()
             .withName("test_table")
             .withAuditInfo(
                 AuditInfo.builder().withCreator("test").withCreateTime(Instant.now()).build())
@@ -598,7 +598,7 @@ public class TestIcebergTable {
             "Iceberg's Distribution Mode.RANGE is distributed based on sortOrder or partition, but both are empty"));
 
     IcebergTable newTable =
-        new IcebergTable.Builder()
+        IcebergTable.builder()
             .withName("test_table2")
             .withAuditInfo(
                 AuditInfo.builder().withCreator("test2").withCreateTime(Instant.now()).build())

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/TestBaseConvert.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/TestBaseConvert.java
@@ -77,7 +77,7 @@ public class TestBaseConvert {
     ArrayList<Column> results = Lists.newArrayList();
     for (String colName : colNames) {
       results.add(
-          new IcebergColumn.Builder()
+          IcebergColumn.builder()
               .withName(colName)
               .withType(getRandomGravitinoType())
               .withComment(TEST_COMMENT)

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/TestConvertUtil.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/TestConvertUtil.java
@@ -32,7 +32,7 @@ public class TestConvertUtil extends TestBaseConvert {
     Column[] columns = createColumns("col_1", "col_2", "col_3", "col_4");
     String col5Name = "col_5";
     IcebergColumn col5 =
-        new IcebergColumn.Builder()
+        IcebergColumn.builder()
             .withName(col5Name)
             .withType(
                 com.datastrato.gravitino.rel.types.Types.MapType.valueNullable(
@@ -46,7 +46,7 @@ public class TestConvertUtil extends TestBaseConvert {
     columns = ArrayUtils.add(columns, col5);
     SortOrder[] sortOrder = createSortOrder("col_1", "col_2", "col_3", "col_4", "col_5");
     IcebergTable icebergTable =
-        new IcebergTable.Builder()
+        IcebergTable.builder()
             .withName(TEST_NAME)
             .withAuditInfo(
                 AuditInfo.builder().withCreator(TEST_NAME).withCreateTime(Instant.now()).build())

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/DTOConverters.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/DTOConverters.java
@@ -56,6 +56,7 @@ class DTOConverters {
     }
   }
 
+  @SuppressWarnings("unchecked")
   static Catalog toCatalog(CatalogDTO catalog, RESTClient client) {
     switch (catalog.type()) {
       case RELATIONAL:

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/DTOConverters.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/DTOConverters.java
@@ -23,7 +23,7 @@ class DTOConverters {
   private DTOConverters() {}
 
   static GravitinoMetalake toMetaLake(MetalakeDTO metalake, RESTClient client) {
-    return new GravitinoMetalake.Builder()
+    return GravitinoMetalake.builder()
         .withName(metalake.name())
         .withComment(metalake.comment())
         .withProperties(metalake.properties())

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoMetalake.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoMetalake.java
@@ -197,6 +197,10 @@ public class GravitinoMetalake extends MetalakeDTO implements SupportsCatalogs {
   static class Builder extends MetalakeDTO.Builder<Builder> {
     private RESTClient restClient;
 
+    private Builder() {
+      super();
+    }
+
     Builder withRestClient(RESTClient restClient) {
       this.restClient = restClient;
       return this;

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoMetalake.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoMetalake.java
@@ -215,4 +215,8 @@ public class GravitinoMetalake extends MetalakeDTO implements SupportsCatalogs {
       return new GravitinoMetalake(name, comment, properties, audit, restClient);
     }
   }
+
+  public static Builder builder() {
+    return new Builder();
+  }
 }

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoMetalake.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoMetalake.java
@@ -216,6 +216,7 @@ public class GravitinoMetalake extends MetalakeDTO implements SupportsCatalogs {
     }
   }
 
+  /** @return the builder for creating a new instance of GravitinoMetaLake. */
   public static Builder builder() {
     return new Builder();
   }

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
@@ -291,9 +291,4 @@ public class RelationalCatalog extends BaseSchemaCatalog implements TableCatalog
       return new RelationalCatalog(name, type, provider, comment, properties, audit, restClient);
     }
   }
-
-  /** @return the builder for creating a new instance of RelationalCatalog. */
-  public static Builder builder() {
-    return new Builder();
-  }
 }

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
@@ -273,7 +273,7 @@ public class RelationalCatalog extends BaseSchemaCatalog implements TableCatalog
     /** The REST client to send the requests. */
     private RESTClient restClient;
 
-    private Builder() {}
+    protected Builder() {}
 
     Builder withRestClient(RESTClient restClient) {
       this.restClient = restClient;
@@ -290,5 +290,9 @@ public class RelationalCatalog extends BaseSchemaCatalog implements TableCatalog
 
       return new RelationalCatalog(name, type, provider, comment, properties, audit, restClient);
     }
+  }
+
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
@@ -292,6 +292,7 @@ public class RelationalCatalog extends BaseSchemaCatalog implements TableCatalog
     }
   }
 
+  /** @return the builder for creating a new instance of RelationalCatalog. */
   public static Builder builder() {
     return new Builder();
   }

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestFilesetCatalog.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestFilesetCatalog.java
@@ -59,14 +59,14 @@ public class TestFilesetCatalog extends TestBase {
     metalake = TestGravitinoMetalake.createMetalake(client, metalakeName);
 
     CatalogDTO mockCatalog =
-        new CatalogDTO.Builder()
+        CatalogDTO.builder()
             .withName(catalogName)
             .withType(CatalogDTO.Type.FILESET)
             .withProvider(provider)
             .withComment("comment")
             .withProperties(ImmutableMap.of("k1", "k2"))
             .withAudit(
-                new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
+                AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build())
             .build();
 
     CatalogCreateRequest catalogCreateRequest =
@@ -370,7 +370,7 @@ public class TestFilesetCatalog extends TestBase {
         .comment(comment)
         .storageLocation(location)
         .properties(properties)
-        .audit(new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
+        .audit(AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build())
         .build();
   }
 

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestGravitinoClient.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestGravitinoClient.java
@@ -40,14 +40,11 @@ public class TestGravitinoClient extends TestBase {
                 AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build())
             .build();
     MetalakeDTO mockMetalake1 =
-         MetalakeDTO.builder()
+        MetalakeDTO.builder()
             .withName("mock1")
             .withComment("comment1")
             .withAudit(
-                AuditDTO.builder()
-                    .withCreator("creator1")
-                    .withCreateTime(Instant.now())
-                    .build())
+                AuditDTO.builder().withCreator("creator1").withCreateTime(Instant.now()).build())
             .build();
 
     MetalakeListResponse resp =

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestGravitinoClient.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestGravitinoClient.java
@@ -33,18 +33,18 @@ public class TestGravitinoClient extends TestBase {
   @Test
   public void testListMetalakes() throws JsonProcessingException {
     MetalakeDTO mockMetalake =
-        new MetalakeDTO.Builder()
+        MetalakeDTO.builder()
             .withName("mock")
             .withComment("comment")
             .withAudit(
-                new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
+                AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build())
             .build();
     MetalakeDTO mockMetalake1 =
-        new MetalakeDTO.Builder()
+         MetalakeDTO.builder()
             .withName("mock1")
             .withComment("comment1")
             .withAudit(
-                new AuditDTO.Builder()
+                AuditDTO.builder()
                     .withCreator("creator1")
                     .withCreateTime(Instant.now())
                     .build())
@@ -86,11 +86,11 @@ public class TestGravitinoClient extends TestBase {
   @Test
   public void testLoadMetalake() throws JsonProcessingException {
     MetalakeDTO mockMetalake =
-        new MetalakeDTO.Builder()
+        MetalakeDTO.builder()
             .withName("mock")
             .withComment("comment")
             .withAudit(
-                new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
+                AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build())
             .build();
 
     MetalakeResponse resp = new MetalakeResponse(mockMetalake);
@@ -126,11 +126,11 @@ public class TestGravitinoClient extends TestBase {
   @Test
   public void testCreateMetalake() throws JsonProcessingException {
     MetalakeDTO mockMetalake =
-        new MetalakeDTO.Builder()
+        MetalakeDTO.builder()
             .withName("mock")
             .withComment("comment")
             .withAudit(
-                new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
+                AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build())
             .build();
 
     MetalakeCreateRequest req =
@@ -177,11 +177,11 @@ public class TestGravitinoClient extends TestBase {
                 .collect(Collectors.toList()));
 
     MetalakeDTO mockMetalake =
-        new MetalakeDTO.Builder()
+        MetalakeDTO.builder()
             .withName("newName")
             .withComment("newComment")
             .withAudit(
-                new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
+                AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build())
             .build();
     MetalakeResponse resp = new MetalakeResponse(mockMetalake);
 

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestGravitinoMetalake.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestGravitinoMetalake.java
@@ -109,13 +109,13 @@ public class TestGravitinoMetalake extends TestBase {
     String path = "/api/metalakes/" + metalakeName + "/catalogs/" + catalogName;
 
     CatalogDTO mockCatalog =
-        new CatalogDTO.Builder()
+        CatalogDTO.builder()
             .withName("mock")
             .withComment("comment")
             .withType(Catalog.Type.RELATIONAL)
             .withProvider("test")
             .withAudit(
-                new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
+                AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build())
             .build();
     CatalogResponse resp = new CatalogResponse(mockCatalog);
 
@@ -138,13 +138,13 @@ public class TestGravitinoMetalake extends TestBase {
 
     // Test return unsupported catalog type
     CatalogDTO mockCatalog1 =
-        new CatalogDTO.Builder()
+        CatalogDTO.builder()
             .withName("mock")
             .withComment("comment")
             .withType(Catalog.Type.MESSAGING)
             .withProvider("test")
             .withAudit(
-                new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
+                AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build())
             .build();
     CatalogResponse resp1 = new CatalogResponse(mockCatalog1);
     buildMockResource(Method.GET, path, null, resp1, HttpStatus.SC_OK);
@@ -171,13 +171,13 @@ public class TestGravitinoMetalake extends TestBase {
     String path = "/api/metalakes/" + metalakeName + "/catalogs";
 
     CatalogDTO mockCatalog =
-        new CatalogDTO.Builder()
+        CatalogDTO.builder()
             .withName(catalogName)
             .withComment("comment")
             .withType(Catalog.Type.RELATIONAL)
             .withProvider("test")
             .withAudit(
-                new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
+                AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build())
             .build();
     CatalogCreateRequest req =
         new CatalogCreateRequest(
@@ -198,13 +198,13 @@ public class TestGravitinoMetalake extends TestBase {
 
     // Test return unsupported catalog type
     CatalogDTO mockCatalog1 =
-        new CatalogDTO.Builder()
+        CatalogDTO.builder()
             .withName("mock")
             .withComment("comment")
             .withType(Catalog.Type.MESSAGING)
             .withProvider("test")
             .withAudit(
-                new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
+                AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build())
             .build();
     CatalogCreateRequest req1 =
         new CatalogCreateRequest(
@@ -263,13 +263,13 @@ public class TestGravitinoMetalake extends TestBase {
     String path = "/api/metalakes/" + metalakeName + "/catalogs/" + catalogName;
 
     CatalogDTO mockCatalog =
-        new CatalogDTO.Builder()
+        CatalogDTO.builder()
             .withName("mock1")
             .withComment("comment1")
             .withType(Catalog.Type.RELATIONAL)
             .withProvider("test")
             .withAudit(
-                new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
+                AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build())
             .build();
     CatalogResponse resp = new CatalogResponse(mockCatalog);
 
@@ -336,11 +336,11 @@ public class TestGravitinoMetalake extends TestBase {
   static GravitinoMetalake createMetalake(GravitinoAdminClient client, String metalakeName)
       throws JsonProcessingException {
     MetalakeDTO mockMetalake =
-        new MetalakeDTO.Builder()
+        MetalakeDTO.builder()
             .withName(metalakeName)
             .withComment("comment")
             .withAudit(
-                new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
+                AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build())
             .build();
     MetalakeCreateRequest req =
         new MetalakeCreateRequest(metalakeName, "comment", Collections.emptyMap());

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestGravitinoMetalake.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestGravitinoMetalake.java
@@ -51,11 +51,11 @@ public class TestGravitinoMetalake extends TestBase {
     createMetalake(client, metalakeName);
 
     MetalakeDTO mockMetalake =
-        new MetalakeDTO.Builder()
+        MetalakeDTO.builder()
             .withName(metalakeName)
             .withComment("comment")
             .withAudit(
-                new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
+                AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build())
             .build();
     MetalakeResponse resp = new MetalakeResponse(mockMetalake);
     buildMockResource(Method.GET, "/api/metalakes/" + metalakeName, null, resp, HttpStatus.SC_OK);

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalCatalog.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalCatalog.java
@@ -957,7 +957,7 @@ public class TestRelationalCatalog extends TestBase {
         .withStrategy(Strategy.HASH)
         .withNumber(bucketNum)
         .withArgs(
-            new FunctionArg[] {new FieldReferenceDTO.Builder().withColumnName(columnName).build()})
+            new FunctionArg[] {FieldReferenceDTO.builder().withColumnName(columnName).build()})
         .build();
   }
 
@@ -967,7 +967,7 @@ public class TestRelationalCatalog extends TestBase {
           .withDirection(direction)
           .withNullOrder(direction.defaultNullOrdering())
           .withSortTerm(
-              new FieldReferenceDTO.Builder().withFieldName(new String[] {columnName}).build())
+              FieldReferenceDTO.builder().withFieldName(new String[] {columnName}).build())
           .build()
     };
   }

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalCatalog.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalCatalog.java
@@ -400,7 +400,7 @@ public class TestRelationalCatalog extends TestBase {
               "comment2",
               false,
               false,
-              new LiteralDTO.Builder().withValue(null).withDataType(Types.NullType.get()).build())
+              LiteralDTO.builder().withValue(null).withDataType(Types.NullType.get()).build())
         };
 
     TableCatalog tableCatalog = catalog.asTableCatalog();
@@ -953,7 +953,7 @@ public class TestRelationalCatalog extends TestBase {
   }
 
   private DistributionDTO createMockDistributionDTO(String columnName, int bucketNum) {
-    return new DistributionDTO.Builder()
+    return DistributionDTO.builder()
         .withStrategy(Strategy.HASH)
         .withNumber(bucketNum)
         .withArgs(
@@ -1113,7 +1113,7 @@ public class TestRelationalCatalog extends TestBase {
 
   protected static SchemaDTO createMockSchema(
       String name, String comment, Map<String, String> props) {
-    return new SchemaDTO.Builder()
+    return SchemaDTO.builder()
         .withName(name)
         .withComment(comment)
         .withProperties(props)

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalCatalog.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalCatalog.java
@@ -93,7 +93,11 @@ public class TestRelationalCatalog extends TestBase {
     metalake = TestGravitinoMetalake.createMetalake(client, metalakeName);
 
     CatalogDTO mockCatalog =
+<<<<<<< HEAD
         new CatalogDTO.Builder()
+=======
+        CatalogDTO.builder()
+>>>>>>> 00fd2c9c (draft2)
             .withName(catalogName)
             .withType(CatalogDTO.Type.RELATIONAL)
             .withProvider(provider)
@@ -1117,8 +1121,12 @@ public class TestRelationalCatalog extends TestBase {
         .withName(name)
         .withComment(comment)
         .withProperties(props)
+<<<<<<< HEAD
         .withAudit(
             new AuditDTO.Builder<>().withCreator("creator").withCreateTime(Instant.now()).build())
+=======
+        .withAudit(AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build())
+>>>>>>> 00fd2c9c (draft2)
         .build();
   }
 
@@ -1182,8 +1190,12 @@ public class TestRelationalCatalog extends TestBase {
         .withProperties(properties)
         .withDistribution(distributionDTO)
         .withSortOrders(sortOrderDTOs)
+<<<<<<< HEAD
         .withAudit(
             new AuditDTO.Builder<>().withCreator("creator").withCreateTime(Instant.now()).build())
+=======
+        .withAudit(AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build())
+>>>>>>> 00fd2c9c (draft2)
         .withPartitioning(partitioning)
         .withIndex(indexDTOS)
         .build();

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalCatalog.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalCatalog.java
@@ -93,18 +93,14 @@ public class TestRelationalCatalog extends TestBase {
     metalake = TestGravitinoMetalake.createMetalake(client, metalakeName);
 
     CatalogDTO mockCatalog =
-<<<<<<< HEAD
-        new CatalogDTO.Builder()
-=======
         CatalogDTO.builder()
->>>>>>> 00fd2c9c (draft2)
             .withName(catalogName)
             .withType(CatalogDTO.Type.RELATIONAL)
             .withProvider(provider)
             .withComment("comment")
             .withProperties(ImmutableMap.of("k1", "k2"))
             .withAudit(
-                new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build())
+                AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build())
             .build();
 
     CatalogCreateRequest catalogCreateRequest =
@@ -967,7 +963,7 @@ public class TestRelationalCatalog extends TestBase {
 
   private SortOrderDTO[] createMockSortOrderDTO(String columnName, SortDirection direction) {
     return new SortOrderDTO[] {
-      new SortOrderDTO.Builder()
+      SortOrderDTO.builder()
           .withDirection(direction)
           .withNullOrder(direction.defaultNullOrdering())
           .withSortTerm(
@@ -1121,12 +1117,7 @@ public class TestRelationalCatalog extends TestBase {
         .withName(name)
         .withComment(comment)
         .withProperties(props)
-<<<<<<< HEAD
-        .withAudit(
-            new AuditDTO.Builder<>().withCreator("creator").withCreateTime(Instant.now()).build())
-=======
         .withAudit(AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build())
->>>>>>> 00fd2c9c (draft2)
         .build();
   }
 
@@ -1183,19 +1174,14 @@ public class TestRelationalCatalog extends TestBase {
       DistributionDTO distributionDTO,
       SortOrderDTO[] sortOrderDTOs,
       IndexDTO[] indexDTOS) {
-    return new TableDTO.Builder()
+    return TableDTO.builder()
         .withName(name)
         .withColumns(columns)
         .withComment(comment)
         .withProperties(properties)
         .withDistribution(distributionDTO)
         .withSortOrders(sortOrderDTOs)
-<<<<<<< HEAD
-        .withAudit(
-            new AuditDTO.Builder<>().withCreator("creator").withCreateTime(Instant.now()).build())
-=======
         .withAudit(AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build())
->>>>>>> 00fd2c9c (draft2)
         .withPartitioning(partitioning)
         .withIndex(indexDTOS)
         .build();

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalTable.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalTable.java
@@ -157,15 +157,9 @@ public class TestRelationalTable extends TestRelationalCatalog {
         RangePartitionDTO.builder()
             .withName(partitionName)
             .withLower(
-                new LiteralDTO.Builder()
-                    .withDataType(Types.IntegerType.get())
-                    .withValue("1")
-                    .build())
+                LiteralDTO.builder().withDataType(Types.IntegerType.get()).withValue("1").build())
             .withUpper(
-                new LiteralDTO.Builder()
-                    .withDataType(Types.IntegerType.get())
-                    .withValue("10")
-                    .build())
+                LiteralDTO.builder().withDataType(Types.IntegerType.get()).withValue("10").build())
             .build();
     String partitionPath =
         withSlash(((RelationalTable) partitionedTable).getPartitionRequestPath());
@@ -197,15 +191,9 @@ public class TestRelationalTable extends TestRelationalCatalog {
         RangePartitionDTO.builder()
             .withName(partitionName)
             .withLower(
-                new LiteralDTO.Builder()
-                    .withDataType(Types.IntegerType.get())
-                    .withValue("1")
-                    .build())
+                LiteralDTO.builder().withDataType(Types.IntegerType.get()).withValue("1").build())
             .withUpper(
-                new LiteralDTO.Builder()
-                    .withDataType(Types.IntegerType.get())
-                    .withValue("10")
-                    .build())
+                LiteralDTO.builder().withDataType(Types.IntegerType.get()).withValue("10").build())
             .build();
     RelationalTable table = (RelationalTable) partitionedTable;
     String partitionPath =

--- a/common/src/main/java/com/datastrato/gravitino/dto/AuditDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/AuditDTO.java
@@ -90,7 +90,7 @@ public class AuditDTO implements Audit {
     protected Instant lastModifiedTime;
 
     /** * Default constructor for the builder. */
-    public Builder() {}
+    private Builder() {}
 
     /**
      * Sets the creator for the audit.

--- a/common/src/main/java/com/datastrato/gravitino/dto/CatalogDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/CatalogDTO.java
@@ -153,7 +153,7 @@ public class CatalogDTO implements Catalog {
     protected AuditDTO audit;
 
     /** Default constructor for the builder. */
-    public Builder() {}
+    protected Builder() {}
 
     /**
      * Sets the name of the catalog.

--- a/common/src/main/java/com/datastrato/gravitino/dto/CatalogDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/CatalogDTO.java
@@ -238,6 +238,7 @@ public class CatalogDTO implements Catalog {
     }
   }
 
+  /** @return the builder for creating a new instance of CatalogDTO. */
   public static Builder builder() {
     return new Builder();
   }

--- a/common/src/main/java/com/datastrato/gravitino/dto/CatalogDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/CatalogDTO.java
@@ -153,7 +153,7 @@ public class CatalogDTO implements Catalog {
     protected AuditDTO audit;
 
     /** Default constructor for the builder. */
-    private Builder() {}
+    public Builder() {}
 
     /**
      * Sets the name of the catalog.

--- a/common/src/main/java/com/datastrato/gravitino/dto/CatalogDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/CatalogDTO.java
@@ -153,7 +153,7 @@ public class CatalogDTO implements Catalog {
     protected AuditDTO audit;
 
     /** Default constructor for the builder. */
-    public Builder() {}
+    private Builder() {}
 
     /**
      * Sets the name of the catalog.
@@ -236,5 +236,9 @@ public class CatalogDTO implements Catalog {
 
       return new CatalogDTO(name, type, provider, comment, properties, audit);
     }
+  }
+
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/common/src/main/java/com/datastrato/gravitino/dto/MetalakeDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/MetalakeDTO.java
@@ -188,4 +188,8 @@ public class MetalakeDTO implements Metalake {
   public int hashCode() {
     return Objects.hashCode(name, comment, audit);
   }
+
+  public static Builder builder() {
+    return new Builder();
+  }
 }

--- a/common/src/main/java/com/datastrato/gravitino/dto/MetalakeDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/MetalakeDTO.java
@@ -189,6 +189,7 @@ public class MetalakeDTO implements Metalake {
     return Objects.hashCode(name, comment, audit);
   }
 
+  /** @return the builder for creating a new instance of MetalakeDTO. */
   public static Builder builder() {
     return new Builder();
   }

--- a/common/src/main/java/com/datastrato/gravitino/dto/MetalakeDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/MetalakeDTO.java
@@ -94,7 +94,7 @@ public class MetalakeDTO implements Metalake {
     protected AuditDTO audit;
 
     /** Default constructor. */
-    public Builder() {}
+    protected Builder() {}
 
     /**
      * Sets the name of the Metalake DTO.

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/DistributionDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/DistributionDTO.java
@@ -105,7 +105,7 @@ public class DistributionDTO implements Distribution {
     private Strategy strategy;
 
     /** Creates a new instance of {@link Builder}. */
-    public Builder() {}
+    private Builder() {}
 
     /**
      * Sets the arguments of the function.

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/SchemaDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/SchemaDTO.java
@@ -141,4 +141,8 @@ public class SchemaDTO implements Schema {
       return new SchemaDTO(name, comment, properties, audit);
     }
   }
+
+  public static Builder builder() {
+    return new Builder();
+  }
 }

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/SchemaDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/SchemaDTO.java
@@ -82,7 +82,7 @@ public class SchemaDTO implements Schema {
     protected AuditDTO audit;
 
     /** Constructs a new Builder instance. */
-    public Builder() {}
+    private Builder() {}
 
     /**
      * Sets the name of the schema.

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/SchemaDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/SchemaDTO.java
@@ -142,6 +142,7 @@ public class SchemaDTO implements Schema {
     }
   }
 
+  /** @return the builder for creating a new instance of SchemaDTO. */
   public static Builder builder() {
     return new Builder();
   }

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/SortOrderDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/SortOrderDTO.java
@@ -129,6 +129,7 @@ public class SortOrderDTO implements SortOrder {
     }
   }
 
+  /** @return the builder for creating a new instance of SortOrderDTO. */
   public static Builder builder() {
     return new Builder();
   }

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/SortOrderDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/SortOrderDTO.java
@@ -77,7 +77,7 @@ public class SortOrderDTO implements SortOrder {
     private NullOrdering nullOrdering;
 
     /** Default constructor. */
-    public Builder() {}
+    private Builder() {}
 
     /**
      * Set the sort term.
@@ -127,5 +127,9 @@ public class SortOrderDTO implements SortOrder {
       Preconditions.checkNotNull(this.sortTerm, "expression cannot be null");
       return new SortOrderDTO(sortTerm, direction, nullOrdering);
     }
+  }
+
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/TableDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/TableDTO.java
@@ -170,7 +170,7 @@ public class TableDTO implements Table {
     protected IndexDTO[] indexes;
 
     /** Default constructor. */
-    public Builder() {}
+    private Builder() {}
 
     /**
      * Sets the name of the table.
@@ -293,6 +293,15 @@ public class TableDTO implements Table {
           distributionDTO,
           sortOrderDTOs,
           indexes);
+    }
+
+    /**
+     * Creates a new instance of {@link Builder}.
+     *
+     * @return The new instance.
+     */
+    public static Builder builder() {
+      return new Builder();
     }
   }
 }

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/expressions/FieldReferenceDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/expressions/FieldReferenceDTO.java
@@ -75,6 +75,7 @@ public class FieldReferenceDTO implements FunctionArg, NamedReference {
     }
   }
 
+  /** @return the builder for creating a new instance of FieldReferenceDTO. */
   public static Builder builder() {
     return new Builder();
   }

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/expressions/FieldReferenceDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/expressions/FieldReferenceDTO.java
@@ -74,4 +74,8 @@ public class FieldReferenceDTO implements FunctionArg, NamedReference {
       return new FieldReferenceDTO(fieldName);
     }
   }
+
+  public static Builder builder() {
+    return new Builder();
+  }
 }

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/expressions/FieldReferenceDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/expressions/FieldReferenceDTO.java
@@ -65,6 +65,9 @@ public class FieldReferenceDTO implements FunctionArg, NamedReference {
       return this;
     }
 
+    /** Creates a new instance of {@link Builder}. */
+    private Builder() {}
+
     /**
      * Build the field reference.
      *

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/expressions/FuncExpressionDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/expressions/FuncExpressionDTO.java
@@ -78,4 +78,8 @@ public class FuncExpressionDTO implements FunctionExpression, FunctionArg {
       return new FuncExpressionDTO(functionName, functionArgs);
     }
   }
+
+  public static Builder builder() {
+    return new Builder();
+  }
 }

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/expressions/FuncExpressionDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/expressions/FuncExpressionDTO.java
@@ -69,6 +69,9 @@ public class FuncExpressionDTO implements FunctionExpression, FunctionArg {
       return this;
     }
 
+    /** Creates a new instance of {@link Builder}. */
+    private Builder() {}
+
     /**
      * Builds the function expression.
      *

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/expressions/FuncExpressionDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/expressions/FuncExpressionDTO.java
@@ -79,6 +79,7 @@ public class FuncExpressionDTO implements FunctionExpression, FunctionArg {
     }
   }
 
+  /** @return the builder for creating a new instance of FuncExpressionDTO. */
   public static Builder builder() {
     return new Builder();
   }

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/expressions/LiteralDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/expressions/LiteralDTO.java
@@ -83,4 +83,8 @@ public class LiteralDTO implements Literal<String>, FunctionArg {
       return new LiteralDTO(value, dataType);
     }
   }
+
+  public static Builder builder() {
+    return new Builder();
+  }
 }

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/expressions/LiteralDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/expressions/LiteralDTO.java
@@ -74,6 +74,9 @@ public class LiteralDTO implements Literal<String>, FunctionArg {
       return this;
     }
 
+    /** Creates a new instance of {@link Builder}. */
+    private Builder() {}
+
     /**
      * Builds a LiteralDTO instance.
      *

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/expressions/LiteralDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/expressions/LiteralDTO.java
@@ -84,6 +84,7 @@ public class LiteralDTO implements Literal<String>, FunctionArg {
     }
   }
 
+  /** @return the builder for creating a new instance of LiteralDTO. */
   public static Builder builder() {
     return new Builder();
   }

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/ListPartitioningDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/ListPartitioningDTO.java
@@ -91,6 +91,7 @@ public final class ListPartitioningDTO implements Partitioning {
     }
   }
 
+  /** @return the builder for creating a new instance of ListPartitioningDTO. */
   public static Builder builder() {
     return new Builder();
   }

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/ListPartitioningDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/ListPartitioningDTO.java
@@ -90,4 +90,8 @@ public final class ListPartitioningDTO implements Partitioning {
       return new ListPartitioningDTO(fieldNames);
     }
   }
+
+  public static Builder builder() {
+    return new Builder();
+  }
 }

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/RangePartitioningDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/RangePartitioningDTO.java
@@ -89,4 +89,8 @@ public final class RangePartitioningDTO implements Partitioning {
       return new RangePartitioningDTO(fieldName);
     }
   }
+
+  public static Builder builder() {
+    return new Builder();
+  }
 }

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/RangePartitioningDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/RangePartitioningDTO.java
@@ -90,6 +90,7 @@ public final class RangePartitioningDTO implements Partitioning {
     }
   }
 
+  /** @return the builder for creating a new instance of RangePartitioningDTO. */
   public static Builder builder() {
     return new Builder();
   }

--- a/common/src/main/java/com/datastrato/gravitino/dto/util/DTOConverters.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/util/DTOConverters.java
@@ -93,11 +93,7 @@ public class DTOConverters {
    * @return The metalake DTO.
    */
   public static MetalakeDTO toDTO(Metalake metalake) {
-<<<<<<< HEAD
-    return new MetalakeDTO.Builder()
-=======
     return MetalakeDTO.builder()
->>>>>>> 00fd2c9c (draft2)
         .withName(metalake.name())
         .withComment(metalake.comment())
         .withProperties(metalake.properties())
@@ -157,7 +153,7 @@ public class DTOConverters {
    * @return The catalog DTO.
    */
   public static CatalogDTO toDTO(Catalog catalog) {
-    return new CatalogDTO.Builder()
+    return CatalogDTO.builder()
         .withName(catalog.name())
         .withType(catalog.type())
         .withProvider(catalog.provider())
@@ -174,11 +170,7 @@ public class DTOConverters {
    * @return The schema DTO.
    */
   public static SchemaDTO toDTO(Schema schema) {
-<<<<<<< HEAD
-    return new SchemaDTO.Builder()
-=======
     return SchemaDTO.builder()
->>>>>>> 00fd2c9c (draft2)
         .withName(schema.name())
         .withComment(schema.comment())
         .withProperties(schema.properties())
@@ -193,11 +185,7 @@ public class DTOConverters {
    * @return The column DTO.
    */
   public static ColumnDTO toDTO(Column column) {
-<<<<<<< HEAD
-    return new ColumnDTO.Builder()
-=======
     return ColumnDTO.builder()
->>>>>>> 00fd2c9c (draft2)
         .withName(column.name())
         .withDataType(column.dataType())
         .withComment(column.comment())
@@ -267,11 +255,8 @@ public class DTOConverters {
     if (sortOrder instanceof SortOrderDTO) {
       return (SortOrderDTO) sortOrder;
     }
-<<<<<<< HEAD
-    return new SortOrderDTO.Builder()
-=======
+
     return SortOrderDTO.builder()
->>>>>>> 00fd2c9c (draft2)
         .withSortTerm(toFunctionArg(sortOrder.expression()))
         .withDirection(sortOrder.direction())
         .withNullOrder(sortOrder.nullOrdering())

--- a/common/src/main/java/com/datastrato/gravitino/dto/util/DTOConverters.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/util/DTOConverters.java
@@ -206,7 +206,7 @@ public class DTOConverters {
    * @return The table DTO.
    */
   public static TableDTO toDTO(Table table) {
-    return new TableDTO.Builder()
+    return TableDTO.builder()
         .withName(table.name())
         .withComment(table.comment())
         .withColumns(
@@ -235,7 +235,7 @@ public class DTOConverters {
       return (DistributionDTO) distribution;
     }
 
-    return new DistributionDTO.Builder()
+    return DistributionDTO.builder()
         .withStrategy(distribution.strategy())
         .withNumber(distribution.number())
         .withArgs(
@@ -341,7 +341,7 @@ public class DTOConverters {
       if (Literals.NULL.equals(expression)) {
         return LiteralDTO.NULL;
       }
-      return new LiteralDTO.Builder()
+      return LiteralDTO.builder()
           .withValue((((Literal) expression).value().toString()))
           .withDataType(((Literal) expression).dataType())
           .build();
@@ -350,7 +350,7 @@ public class DTOConverters {
           .withFieldName(((NamedReference.FieldReference) expression).fieldName())
           .build();
     } else if (expression instanceof FunctionExpression) {
-      return new FuncExpressionDTO.Builder()
+      return FuncExpressionDTO.builder()
           .withFunctionName(((FunctionExpression) expression).functionName())
           .withFunctionArgs(
               Arrays.stream(((FunctionExpression) expression).arguments())

--- a/common/src/main/java/com/datastrato/gravitino/dto/util/DTOConverters.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/util/DTOConverters.java
@@ -346,7 +346,7 @@ public class DTOConverters {
           .withDataType(((Literal) expression).dataType())
           .build();
     } else if (expression instanceof NamedReference.FieldReference) {
-      return new FieldReferenceDTO.Builder()
+      return FieldReferenceDTO.builder()
           .withFieldName(((NamedReference.FieldReference) expression).fieldName())
           .build();
     } else if (expression instanceof FunctionExpression) {

--- a/common/src/main/java/com/datastrato/gravitino/dto/util/DTOConverters.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/util/DTOConverters.java
@@ -93,7 +93,11 @@ public class DTOConverters {
    * @return The metalake DTO.
    */
   public static MetalakeDTO toDTO(Metalake metalake) {
+<<<<<<< HEAD
     return new MetalakeDTO.Builder()
+=======
+    return MetalakeDTO.builder()
+>>>>>>> 00fd2c9c (draft2)
         .withName(metalake.name())
         .withComment(metalake.comment())
         .withProperties(metalake.properties())
@@ -170,7 +174,11 @@ public class DTOConverters {
    * @return The schema DTO.
    */
   public static SchemaDTO toDTO(Schema schema) {
+<<<<<<< HEAD
     return new SchemaDTO.Builder()
+=======
+    return SchemaDTO.builder()
+>>>>>>> 00fd2c9c (draft2)
         .withName(schema.name())
         .withComment(schema.comment())
         .withProperties(schema.properties())
@@ -185,7 +193,11 @@ public class DTOConverters {
    * @return The column DTO.
    */
   public static ColumnDTO toDTO(Column column) {
+<<<<<<< HEAD
     return new ColumnDTO.Builder()
+=======
+    return ColumnDTO.builder()
+>>>>>>> 00fd2c9c (draft2)
         .withName(column.name())
         .withDataType(column.dataType())
         .withComment(column.comment())
@@ -255,7 +267,11 @@ public class DTOConverters {
     if (sortOrder instanceof SortOrderDTO) {
       return (SortOrderDTO) sortOrder;
     }
+<<<<<<< HEAD
     return new SortOrderDTO.Builder()
+=======
+    return SortOrderDTO.builder()
+>>>>>>> 00fd2c9c (draft2)
         .withSortTerm(toFunctionArg(sortOrder.expression()))
         .withDirection(sortOrder.direction())
         .withNullOrder(sortOrder.nullOrdering())

--- a/common/src/main/java/com/datastrato/gravitino/json/JsonUtils.java
+++ b/common/src/main/java/com/datastrato/gravitino/json/JsonUtils.java
@@ -362,7 +362,7 @@ public class JsonUtils {
             node);
         Type dataType = readDataType(node.get(DATA_TYPE));
         String value = getStringOrNull(LITERAL_VALUE, node);
-        return new LiteralDTO.Builder().withDataType(dataType).withValue(value).build();
+        return LiteralDTO.builder().withDataType(dataType).withValue(value).build();
       case FIELD:
         Preconditions.checkArgument(
             node.has(FIELD_NAME),
@@ -382,7 +382,7 @@ public class JsonUtils {
         String functionName = getString(FUNCTION_NAME, node);
         List<FunctionArg> args = Lists.newArrayList();
         node.get(FUNCTION_ARGS).forEach(arg -> args.add(readFunctionArg(arg)));
-        return new FuncExpressionDTO.Builder()
+        return FuncExpressionDTO.builder()
             .withFunctionName(functionName)
             .withFunctionArgs(args.toArray(FunctionArg.EMPTY_ARGS))
             .build();
@@ -998,7 +998,7 @@ public class JsonUtils {
       Preconditions.checkArgument(
           node.has(SORT_TERM), "Cannot parse sort order from missing sort term: %s", node);
       FunctionArg sortTerm = readFunctionArg(node.get(SORT_TERM));
-      SortOrderDTO.Builder builder = new SortOrderDTO.Builder().withSortTerm(sortTerm);
+      SortOrderDTO.Builder builder = SortOrderDTO.builder().withSortTerm(sortTerm);
       if (node.has(DIRECTION)) {
         builder.withDirection(SortDirection.fromString(getString(DIRECTION, node)));
       }
@@ -1036,7 +1036,7 @@ public class JsonUtils {
           node != null && !node.isNull() && node.isObject(),
           "Cannot parse distribution from invalid JSON: %s",
           node);
-      DistributionDTO.Builder builder = new DistributionDTO.Builder();
+      DistributionDTO.Builder builder = DistributionDTO.builder();
       if (node.has(STRATEGY)) {
         String strategy = getString(STRATEGY, node);
         builder.withStrategy(Strategy.getByName(strategy));
@@ -1234,7 +1234,7 @@ public class JsonUtils {
           "Index must be a valid JSON object, but found: %s",
           node);
 
-      IndexDTO.Builder builder = new IndexDTO.Builder();
+      IndexDTO.Builder builder = IndexDTO.builder();
       Preconditions.checkArgument(
           node.has(INDEX_TYPE), "Cannot parse index from missing type: %s", node);
       String indexType = getString(INDEX_TYPE, node);

--- a/common/src/test/java/com/datastrato/gravitino/dto/rel/TestDistributionDTO.java
+++ b/common/src/test/java/com/datastrato/gravitino/dto/rel/TestDistributionDTO.java
@@ -18,7 +18,7 @@ public class TestDistributionDTO {
   void test() throws JsonProcessingException {
 
     DistributionDTO distributionDTO =
-        new DistributionDTO.Builder()
+        DistributionDTO.builder()
             .withNumber(10)
             .withStrategy(Strategy.HASH)
             .withArgs(FieldReferenceDTO.of("a"))
@@ -44,9 +44,9 @@ public class TestDistributionDTO {
         JsonUtils.objectMapper().readTree(stringValue));
 
     distributionDTO =
-        new DistributionDTO.Builder()
+        DistributionDTO.builder()
             .withArgs(
-                new FuncExpressionDTO.Builder()
+                FuncExpressionDTO.builder()
                     .withFunctionName("date")
                     .withFunctionArgs(FieldReferenceDTO.of("a"))
                     .build())

--- a/common/src/test/java/com/datastrato/gravitino/dto/rel/TestSortOrderDTO.java
+++ b/common/src/test/java/com/datastrato/gravitino/dto/rel/TestSortOrderDTO.java
@@ -19,7 +19,7 @@ public class TestSortOrderDTO {
   @Test
   void testJsonSerDe() throws JsonProcessingException {
     SortOrderDTO dto =
-        new SortOrderDTO.Builder()
+         SortOrderDTO.builder()
             .withDirection(SortDirection.ASCENDING)
             .withNullOrder(NullOrdering.NULLS_FIRST)
             .withSortTerm(FieldReferenceDTO.of("field1"))
@@ -44,7 +44,7 @@ public class TestSortOrderDTO {
     SortOrderDTO dto2 = JsonUtils.objectMapper().readValue(value, SortOrderDTO.class);
     Assertions.assertEquals(dto, dto2);
 
-    dto = new SortOrderDTO.Builder().withSortTerm(FieldReferenceDTO.of("field1")).build();
+    dto = SortOrderDTO.builder().withSortTerm(FieldReferenceDTO.of("field1")).build();
 
     Assertions.assertEquals(
         dto,
@@ -52,7 +52,7 @@ public class TestSortOrderDTO {
             .readValue(JsonUtils.objectMapper().writeValueAsString(dto), SortOrderDTO.class));
 
     dto =
-        new SortOrderDTO.Builder()
+        SortOrderDTO.builder()
             .withSortTerm(
                 new FuncExpressionDTO.Builder()
                     .withFunctionName("date")

--- a/common/src/test/java/com/datastrato/gravitino/dto/rel/TestSortOrderDTO.java
+++ b/common/src/test/java/com/datastrato/gravitino/dto/rel/TestSortOrderDTO.java
@@ -54,7 +54,7 @@ public class TestSortOrderDTO {
     dto =
         SortOrderDTO.builder()
             .withSortTerm(
-                new FuncExpressionDTO.Builder()
+                FuncExpressionDTO.builder()
                     .withFunctionName("date")
                     .withFunctionArgs(FieldReferenceDTO.of("field1"))
                     .build())

--- a/common/src/test/java/com/datastrato/gravitino/dto/rel/TestSortOrderDTO.java
+++ b/common/src/test/java/com/datastrato/gravitino/dto/rel/TestSortOrderDTO.java
@@ -19,7 +19,7 @@ public class TestSortOrderDTO {
   @Test
   void testJsonSerDe() throws JsonProcessingException {
     SortOrderDTO dto =
-         SortOrderDTO.builder()
+        SortOrderDTO.builder()
             .withDirection(SortDirection.ASCENDING)
             .withNullOrder(NullOrdering.NULLS_FIRST)
             .withSortTerm(FieldReferenceDTO.of("field1"))

--- a/common/src/test/java/com/datastrato/gravitino/dto/responses/TestResponses.java
+++ b/common/src/test/java/com/datastrato/gravitino/dto/responses/TestResponses.java
@@ -74,8 +74,8 @@ public class TestResponses {
   @Test
   void testMetalakeResponse() throws IllegalArgumentException {
     AuditDTO audit =
-        new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build();
-    MetalakeDTO metalake = new MetalakeDTO.Builder().withName("Metalake").withAudit(audit).build();
+         AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build();
+    MetalakeDTO metalake = MetalakeDTO.builder().withName("Metalake").withAudit(audit).build();
     MetalakeResponse response = new MetalakeResponse(metalake);
     response.validate(); // No exception thrown
   }
@@ -89,8 +89,8 @@ public class TestResponses {
   @Test
   void testMetalakeListResponse() throws IllegalArgumentException {
     AuditDTO audit =
-        new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build();
-    MetalakeDTO metalake = new MetalakeDTO.Builder().withName("Metalake").withAudit(audit).build();
+         AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build();
+    MetalakeDTO metalake = MetalakeDTO.builder().withName("Metalake").withAudit(audit).build();
     MetalakeListResponse response = new MetalakeListResponse(new MetalakeDTO[] {metalake});
     response.validate(); // No exception thrown
   }
@@ -104,9 +104,9 @@ public class TestResponses {
   @Test
   void testCatalogResponse() throws IllegalArgumentException {
     AuditDTO audit =
-        new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build();
+         AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build();
     CatalogDTO catalog =
-        new CatalogDTO.Builder()
+         CatalogDTO.builder()
             .withName("CatalogA")
             .withComment("comment")
             .withType(Catalog.Type.RELATIONAL)
@@ -126,9 +126,9 @@ public class TestResponses {
   @Test
   void testSchemaResponse() throws IllegalArgumentException {
     AuditDTO audit =
-        new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build();
+         AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build();
     SchemaDTO schema =
-        new SchemaDTO.Builder().withName("SchemaA").withComment("comment").withAudit(audit).build();
+         SchemaDTO.builder().withName("SchemaA").withComment("comment").withAudit(audit).build();
     SchemaResponse schemaResponse = new SchemaResponse(schema);
     schemaResponse.validate(); // No exception thrown
   }
@@ -142,11 +142,11 @@ public class TestResponses {
   @Test
   void testTableResponse() throws IllegalArgumentException {
     AuditDTO audit =
-        new AuditDTO.Builder().withCreator("creator").withCreateTime(Instant.now()).build();
+         AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build();
     ColumnDTO column =
-        new ColumnDTO.Builder().withName("ColumnA").withDataType(Types.ByteType.get()).build();
+         ColumnDTO.builder().withName("ColumnA").withDataType(Types.ByteType.get()).build();
     TableDTO table =
-        new TableDTO.Builder()
+         TableDTO.builder()
             .withName("TableA")
             .withComment("comment")
             .withColumns(new ColumnDTO[] {column})

--- a/common/src/test/java/com/datastrato/gravitino/dto/responses/TestResponses.java
+++ b/common/src/test/java/com/datastrato/gravitino/dto/responses/TestResponses.java
@@ -74,7 +74,7 @@ public class TestResponses {
   @Test
   void testMetalakeResponse() throws IllegalArgumentException {
     AuditDTO audit =
-         AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build();
+        AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build();
     MetalakeDTO metalake = MetalakeDTO.builder().withName("Metalake").withAudit(audit).build();
     MetalakeResponse response = new MetalakeResponse(metalake);
     response.validate(); // No exception thrown
@@ -89,7 +89,7 @@ public class TestResponses {
   @Test
   void testMetalakeListResponse() throws IllegalArgumentException {
     AuditDTO audit =
-         AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build();
+        AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build();
     MetalakeDTO metalake = MetalakeDTO.builder().withName("Metalake").withAudit(audit).build();
     MetalakeListResponse response = new MetalakeListResponse(new MetalakeDTO[] {metalake});
     response.validate(); // No exception thrown
@@ -104,9 +104,9 @@ public class TestResponses {
   @Test
   void testCatalogResponse() throws IllegalArgumentException {
     AuditDTO audit =
-         AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build();
+        AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build();
     CatalogDTO catalog =
-         CatalogDTO.builder()
+        CatalogDTO.builder()
             .withName("CatalogA")
             .withComment("comment")
             .withType(Catalog.Type.RELATIONAL)
@@ -126,9 +126,9 @@ public class TestResponses {
   @Test
   void testSchemaResponse() throws IllegalArgumentException {
     AuditDTO audit =
-         AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build();
+        AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build();
     SchemaDTO schema =
-         SchemaDTO.builder().withName("SchemaA").withComment("comment").withAudit(audit).build();
+        SchemaDTO.builder().withName("SchemaA").withComment("comment").withAudit(audit).build();
     SchemaResponse schemaResponse = new SchemaResponse(schema);
     schemaResponse.validate(); // No exception thrown
   }
@@ -142,11 +142,11 @@ public class TestResponses {
   @Test
   void testTableResponse() throws IllegalArgumentException {
     AuditDTO audit =
-         AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build();
+        AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build();
     ColumnDTO column =
-         ColumnDTO.builder().withName("ColumnA").withDataType(Types.ByteType.get()).build();
+        ColumnDTO.builder().withName("ColumnA").withDataType(Types.ByteType.get()).build();
     TableDTO table =
-         TableDTO.builder()
+        TableDTO.builder()
             .withName("TableA")
             .withComment("comment")
             .withColumns(new ColumnDTO[] {column})

--- a/common/src/test/java/com/datastrato/gravitino/dto/util/TestDTOConverters.java
+++ b/common/src/test/java/com/datastrato/gravitino/dto/util/TestDTOConverters.java
@@ -32,9 +32,9 @@ public class TestDTOConverters {
     String[] field1 = {"dt"};
     String[] field2 = {"country"};
     LiteralDTO literal1 =
-        new LiteralDTO.Builder().withDataType(Types.DateType.get()).withValue("2008-08-08").build();
+        LiteralDTO.builder().withDataType(Types.DateType.get()).withValue("2008-08-08").build();
     LiteralDTO literal2 =
-        new LiteralDTO.Builder().withDataType(Types.StringType.get()).withValue("us").build();
+        LiteralDTO.builder().withDataType(Types.StringType.get()).withValue("us").build();
     String[][] fieldNames = {field1, field2};
     LiteralDTO[] values = {literal1, literal2};
 
@@ -63,9 +63,9 @@ public class TestDTOConverters {
 
     // given
     LiteralDTO lower =
-        new LiteralDTO.Builder().withDataType(Types.DateType.get()).withValue("2008-08-08").build();
+        LiteralDTO.builder().withDataType(Types.DateType.get()).withValue("2008-08-08").build();
     LiteralDTO upper =
-        new LiteralDTO.Builder().withDataType(Types.StringType.get()).withValue("us").build();
+        LiteralDTO.builder().withDataType(Types.StringType.get()).withValue("us").build();
 
     Map<String, String> properties = Collections.singletonMap("key", "value");
     PartitionDTO rangePartitionDTO =
@@ -90,9 +90,9 @@ public class TestDTOConverters {
 
     // given
     LiteralDTO literal1 =
-        new LiteralDTO.Builder().withDataType(Types.DateType.get()).withValue("2008-08-08").build();
+        LiteralDTO.builder().withDataType(Types.DateType.get()).withValue("2008-08-08").build();
     LiteralDTO literal2 =
-        new LiteralDTO.Builder().withDataType(Types.StringType.get()).withValue("us").build();
+        LiteralDTO.builder().withDataType(Types.StringType.get()).withValue("us").build();
 
     Map<String, String> properties = Collections.singletonMap("key", "value");
     LiteralDTO[][] literalDTOS = {new LiteralDTO[] {literal1}, new LiteralDTO[] {literal2}};

--- a/common/src/test/java/com/datastrato/gravitino/json/TestDTOJsonSerDe.java
+++ b/common/src/test/java/com/datastrato/gravitino/json/TestDTOJsonSerDe.java
@@ -143,7 +143,7 @@ public class TestDTOJsonSerDe {
     Assertions.assertEquals(metalake, desermetalake);
 
     // Test with optional fields
-    MetalakeDTO metalake1 =  MetalakeDTO.builder().withName(name).withAudit(audit).build();
+    MetalakeDTO metalake1 = MetalakeDTO.builder().withName(name).withAudit(audit).build();
 
     String serJson1 = JsonUtils.objectMapper().writeValueAsString(metalake1);
     String expectedJson1 =
@@ -339,10 +339,7 @@ public class TestDTOJsonSerDe {
             .withValue("Asia/Shanghai")
             .build();
     FunctionArg toDateFunc =
-        FuncExpressionDTO.builder()
-            .withFunctionName("toDate")
-            .withFunctionArgs(arg1, arg2)
-            .build();
+        FuncExpressionDTO.builder().withFunctionName("toDate").withFunctionArgs(arg1, arg2).build();
     Partitioning expressionPart = FunctionPartitioningDTO.of("toYYYYMM", toDateFunc);
     Partitioning bucketPart = BucketPartitioningDTO.of(10, field1);
     Partitioning truncatePart = TruncatePartitioningDTO.of(20, field2);

--- a/common/src/test/java/com/datastrato/gravitino/json/TestDTOJsonSerDe.java
+++ b/common/src/test/java/com/datastrato/gravitino/json/TestDTOJsonSerDe.java
@@ -123,7 +123,7 @@ public class TestDTOJsonSerDe {
 
     // Test with required fields
     MetalakeDTO metalake =
-        new MetalakeDTO.Builder()
+        MetalakeDTO.builder()
             .withName(name)
             .withComment(comment)
             .withProperties(properties)
@@ -143,7 +143,7 @@ public class TestDTOJsonSerDe {
     Assertions.assertEquals(metalake, desermetalake);
 
     // Test with optional fields
-    MetalakeDTO metalake1 = new MetalakeDTO.Builder().withName(name).withAudit(audit).build();
+    MetalakeDTO metalake1 =  MetalakeDTO.builder().withName(name).withAudit(audit).build();
 
     String serJson1 = JsonUtils.objectMapper().writeValueAsString(metalake1);
     String expectedJson1 =
@@ -163,7 +163,7 @@ public class TestDTOJsonSerDe {
     AuditDTO audit =
         AuditDTO.builder().withCreator("creator").withCreateTime(Instant.now()).build();
     CatalogDTO catalog =
-        new CatalogDTO.Builder()
+        CatalogDTO.builder()
             .withName("catalog")
             .withType(Catalog.Type.RELATIONAL)
             .withProvider("test")
@@ -178,7 +178,7 @@ public class TestDTOJsonSerDe {
 
     // test with optional fields
     CatalogDTO catalog1 =
-        new CatalogDTO.Builder()
+        CatalogDTO.builder()
             .withName("catalog")
             .withType(Catalog.Type.RELATIONAL)
             .withProvider("test")
@@ -225,7 +225,7 @@ public class TestDTOJsonSerDe {
             .withDataType(Types.DateType.get())
             .withComment(comment)
             .withDefaultValue(
-                new LiteralDTO.Builder()
+                LiteralDTO.builder()
                     .withDataType(Types.DateType.get())
                     .withValue("2023-04-01")
                     .build())
@@ -316,7 +316,7 @@ public class TestDTOJsonSerDe {
     // String[][] p1Value = {{"2023-04-01", "San Francisco"}, {"2023-04-01", "San Francisco"}};
     // String[][] p2Value = {{"2023-04-01", "Houston"}, {"2023-04-01", "Dallas"}};
     Partitioning listPart =
-        new ListPartitioningDTO.Builder()
+        ListPartitioningDTO.builder()
             .withFieldNames(new String[][] {field1, field2})
             // .withAssignment("p202304_California", p1Value)
             // .withAssignment("p202304_Texas", p2Value)
@@ -325,7 +325,7 @@ public class TestDTOJsonSerDe {
     // construct range partition
     // TODO: support assign partition value
     Partitioning rangePart =
-        new RangePartitioningDTO.Builder()
+        RangePartitioningDTO.builder()
             .withFieldName(field1)
             // .withRange("p20230101", "2023-01-01T00:00:00", "2023-01-02T00:00:00")
             // .withRange("p20230102", "2023-01-01T00:00:00", null)
@@ -334,12 +334,12 @@ public class TestDTOJsonSerDe {
     // construct function partitioning, toYYYYMM(toDate(ts, ‘Asia/Shanghai’))
     FunctionArg arg1 = FieldReferenceDTO.of(field1);
     FunctionArg arg2 =
-        new LiteralDTO.Builder()
+        LiteralDTO.builder()
             .withDataType(Types.StringType.get())
             .withValue("Asia/Shanghai")
             .build();
     FunctionArg toDateFunc =
-        new FuncExpressionDTO.Builder()
+        FuncExpressionDTO.builder()
             .withFunctionName("toDate")
             .withFunctionArgs(arg1, arg2)
             .build();

--- a/common/src/test/java/com/datastrato/gravitino/json/TestJsonUtils.java
+++ b/common/src/test/java/com/datastrato/gravitino/json/TestJsonUtils.java
@@ -180,9 +180,9 @@ public class TestJsonUtils {
     String[] field1 = {"dt"};
     String[] field2 = {"country"};
     LiteralDTO literal1 =
-        new LiteralDTO.Builder().withDataType(Types.DateType.get()).withValue("2008-08-08").build();
+        LiteralDTO.builder().withDataType(Types.DateType.get()).withValue("2008-08-08").build();
     LiteralDTO literal2 =
-        new LiteralDTO.Builder().withDataType(Types.StringType.get()).withValue("us").build();
+        LiteralDTO.builder().withDataType(Types.StringType.get()).withValue("us").build();
     PartitionDTO partition =
         IdentityPartitionDTO.builder()
             .withFieldNames(new String[][] {field1, field2})
@@ -223,15 +223,9 @@ public class TestJsonUtils {
         RangePartitionDTO.builder()
             .withName("p0")
             .withUpper(
-                new LiteralDTO.Builder()
-                    .withDataType(Types.NullType.get())
-                    .withValue("null")
-                    .build())
+                LiteralDTO.builder().withDataType(Types.NullType.get()).withValue("null").build())
             .withLower(
-                new LiteralDTO.Builder()
-                    .withDataType(Types.IntegerType.get())
-                    .withValue("6")
-                    .build())
+                LiteralDTO.builder().withDataType(Types.IntegerType.get()).withValue("6").build())
             .build();
     jsonValue = JsonUtils.objectMapper().writeValueAsString(partition);
     expected =
@@ -259,21 +253,21 @@ public class TestJsonUtils {
             .withLists(
                 new LiteralDTO[][] {
                   {
-                    new LiteralDTO.Builder()
+                    LiteralDTO.builder()
                         .withDataType(Types.DateType.get())
                         .withValue("2022-04-01")
                         .build(),
-                    new LiteralDTO.Builder()
+                    LiteralDTO.builder()
                         .withDataType(Types.StringType.get())
                         .withValue("Los Angeles")
                         .build()
                   },
                   {
-                    new LiteralDTO.Builder()
+                    LiteralDTO.builder()
                         .withDataType(Types.DateType.get())
                         .withValue("2022-04-01")
                         .build(),
-                    new LiteralDTO.Builder()
+                    LiteralDTO.builder()
                         .withDataType(Types.StringType.get())
                         .withValue("San Francisco")
                         .build()

--- a/common/src/test/java/com/datastrato/gravitino/json/TestResponseJsonSerDe.java
+++ b/common/src/test/java/com/datastrato/gravitino/json/TestResponseJsonSerDe.java
@@ -82,7 +82,7 @@ public class TestResponseJsonSerDe {
   @Test
   public void testMetalakeResponseBuilderSerDe() throws JsonProcessingException {
     MetalakeDTO metalake =
-        new MetalakeDTO.Builder()
+        MetalakeDTO.builder()
             .withName("metalake")
             .withComment("comment")
             .withProperties(ImmutableMap.of("key", "value"))

--- a/core/src/main/java/com/datastrato/gravitino/catalog/CatalogOperationDispatcher.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/CatalogOperationDispatcher.java
@@ -166,7 +166,7 @@ public class CatalogOperationDispatcher implements TableCatalog, FilesetCatalog,
             NoSuchSchemaException.class);
 
     SchemaEntity schemaEntity =
-        new SchemaEntity.Builder()
+        SchemaEntity.builder()
             .withId(uid)
             .withName(ident.name())
             .withNamespace(ident.namespace())
@@ -311,7 +311,7 @@ public class CatalogOperationDispatcher implements TableCatalog, FilesetCatalog,
                     SchemaEntity.class,
                     SCHEMA,
                     schemaEntity ->
-                        new SchemaEntity.Builder()
+                        SchemaEntity.builder()
                             .withId(schemaEntity.id())
                             .withName(schemaEntity.name())
                             .withNamespace(ident.namespace())
@@ -486,7 +486,7 @@ public class CatalogOperationDispatcher implements TableCatalog, FilesetCatalog,
             NoSuchTableException.class);
 
     TableEntity tableEntity =
-        new TableEntity.Builder()
+        TableEntity.builder()
             .withId(uid)
             .withName(ident.name())
             .withNamespace(ident.namespace())
@@ -573,7 +573,7 @@ public class CatalogOperationDispatcher implements TableCatalog, FilesetCatalog,
                               .reduce((c1, c2) -> c2)
                               .orElse(tableEntity.name());
 
-                      return new TableEntity.Builder()
+                      return TableEntity.builder()
                           .withId(tableEntity.id())
                           .withName(newName)
                           .withNamespace(ident.namespace())

--- a/core/src/main/java/com/datastrato/gravitino/meta/BaseMetalake.java
+++ b/core/src/main/java/com/datastrato/gravitino/meta/BaseMetalake.java
@@ -135,7 +135,7 @@ public class BaseMetalake implements Metalake, Entity, Auditable, HasIdentifier 
     private final BaseMetalake metalake;
 
     /** Constructs a new {@link Builder}. */
-    public Builder() {
+    private Builder() {
       metalake = new BaseMetalake();
     }
 
@@ -214,5 +214,14 @@ public class BaseMetalake implements Metalake, Entity, Auditable, HasIdentifier 
       metalake.validate();
       return metalake;
     }
+  }
+
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/core/src/main/java/com/datastrato/gravitino/meta/FilesetEntity.java
+++ b/core/src/main/java/com/datastrato/gravitino/meta/FilesetEntity.java
@@ -182,7 +182,7 @@ public class FilesetEntity implements Entity, Auditable, HasIdentifier {
 
     private final FilesetEntity fileset;
 
-    public Builder() {
+    private Builder() {
       fileset = new FilesetEntity();
     }
 
@@ -285,5 +285,14 @@ public class FilesetEntity implements Entity, Auditable, HasIdentifier {
       fileset.validate();
       return fileset;
     }
+  }
+
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/core/src/main/java/com/datastrato/gravitino/meta/SchemaEntity.java
+++ b/core/src/main/java/com/datastrato/gravitino/meta/SchemaEntity.java
@@ -160,7 +160,7 @@ public class SchemaEntity implements Entity, Auditable, HasIdentifier {
 
     private final SchemaEntity schema;
 
-    public Builder() {
+    private Builder() {
       this.schema = new SchemaEntity();
     }
 
@@ -238,6 +238,15 @@ public class SchemaEntity implements Entity, Auditable, HasIdentifier {
     public SchemaEntity build() {
       schema.validate();
       return schema;
+    }
+
+    /**
+     * Creates a new instance of {@link Builder}.
+     *
+     * @return The new instance.
+     */
+    public static Builder builder() {
+      return new Builder();
     }
   }
 }

--- a/core/src/main/java/com/datastrato/gravitino/meta/TableEntity.java
+++ b/core/src/main/java/com/datastrato/gravitino/meta/TableEntity.java
@@ -121,7 +121,7 @@ public class TableEntity implements Entity, Auditable, HasIdentifier {
 
     private final TableEntity tableEntity;
 
-    public Builder() {
+    private Builder() {
       this.tableEntity = new TableEntity();
     }
 
@@ -149,5 +149,14 @@ public class TableEntity implements Entity, Auditable, HasIdentifier {
       tableEntity.validate();
       return tableEntity;
     }
+  }
+
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/core/src/main/java/com/datastrato/gravitino/metalake/MetalakeManager.java
+++ b/core/src/main/java/com/datastrato/gravitino/metalake/MetalakeManager.java
@@ -105,7 +105,7 @@ public class MetalakeManager implements SupportsMetalakes {
     StringIdentifier stringId = StringIdentifier.fromId(uid);
 
     BaseMetalake metalake =
-        new BaseMetalake.Builder()
+        BaseMetalake.builder()
             .withId(uid)
             .withName(ident.name())
             .withComment(comment)
@@ -150,7 +150,7 @@ public class MetalakeManager implements SupportsMetalakes {
           EntityType.METALAKE,
           metalake -> {
             BaseMetalake.Builder builder =
-                new BaseMetalake.Builder()
+                BaseMetalake.builder()
                     .withId(metalake.id())
                     .withName(metalake.name())
                     .withComment(metalake.comment())

--- a/core/src/main/java/com/datastrato/gravitino/proto/BaseMetalakeSerDe.java
+++ b/core/src/main/java/com/datastrato/gravitino/proto/BaseMetalakeSerDe.java
@@ -54,7 +54,7 @@ class BaseMetalakeSerDe
   @Override
   public com.datastrato.gravitino.meta.BaseMetalake deserialize(Metalake p) {
     com.datastrato.gravitino.meta.BaseMetalake.Builder builder =
-        new com.datastrato.gravitino.meta.BaseMetalake.Builder();
+        com.datastrato.gravitino.meta.BaseMetalake.builder();
     builder
         .withId(p.getId())
         .withName(p.getName())

--- a/core/src/main/java/com/datastrato/gravitino/proto/FilesetEntitySerDe.java
+++ b/core/src/main/java/com/datastrato/gravitino/proto/FilesetEntitySerDe.java
@@ -33,7 +33,7 @@ public class FilesetEntitySerDe implements ProtoSerDe<FilesetEntity, Fileset> {
   @Override
   public FilesetEntity deserialize(Fileset p) {
     FilesetEntity.Builder builder =
-        new FilesetEntity.Builder()
+        FilesetEntity.builder()
             .withId(p.getId())
             .withName(p.getName())
             .withStorageLocation(p.getStorageLocation())

--- a/core/src/main/java/com/datastrato/gravitino/proto/SchemaEntitySerDe.java
+++ b/core/src/main/java/com/datastrato/gravitino/proto/SchemaEntitySerDe.java
@@ -29,7 +29,7 @@ public class SchemaEntitySerDe implements ProtoSerDe<SchemaEntity, Schema> {
   @Override
   public SchemaEntity deserialize(Schema p) {
     SchemaEntity.Builder builder =
-        new SchemaEntity.Builder()
+        SchemaEntity.builder()
             .withId(p.getId())
             .withName(p.getName())
             .withAuditInfo(new AuditInfoSerDe().deserialize(p.getAuditInfo()));

--- a/core/src/main/java/com/datastrato/gravitino/proto/TableEntitySerDe.java
+++ b/core/src/main/java/com/datastrato/gravitino/proto/TableEntitySerDe.java
@@ -18,7 +18,7 @@ public class TableEntitySerDe implements ProtoSerDe<TableEntity, Table> {
 
   @Override
   public TableEntity deserialize(Table p) {
-    return new TableEntity.Builder()
+    return TableEntity.builder()
         .withId(p.getId())
         .withName(p.getName())
         .withAuditInfo(new AuditInfoSerDe().deserialize(p.getAuditInfo()))

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/po/CatalogPO.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/po/CatalogPO.java
@@ -104,82 +104,91 @@ public class CatalogPO {
   }
 
   public static class Builder {
-    private final CatalogPO metalakePO;
+    private final CatalogPO catalogPO;
 
-    public Builder() {
-      metalakePO = new CatalogPO();
+    private Builder() {
+      catalogPO = new CatalogPO();
     }
 
     public CatalogPO.Builder withCatalogId(Long catalogId) {
-      metalakePO.catalogId = catalogId;
+      catalogPO.catalogId = catalogId;
       return this;
     }
 
     public CatalogPO.Builder withCatalogName(String name) {
-      metalakePO.catalogName = name;
+      catalogPO.catalogName = name;
       return this;
     }
 
     public CatalogPO.Builder withMetalakeId(Long metalakeId) {
-      metalakePO.metalakeId = metalakeId;
+      catalogPO.metalakeId = metalakeId;
       return this;
     }
 
     public CatalogPO.Builder withType(String type) {
-      metalakePO.type = type;
+      catalogPO.type = type;
       return this;
     }
 
     public CatalogPO.Builder withProvider(String provider) {
-      metalakePO.provider = provider;
+      catalogPO.provider = provider;
       return this;
     }
 
     public CatalogPO.Builder withCatalogComment(String comment) {
-      metalakePO.catalogComment = comment;
+      catalogPO.catalogComment = comment;
       return this;
     }
 
     public CatalogPO.Builder withProperties(String properties) {
-      metalakePO.properties = properties;
+      catalogPO.properties = properties;
       return this;
     }
 
     public CatalogPO.Builder withAuditInfo(String auditInfo) {
-      metalakePO.auditInfo = auditInfo;
+      catalogPO.auditInfo = auditInfo;
       return this;
     }
 
     public CatalogPO.Builder withCurrentVersion(Long currentVersion) {
-      metalakePO.currentVersion = currentVersion;
+      catalogPO.currentVersion = currentVersion;
       return this;
     }
 
     public CatalogPO.Builder withLastVersion(Long lastVersion) {
-      metalakePO.lastVersion = lastVersion;
+      catalogPO.lastVersion = lastVersion;
       return this;
     }
 
     public CatalogPO.Builder withDeletedAt(Long deletedAt) {
-      metalakePO.deletedAt = deletedAt;
+      catalogPO.deletedAt = deletedAt;
       return this;
     }
 
     private void validate() {
-      Preconditions.checkArgument(metalakePO.catalogId != null, "Catalog id is required");
-      Preconditions.checkArgument(metalakePO.catalogName != null, "Catalog name is required");
-      Preconditions.checkArgument(metalakePO.metalakeId != null, "Metalake id is required");
-      Preconditions.checkArgument(metalakePO.type != null, "Catalog type is required");
-      Preconditions.checkArgument(metalakePO.provider != null, "Catalog provider is required");
-      Preconditions.checkArgument(metalakePO.auditInfo != null, "Audit info is required");
-      Preconditions.checkArgument(metalakePO.currentVersion != null, "Current version is required");
-      Preconditions.checkArgument(metalakePO.lastVersion != null, "Last version is required");
-      Preconditions.checkArgument(metalakePO.deletedAt != null, "Deleted at is required");
+      Preconditions.checkArgument(catalogPO.catalogId != null, "Catalog id is required");
+      Preconditions.checkArgument(catalogPO.catalogName != null, "Catalog name is required");
+      Preconditions.checkArgument(catalogPO.metalakeId != null, "Metalake id is required");
+      Preconditions.checkArgument(catalogPO.type != null, "Catalog type is required");
+      Preconditions.checkArgument(catalogPO.provider != null, "Catalog provider is required");
+      Preconditions.checkArgument(catalogPO.auditInfo != null, "Audit info is required");
+      Preconditions.checkArgument(catalogPO.currentVersion != null, "Current version is required");
+      Preconditions.checkArgument(catalogPO.lastVersion != null, "Last version is required");
+      Preconditions.checkArgument(catalogPO.deletedAt != null, "Deleted at is required");
     }
 
     public CatalogPO build() {
       validate();
-      return metalakePO;
+      return catalogPO;
     }
+  }
+
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/po/FilesetPO.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/po/FilesetPO.java
@@ -105,7 +105,7 @@ public class FilesetPO {
   public static class Builder {
     private final FilesetPO filesetPO;
 
-    public Builder() {
+    private Builder() {
       filesetPO = new FilesetPO();
     }
 
@@ -197,5 +197,14 @@ public class FilesetPO {
       validate();
       return filesetPO;
     }
+  }
+
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/po/FilesetVersionPO.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/po/FilesetVersionPO.java
@@ -99,7 +99,7 @@ public class FilesetVersionPO {
   public static class Builder {
     private final FilesetVersionPO filesetVersionPO;
 
-    public Builder() {
+    private Builder() {
       filesetVersionPO = new FilesetVersionPO();
     }
 
@@ -168,5 +168,14 @@ public class FilesetVersionPO {
       validate();
       return filesetVersionPO;
     }
+  }
+
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/po/MetalakePO.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/po/MetalakePO.java
@@ -92,7 +92,7 @@ public class MetalakePO {
   public static class Builder {
     private final MetalakePO metalakePO;
 
-    public Builder() {
+    private Builder() {
       metalakePO = new MetalakePO();
     }
 
@@ -155,5 +155,13 @@ public class MetalakePO {
       validate();
       return metalakePO;
     }
+  }
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/po/SchemaPO.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/po/SchemaPO.java
@@ -98,7 +98,7 @@ public class SchemaPO {
   public static class Builder {
     private final SchemaPO schemaPO;
 
-    public Builder() {
+    private Builder() {
       schemaPO = new SchemaPO();
     }
 
@@ -167,5 +167,13 @@ public class SchemaPO {
       validate();
       return schemaPO;
     }
+  }
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/po/TablePO.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/po/TablePO.java
@@ -91,7 +91,7 @@ public class TablePO {
   public static class Builder {
     private final TablePO tablePO;
 
-    public Builder() {
+    private Builder() {
       tablePO = new TablePO();
     }
 
@@ -156,5 +156,14 @@ public class TablePO {
       validate();
       return tablePO;
     }
+  }
+
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/service/FilesetMetaService.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/service/FilesetMetaService.java
@@ -94,7 +94,7 @@ public class FilesetMetaService {
     try {
       NameIdentifier.checkFileset(filesetEntity.nameIdentifier());
 
-      FilesetPO.Builder builder = new FilesetPO.Builder();
+      FilesetPO.Builder builder = FilesetPO.builder();
       fillFilesetPOBuilderParentEntityId(builder, filesetEntity.namespace());
 
       FilesetPO po = POConverters.initializeFilesetPOWithVersion(filesetEntity, builder);

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/service/SchemaMetaService.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/service/SchemaMetaService.java
@@ -94,7 +94,7 @@ public class SchemaMetaService {
     try {
       NameIdentifier.checkSchema(schemaEntity.nameIdentifier());
 
-      SchemaPO.Builder builder = new SchemaPO.Builder();
+      SchemaPO.Builder builder = SchemaPO.builder();
       fillSchemaPOBuilderParentEntityId(builder, schemaEntity.namespace());
 
       SessionUtils.doWithCommit(

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/service/TableMetaService.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/service/TableMetaService.java
@@ -88,7 +88,7 @@ public class TableMetaService {
     try {
       NameIdentifier.checkTable(tableEntity.nameIdentifier());
 
-      TablePO.Builder builder = new TablePO.Builder();
+      TablePO.Builder builder = TablePO.builder();
       fillTablePOBuilderParentEntityId(builder, tableEntity.namespace());
 
       SessionUtils.doWithCommit(

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/utils/POConverters.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/utils/POConverters.java
@@ -43,7 +43,7 @@ public class POConverters {
    */
   public static MetalakePO initializeMetalakePOWithVersion(BaseMetalake baseMetalake) {
     try {
-      return new MetalakePO.Builder()
+      return MetalakePO.builder()
           .withMetalakeId(baseMetalake.id())
           .withMetalakeName(baseMetalake.name())
           .withMetalakeComment(baseMetalake.comment())
@@ -73,7 +73,7 @@ public class POConverters {
     // Will set the version to the last version + 1 when having some fields need be multiple version
     Long nextVersion = lastVersion;
     try {
-      return new MetalakePO.Builder()
+      return MetalakePO.builder()
           .withMetalakeId(newMetalake.id())
           .withMetalakeName(newMetalake.name())
           .withMetalakeComment(newMetalake.comment())
@@ -98,7 +98,7 @@ public class POConverters {
    */
   public static BaseMetalake fromMetalakePO(MetalakePO metalakePO) {
     try {
-      return new BaseMetalake.Builder()
+      return BaseMetalake.builder()
           .withId(metalakePO.getMetalakeId())
           .withName(metalakePO.getMetalakeName())
           .withComment(metalakePO.getMetalakeComment())
@@ -134,7 +134,7 @@ public class POConverters {
   public static CatalogPO initializeCatalogPOWithVersion(
       CatalogEntity catalogEntity, Long metalakeId) {
     try {
-      return new CatalogPO.Builder()
+      return CatalogPO.builder()
           .withCatalogId(catalogEntity.id())
           .withCatalogName(catalogEntity.name())
           .withMetalakeId(metalakeId)
@@ -166,7 +166,7 @@ public class POConverters {
     // Will set the version to the last version + 1 when having some fields need be multiple version
     Long nextVersion = lastVersion;
     try {
-      return new CatalogPO.Builder()
+      return CatalogPO.builder()
           .withCatalogId(newCatalog.id())
           .withCatalogName(newCatalog.name())
           .withMetalakeId(metalakeId)
@@ -260,7 +260,7 @@ public class POConverters {
     // Will set the version to the last version + 1 when having some fields need be multiple version
     Long nextVersion = lastVersion;
     try {
-      return new SchemaPO.Builder()
+      return SchemaPO.builder()
           .withSchemaId(oldSchemaPO.getSchemaId())
           .withSchemaName(newSchema.name())
           .withMetalakeId(oldSchemaPO.getMetalakeId())
@@ -286,7 +286,7 @@ public class POConverters {
    */
   public static SchemaEntity fromSchemaPO(SchemaPO schemaPO, Namespace namespace) {
     try {
-      return new SchemaEntity.Builder()
+      return SchemaEntity.builder()
           .withId(schemaPO.getSchemaId())
           .withName(schemaPO.getSchemaName())
           .withNamespace(namespace)
@@ -347,7 +347,7 @@ public class POConverters {
     // Will set the version to the last version + 1 when having some fields need be multiple version
     Long nextVersion = lastVersion;
     try {
-      return new TablePO.Builder()
+      return TablePO.builder()
           .withTableId(oldTablePO.getTableId())
           .withTableName(newTable.name())
           .withMetalakeId(oldTablePO.getMetalakeId())
@@ -372,7 +372,7 @@ public class POConverters {
    */
   public static TableEntity fromTablePO(TablePO tablePO, Namespace namespace) {
     try {
-      return new TableEntity.Builder()
+      return TableEntity.builder()
           .withId(tablePO.getTableId())
           .withName(tablePO.getTableName())
           .withNamespace(namespace)
@@ -407,7 +407,7 @@ public class POConverters {
       FilesetEntity filesetEntity, FilesetPO.Builder builder) {
     try {
       FilesetVersionPO filesetVersionPO =
-          new FilesetVersionPO.Builder()
+          FilesetVersionPO.builder()
               .withMetalakeId(builder.getFilesetMetalakeId())
               .withCatalogId(builder.getFilesetCatalogId())
               .withSchemaId(builder.getFilesetSchemaId())
@@ -452,7 +452,7 @@ public class POConverters {
         lastVersion++;
         currentVersion = lastVersion;
         newFilesetVersionPO =
-            new FilesetVersionPO.Builder()
+            FilesetVersionPO.builder()
                 .withMetalakeId(oldFilesetPO.getMetalakeId())
                 .withCatalogId(oldFilesetPO.getCatalogId())
                 .withSchemaId(oldFilesetPO.getSchemaId())
@@ -468,7 +468,7 @@ public class POConverters {
         currentVersion = oldFilesetPO.getCurrentVersion();
         newFilesetVersionPO = oldFilesetPO.getFilesetVersionPO();
       }
-      return new FilesetPO.Builder()
+      return FilesetPO.builder()
           .withFilesetId(newFileset.id())
           .withFilesetName(newFileset.name())
           .withMetalakeId(oldFilesetPO.getMetalakeId())
@@ -512,7 +512,7 @@ public class POConverters {
    */
   public static FilesetEntity fromFilesetPO(FilesetPO filesetPO, Namespace namespace) {
     try {
-      return new FilesetEntity.Builder()
+      return FilesetEntity.builder()
           .withId(filesetPO.getFilesetId())
           .withName(filesetPO.getFilesetName())
           .withNamespace(namespace)

--- a/core/src/test/java/com/datastrato/gravitino/TestCatalogOperations.java
+++ b/core/src/test/java/com/datastrato/gravitino/TestCatalogOperations.java
@@ -108,7 +108,7 @@ public class TestCatalogOperations
         AuditInfo.builder().withCreator("test").withCreateTime(Instant.now()).build();
 
     TestTable table =
-        new TestTable.Builder()
+        TestTable.builder()
             .withName(ident.name())
             .withComment(comment)
             .withProperties(new HashMap<>(properties))
@@ -126,7 +126,7 @@ public class TestCatalogOperations
       tables.put(ident, table);
     }
 
-    return new TestTable.Builder()
+    return TestTable.builder()
         .withName(ident.name())
         .withComment(comment)
         .withProperties(new HashMap<>(properties))
@@ -171,7 +171,7 @@ public class TestCatalogOperations
     }
 
     TestTable updatedTable =
-        new TestTable.Builder()
+        TestTable.builder()
             .withName(ident.name())
             .withComment(table.comment())
             .withProperties(new HashMap<>(newProps))
@@ -181,7 +181,7 @@ public class TestCatalogOperations
             .build();
 
     tables.put(ident, updatedTable);
-    return new TestTable.Builder()
+    return TestTable.builder()
         .withName(ident.name())
         .withComment(table.comment())
         .withProperties(new HashMap<>(newProps))
@@ -215,7 +215,7 @@ public class TestCatalogOperations
         AuditInfo.builder().withCreator("test").withCreateTime(Instant.now()).build();
 
     TestSchema schema =
-        new TestSchema.Builder()
+        TestSchema.builder()
             .withName(ident.name())
             .withComment(comment)
             .withProperties(properties)
@@ -272,7 +272,7 @@ public class TestCatalogOperations
     }
 
     TestSchema updatedSchema =
-        new TestSchema.Builder()
+        TestSchema.builder()
             .withName(ident.name())
             .withComment(schema.comment())
             .withProperties(newProps)
@@ -422,7 +422,7 @@ public class TestCatalogOperations
     AuditInfo auditInfo =
         AuditInfo.builder().withCreator("test").withCreateTime(Instant.now()).build();
     TestFileset fileset =
-        new TestFileset.Builder()
+        TestFileset.builder()
             .withName(ident.name())
             .withComment(comment)
             .withProperties(properties)
@@ -472,7 +472,7 @@ public class TestCatalogOperations
     }
 
     TestFileset updatedFileset =
-        new TestFileset.Builder()
+        TestFileset.builder()
             .withName(ident.name())
             .withComment(fileset.comment())
             .withProperties(newProps)

--- a/core/src/test/java/com/datastrato/gravitino/TestColumn.java
+++ b/core/src/test/java/com/datastrato/gravitino/TestColumn.java
@@ -15,6 +15,8 @@ public class TestColumn extends BaseColumn {
   private TestColumn() {}
 
   public static class Builder extends BaseColumn.BaseColumnBuilder<Builder, TestColumn> {
+    /** Creates a new instance of {@link Builder}. */
+    private Builder() {}
 
     @Override
     protected TestColumn internalBuild() {
@@ -28,5 +30,14 @@ public class TestColumn extends BaseColumn {
 
       return column;
     }
+  }
+
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/core/src/test/java/com/datastrato/gravitino/TestEntityStore.java
+++ b/core/src/test/java/com/datastrato/gravitino/TestEntityStore.java
@@ -151,7 +151,7 @@ public class TestEntityStore {
         AuditInfo.builder().withCreator("creator").withCreateTime(Instant.now()).build();
 
     BaseMetalake metalake =
-        new BaseMetalake.Builder()
+        BaseMetalake.builder()
             .withId(1L)
             .withName("metalake")
             .withAuditInfo(auditInfo)
@@ -169,7 +169,7 @@ public class TestEntityStore {
             .build();
 
     SchemaEntity schemaEntity =
-        new SchemaEntity.Builder()
+        SchemaEntity.builder()
             .withId(1L)
             .withName("schema")
             .withNamespace(Namespace.of("metalake", "catalog"))
@@ -177,7 +177,7 @@ public class TestEntityStore {
             .build();
 
     TableEntity tableEntity =
-        new TableEntity.Builder()
+        TableEntity.builder()
             .withId(1L)
             .withName("table")
             .withNamespace(Namespace.of("metalake", "catalog", "db"))
@@ -185,7 +185,7 @@ public class TestEntityStore {
             .build();
 
     FilesetEntity filesetEntity =
-        new FilesetEntity.Builder()
+        FilesetEntity.builder()
             .withId(1L)
             .withName("fileset")
             .withFilesetType(Fileset.Type.MANAGED)

--- a/core/src/test/java/com/datastrato/gravitino/TestFileset.java
+++ b/core/src/test/java/com/datastrato/gravitino/TestFileset.java
@@ -11,6 +11,8 @@ import lombok.EqualsAndHashCode;
 public class TestFileset extends BaseFileset {
 
   public static class Builder extends BaseFilesetBuilder<Builder, TestFileset> {
+    /** Creates a new instance of {@link Builder}. */
+    private Builder() {}
 
     @Override
     protected TestFileset internalBuild() {
@@ -23,5 +25,14 @@ public class TestFileset extends BaseFileset {
       fileset.storageLocation = storageLocation;
       return fileset;
     }
+  }
+
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/core/src/test/java/com/datastrato/gravitino/TestSchema.java
+++ b/core/src/test/java/com/datastrato/gravitino/TestSchema.java
@@ -13,6 +13,8 @@ public class TestSchema extends BaseSchema {
   private TestSchema() {}
 
   public static class Builder extends BaseSchema.BaseSchemaBuilder<Builder, TestSchema> {
+    /** Creates a new instance of {@link Builder}. */
+    private Builder() {}
 
     @Override
     protected TestSchema internalBuild() {
@@ -25,5 +27,14 @@ public class TestSchema extends BaseSchema {
 
       return schema;
     }
+  }
+
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/core/src/test/java/com/datastrato/gravitino/TestTable.java
+++ b/core/src/test/java/com/datastrato/gravitino/TestTable.java
@@ -18,6 +18,9 @@ public class TestTable extends BaseTable {
 
   public static class Builder extends BaseTable.BaseTableBuilder<Builder, TestTable> {
 
+    /** Creates a new instance of {@link Builder}. */
+    private Builder() {}
+
     @Override
     protected TestTable internalBuild() {
       TestTable table = new TestTable();
@@ -31,5 +34,13 @@ public class TestTable extends BaseTable {
       table.partitioning = partitioning;
       return table;
     }
+  }
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }

--- a/core/src/test/java/com/datastrato/gravitino/catalog/TestBaseColumn.java
+++ b/core/src/test/java/com/datastrato/gravitino/catalog/TestBaseColumn.java
@@ -16,6 +16,9 @@ final class BaseColumnExtension extends BaseColumn {
 
   public static class Builder extends BaseColumnBuilder<Builder, BaseColumnExtension> {
 
+    /** Creates a new instance of {@link Builder}. */
+    private Builder() {}
+
     @Override
     protected BaseColumnExtension internalBuild() {
       BaseColumnExtension column = new BaseColumnExtension();
@@ -26,6 +29,15 @@ final class BaseColumnExtension extends BaseColumn {
       return column;
     }
   }
+
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
 }
 
 public class TestBaseColumn {
@@ -33,7 +45,7 @@ public class TestBaseColumn {
   @Test
   void testColumnFields() {
     BaseColumn column =
-        new BaseColumnExtension.Builder()
+        BaseColumnExtension.builder()
             .withName("testColumnName")
             .withComment("testColumnComment")
             .withType(Types.IntegerType.get())
@@ -47,28 +59,28 @@ public class TestBaseColumn {
   @Test
   void testEqualsAndHashCode() {
     BaseColumn column1 =
-        new BaseColumnExtension.Builder()
+        BaseColumnExtension.builder()
             .withName("testColumnName")
             .withComment("testColumnComment")
             .withType(Types.StringType.get())
             .build();
 
     BaseColumn column2 =
-        new BaseColumnExtension.Builder()
+        BaseColumnExtension.builder()
             .withName("testColumnName")
             .withComment("testColumnComment")
             .withType(Types.StringType.get())
             .build();
 
     BaseColumn column3 =
-        new BaseColumnExtension.Builder()
+        BaseColumnExtension.builder()
             .withName("differentColumnName")
             .withComment("testColumnComment")
             .withType(Types.StringType.get())
             .build();
 
     BaseColumn column4 =
-        new BaseColumnExtension.Builder()
+        BaseColumnExtension.builder()
             .withName("testColumnName")
             .withComment("testColumnComment")
             .withType(Types.IntegerType.get())

--- a/core/src/test/java/com/datastrato/gravitino/catalog/TestBaseSchema.java
+++ b/core/src/test/java/com/datastrato/gravitino/catalog/TestBaseSchema.java
@@ -18,6 +18,8 @@ final class BaseSchemaExtension extends BaseSchema {
   private BaseSchemaExtension() {}
 
   public static class Builder extends BaseSchemaBuilder<Builder, BaseSchemaExtension> {
+    /** Creates a new instance of {@link Builder}. */
+    private Builder() {}
 
     @Override
     protected BaseSchemaExtension internalBuild() {
@@ -28,6 +30,14 @@ final class BaseSchemaExtension extends BaseSchema {
       schema.auditInfo = auditInfo;
       return schema;
     }
+  }
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }
 
@@ -42,7 +52,7 @@ public class TestBaseSchema {
         AuditInfo.builder().withCreator("Justin").withCreateTime(Instant.now()).build();
 
     BaseSchema schema =
-        new BaseSchemaExtension.Builder()
+        BaseSchemaExtension.builder()
             .withName("testSchemaName")
             .withComment("testSchemaComment")
             .withProperties(properties)

--- a/core/src/test/java/com/datastrato/gravitino/catalog/TestBaseTable.java
+++ b/core/src/test/java/com/datastrato/gravitino/catalog/TestBaseTable.java
@@ -27,6 +27,8 @@ final class BaseTableExtension extends BaseTable {
   }
 
   public static class Builder extends BaseTableBuilder<Builder, BaseTableExtension> {
+    /** Creates a new instance of {@link Builder}. */
+    private Builder() {}
 
     @Override
     protected BaseTableExtension internalBuild() {
@@ -39,6 +41,15 @@ final class BaseTableExtension extends BaseTable {
       table.partitioning = partitioning;
       return table;
     }
+  }
+
+  /**
+   * Creates a new instance of {@link Builder}.
+   *
+   * @return The new instance.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 }
 
@@ -53,7 +64,7 @@ public class TestBaseTable {
         AuditInfo.builder().withCreator("Justin").withCreateTime(Instant.now()).build();
 
     BaseTable table =
-        new BaseTableExtension.Builder()
+        BaseTableExtension.builder()
             .withName("testTableName")
             .withComment("testTableComment")
             .withColumns(new Column[0])

--- a/core/src/test/java/com/datastrato/gravitino/catalog/TestCatalogManager.java
+++ b/core/src/test/java/com/datastrato/gravitino/catalog/TestCatalogManager.java
@@ -51,7 +51,7 @@ public class TestCatalogManager {
   private static String provider = "test";
 
   private static BaseMetalake metalakeEntity =
-      new BaseMetalake.Builder()
+      BaseMetalake.builder()
           .withId(1L)
           .withName(metalake)
           .withAuditInfo(

--- a/core/src/test/java/com/datastrato/gravitino/catalog/TestCatalogOperationDispatcher.java
+++ b/core/src/test/java/com/datastrato/gravitino/catalog/TestCatalogOperationDispatcher.java
@@ -87,7 +87,7 @@ public class TestCatalogOperationDispatcher {
     entityStore.setSerDe(null);
 
     BaseMetalake metalakeEntity =
-        new BaseMetalake.Builder()
+        BaseMetalake.builder()
             .withId(1L)
             .withName(metalake)
             .withAuditInfo(
@@ -217,7 +217,7 @@ public class TestCatalogOperationDispatcher {
     // Case 4: Test if the fetched schema entity is matched.
     reset(entityStore);
     SchemaEntity unmatchedEntity =
-        new SchemaEntity.Builder()
+        SchemaEntity.builder()
             .withId(1L)
             .withName("schema11")
             .withNamespace(Namespace.of(metalake, catalog))
@@ -286,7 +286,7 @@ public class TestCatalogOperationDispatcher {
     // Case 4: Test if the fetched schema entity is matched.
     reset(entityStore);
     SchemaEntity unmatchedEntity =
-        new SchemaEntity.Builder()
+        SchemaEntity.builder()
             .withId(1L)
             .withName("schema21")
             .withNamespace(Namespace.of(metalake, catalog))
@@ -331,8 +331,8 @@ public class TestCatalogOperationDispatcher {
     NameIdentifier tableIdent1 = NameIdentifier.of(tableNs, "table1");
     Column[] columns =
         new Column[] {
-          new TestColumn.Builder().withName("col1").withType(Types.StringType.get()).build(),
-          new TestColumn.Builder().withName("col2").withType(Types.StringType.get()).build()
+          TestColumn.builder().withName("col1").withType(Types.StringType.get()).build(),
+          TestColumn.builder().withName("col2").withType(Types.StringType.get()).build()
         };
 
     Table table1 = dispatcher.createTable(tableIdent1, columns, "comment", props, new Transform[0]);
@@ -407,8 +407,8 @@ public class TestCatalogOperationDispatcher {
     NameIdentifier tableIdent1 = NameIdentifier.of(tableNs, "table11");
     Column[] columns =
         new Column[] {
-          new TestColumn.Builder().withName("col1").withType(Types.StringType.get()).build(),
-          new TestColumn.Builder().withName("col2").withType(Types.StringType.get()).build()
+          TestColumn.builder().withName("col1").withType(Types.StringType.get()).build(),
+          TestColumn.builder().withName("col2").withType(Types.StringType.get()).build()
         };
 
     Table table1 = dispatcher.createTable(tableIdent1, columns, "comment", props, new Transform[0]);
@@ -438,7 +438,7 @@ public class TestCatalogOperationDispatcher {
     // Case 4: Test if the table entity is not matched
     reset(entityStore);
     TableEntity tableEntity =
-        new TableEntity.Builder()
+        TableEntity.builder()
             .withId(1L)
             .withName("table11")
             .withNamespace(tableNs)
@@ -460,8 +460,8 @@ public class TestCatalogOperationDispatcher {
     NameIdentifier tableIdent = NameIdentifier.of(tableNs, "table21");
     Column[] columns =
         new Column[] {
-          new TestColumn.Builder().withName("col1").withType(Types.StringType.get()).build(),
-          new TestColumn.Builder().withName("col2").withType(Types.StringType.get()).build()
+          TestColumn.builder().withName("col1").withType(Types.StringType.get()).build(),
+          TestColumn.builder().withName("col2").withType(Types.StringType.get()).build()
         };
 
     Table table = dispatcher.createTable(tableIdent, columns, "comment", props, new Transform[0]);
@@ -504,7 +504,7 @@ public class TestCatalogOperationDispatcher {
     // Case 4: Test if the table entity is not matched
     reset(entityStore);
     TableEntity unmatchedEntity =
-        new TableEntity.Builder()
+        TableEntity.builder()
             .withId(1L)
             .withName("table21")
             .withNamespace(tableNs)
@@ -524,8 +524,8 @@ public class TestCatalogOperationDispatcher {
     Map<String, String> props = ImmutableMap.of("k1", "v1", "k2", "v2");
     Column[] columns =
         new Column[] {
-          new TestColumn.Builder().withName("col1").withType(Types.StringType.get()).build(),
-          new TestColumn.Builder().withName("col2").withType(Types.StringType.get()).build()
+          TestColumn.builder().withName("col1").withType(Types.StringType.get()).build(),
+          TestColumn.builder().withName("col2").withType(Types.StringType.get()).build()
         };
     Table table = dispatcher.createTable(tableIdent, columns, "comment", props, new Transform[0]);
 

--- a/core/src/test/java/com/datastrato/gravitino/meta/TestEntity.java
+++ b/core/src/test/java/com/datastrato/gravitino/meta/TestEntity.java
@@ -50,7 +50,7 @@ public class TestEntity {
   @Test
   public void testMetalake() {
     BaseMetalake metalake =
-        new BaseMetalake.Builder()
+        BaseMetalake.builder()
             .withId(metalakeId)
             .withName(metalakeName)
             .withAuditInfo(auditInfo)
@@ -93,7 +93,7 @@ public class TestEntity {
   @Test
   public void testSchema() {
     SchemaEntity testSchema =
-        new SchemaEntity.Builder()
+        SchemaEntity.builder()
             .withId(schemaId)
             .withName(schemaName)
             .withAuditInfo(auditInfo)
@@ -105,7 +105,7 @@ public class TestEntity {
     Assertions.assertEquals(auditInfo, fields.get(SchemaEntity.AUDIT_INFO));
 
     SchemaEntity testSchema1 =
-        new SchemaEntity.Builder()
+        SchemaEntity.builder()
             .withId(schemaId)
             .withName(schemaName)
             .withAuditInfo(auditInfo)
@@ -120,11 +120,7 @@ public class TestEntity {
   @Test
   public void testTable() {
     TableEntity testTable =
-        new TableEntity.Builder()
-            .withId(tableId)
-            .withName(tableName)
-            .withAuditInfo(auditInfo)
-            .build();
+        TableEntity.builder().withId(tableId).withName(tableName).withAuditInfo(auditInfo).build();
 
     Map<Field, Object> fields = testTable.fields();
     Assertions.assertEquals(tableId, fields.get(TableEntity.ID));
@@ -135,7 +131,7 @@ public class TestEntity {
   @Test
   public void testFile() {
     FilesetEntity testFile =
-        new FilesetEntity.Builder()
+        FilesetEntity.builder()
             .withId(fileId)
             .withName(fileName)
             .withAuditInfo(auditInfo)
@@ -154,7 +150,7 @@ public class TestEntity {
     Assertions.assertEquals("testLocation", fields.get(FilesetEntity.STORAGE_LOCATION));
 
     FilesetEntity testFile1 =
-        new FilesetEntity.Builder()
+        FilesetEntity.builder()
             .withId(fileId)
             .withName(fileName)
             .withAuditInfo(auditInfo)
@@ -169,7 +165,7 @@ public class TestEntity {
         Assertions.assertThrows(
             IllegalArgumentException.class,
             () -> {
-              new FilesetEntity.Builder()
+              FilesetEntity.builder()
                   .withId(fileId)
                   .withName(fileName)
                   .withAuditInfo(auditInfo)

--- a/core/src/test/java/com/datastrato/gravitino/proto/TestEntityProtoSerDe.java
+++ b/core/src/test/java/com/datastrato/gravitino/proto/TestEntityProtoSerDe.java
@@ -79,7 +79,7 @@ public class TestEntityProtoSerDe {
 
     // Test Metalake
     com.datastrato.gravitino.meta.BaseMetalake metalake =
-        new com.datastrato.gravitino.meta.BaseMetalake.Builder()
+        com.datastrato.gravitino.meta.BaseMetalake.builder()
             .withId(metalakeId)
             .withName(metalakeName)
             .withProperties(props)
@@ -97,7 +97,7 @@ public class TestEntityProtoSerDe {
 
     // Test metalake without props map
     com.datastrato.gravitino.meta.BaseMetalake metalake1 =
-        new com.datastrato.gravitino.meta.BaseMetalake.Builder()
+        com.datastrato.gravitino.meta.BaseMetalake.builder()
             .withId(metalakeId)
             .withName(metalakeName)
             .withAuditInfo(auditInfo)
@@ -152,7 +152,7 @@ public class TestEntityProtoSerDe {
     Long schemaId = 1L;
     String schemaName = "schema";
     com.datastrato.gravitino.meta.SchemaEntity schemaEntity =
-        new com.datastrato.gravitino.meta.SchemaEntity.Builder()
+        com.datastrato.gravitino.meta.SchemaEntity.builder()
             .withId(schemaId)
             .withName(schemaName)
             .withAuditInfo(auditInfo)
@@ -165,7 +165,7 @@ public class TestEntityProtoSerDe {
 
     // Test SchemaEntity with additional fields
     com.datastrato.gravitino.meta.SchemaEntity schemaEntity1 =
-        new com.datastrato.gravitino.meta.SchemaEntity.Builder()
+        com.datastrato.gravitino.meta.SchemaEntity.builder()
             .withId(schemaId)
             .withName(schemaName)
             .withAuditInfo(auditInfo)
@@ -184,7 +184,7 @@ public class TestEntityProtoSerDe {
     Long tableId = 1L;
     String tableName = "table";
     com.datastrato.gravitino.meta.TableEntity tableEntity =
-        new com.datastrato.gravitino.meta.TableEntity.Builder()
+        com.datastrato.gravitino.meta.TableEntity.builder()
             .withId(tableId)
             .withName(tableName)
             .withAuditInfo(auditInfo)
@@ -199,7 +199,7 @@ public class TestEntityProtoSerDe {
     Long fileId = 1L;
     String fileName = "file";
     com.datastrato.gravitino.meta.FilesetEntity fileEntity =
-        new com.datastrato.gravitino.meta.FilesetEntity.Builder()
+        com.datastrato.gravitino.meta.FilesetEntity.builder()
             .withId(fileId)
             .withName(fileName)
             .withAuditInfo(auditInfo)
@@ -214,7 +214,7 @@ public class TestEntityProtoSerDe {
     Assertions.assertEquals(fileEntity, fileEntityFromBytes);
 
     com.datastrato.gravitino.meta.FilesetEntity fileEntity1 =
-        new com.datastrato.gravitino.meta.FilesetEntity.Builder()
+        com.datastrato.gravitino.meta.FilesetEntity.builder()
             .withId(fileId)
             .withName(fileName)
             .withAuditInfo(auditInfo)
@@ -229,7 +229,7 @@ public class TestEntityProtoSerDe {
     Assertions.assertNull(fileEntityFromBytes1.properties());
 
     com.datastrato.gravitino.meta.FilesetEntity fileEntity2 =
-        new com.datastrato.gravitino.meta.FilesetEntity.Builder()
+        com.datastrato.gravitino.meta.FilesetEntity.builder()
             .withId(fileId)
             .withName(fileName)
             .withAuditInfo(auditInfo)

--- a/core/src/test/java/com/datastrato/gravitino/storage/kv/TestKvEntityStorage.java
+++ b/core/src/test/java/com/datastrato/gravitino/storage/kv/TestKvEntityStorage.java
@@ -71,7 +71,7 @@ public class TestKvEntityStorage {
   }
 
   public static BaseMetalake createBaseMakeLake(String name, AuditInfo auditInfo) {
-    return new BaseMetalake.Builder()
+    return BaseMetalake.builder()
         .withId(1L)
         .withName(name)
         .withAuditInfo(auditInfo)
@@ -92,7 +92,7 @@ public class TestKvEntityStorage {
 
   public static SchemaEntity createSchemaEntity(
       Namespace namespace, String name, AuditInfo auditInfo) {
-    return new SchemaEntity.Builder()
+    return SchemaEntity.builder()
         .withId(1L)
         .withName(name)
         .withNamespace(namespace)
@@ -102,7 +102,7 @@ public class TestKvEntityStorage {
 
   public static TableEntity createTableEntity(
       Namespace namespace, String name, AuditInfo auditInfo) {
-    return new TableEntity.Builder()
+    return TableEntity.builder()
         .withId(1L)
         .withName(name)
         .withNamespace(namespace)
@@ -112,7 +112,7 @@ public class TestKvEntityStorage {
 
   public static FilesetEntity createFilesetEntity(
       Namespace namespace, String name, AuditInfo auditInfo) {
-    return new FilesetEntity.Builder()
+    return FilesetEntity.builder()
         .withId(1L)
         .withName(name)
         .withNamespace(namespace)

--- a/core/src/test/java/com/datastrato/gravitino/storage/relational/TestRelationalEntityStore.java
+++ b/core/src/test/java/com/datastrato/gravitino/storage/relational/TestRelationalEntityStore.java
@@ -812,7 +812,7 @@ public class TestRelationalEntityStore {
                 Entity.EntityType.METALAKE,
                 m -> {
                   BaseMetalake.Builder builder =
-                      new BaseMetalake.Builder()
+                      BaseMetalake.builder()
                           // Change the id, which is not allowed
                           .withId(2L)
                           .withName("test_metalake2")
@@ -832,7 +832,7 @@ public class TestRelationalEntityStore {
             Entity.EntityType.METALAKE,
             m -> {
               BaseMetalake.Builder builder =
-                  new BaseMetalake.Builder()
+                  BaseMetalake.builder()
                       .withId(m.id())
                       .withName("test_metalake2")
                       .withComment("this is test 2")
@@ -862,7 +862,7 @@ public class TestRelationalEntityStore {
                 Entity.EntityType.METALAKE,
                 m -> {
                   BaseMetalake.Builder builder =
-                      new BaseMetalake.Builder()
+                      BaseMetalake.builder()
                           .withId(metalake3.id())
                           // metalake name already exists
                           .withName("test_metalake2")
@@ -990,7 +990,7 @@ public class TestRelationalEntityStore {
                 Entity.EntityType.SCHEMA,
                 s -> {
                   SchemaEntity.Builder builder =
-                      new SchemaEntity.Builder()
+                      SchemaEntity.builder()
                           // Change the id, which is not allowed
                           .withId(2L)
                           .withName("test_schema2")
@@ -1010,7 +1010,7 @@ public class TestRelationalEntityStore {
             Entity.EntityType.SCHEMA,
             s -> {
               SchemaEntity.Builder builder =
-                  new SchemaEntity.Builder()
+                  SchemaEntity.builder()
                       .withId(s.id())
                       .withName("test_schema2")
                       .withNamespace(Namespace.ofSchema(metalake.name(), catalog.name()))
@@ -1046,7 +1046,7 @@ public class TestRelationalEntityStore {
                 Entity.EntityType.SCHEMA,
                 s -> {
                   SchemaEntity.Builder builder =
-                      new SchemaEntity.Builder()
+                      SchemaEntity.builder()
                           .withId(schema3.id())
                           // schema name already exists
                           .withName("test_schema2")
@@ -1090,7 +1090,7 @@ public class TestRelationalEntityStore {
                 Entity.EntityType.TABLE,
                 s -> {
                   TableEntity.Builder builder =
-                      new TableEntity.Builder()
+                      TableEntity.builder()
                           // Change the id, which is not allowed
                           .withId(2L)
                           .withName("test_table2")
@@ -1109,7 +1109,7 @@ public class TestRelationalEntityStore {
             Entity.EntityType.TABLE,
             s -> {
               TableEntity.Builder builder =
-                  new TableEntity.Builder()
+                  TableEntity.builder()
                       .withId(s.id())
                       .withName("test_table2")
                       .withNamespace(
@@ -1139,7 +1139,7 @@ public class TestRelationalEntityStore {
                 Entity.EntityType.TABLE,
                 s -> {
                   TableEntity.Builder builder =
-                      new TableEntity.Builder()
+                      TableEntity.builder()
                           .withId(table3.id())
                           // table name already exists
                           .withName("test_table2")
@@ -1186,7 +1186,7 @@ public class TestRelationalEntityStore {
                 Entity.EntityType.FILESET,
                 f -> {
                   FilesetEntity.Builder builder =
-                      new FilesetEntity.Builder()
+                      FilesetEntity.builder()
                           // Change the id, which is not allowed
                           .withId(2L)
                           .withName("test_fileset2")
@@ -1210,7 +1210,7 @@ public class TestRelationalEntityStore {
             Entity.EntityType.FILESET,
             f -> {
               FilesetEntity.Builder builder =
-                  new FilesetEntity.Builder()
+                  FilesetEntity.builder()
                       .withId(f.id())
                       .withName("test_fileset2")
                       .withNamespace(
@@ -1251,7 +1251,7 @@ public class TestRelationalEntityStore {
                 Entity.EntityType.FILESET,
                 f -> {
                   FilesetEntity.Builder builder =
-                      new FilesetEntity.Builder()
+                      FilesetEntity.builder()
                           .withId(fileset3.id())
                           // fileset name already exists
                           .withName("test_fileset2")
@@ -1273,7 +1273,7 @@ public class TestRelationalEntityStore {
             Entity.EntityType.FILESET,
             f -> {
               FilesetEntity.Builder builder =
-                  new FilesetEntity.Builder()
+                  FilesetEntity.builder()
                       .withId(f.id())
                       .withName("test_fileset4")
                       .withNamespace(
@@ -1384,7 +1384,7 @@ public class TestRelationalEntityStore {
   private static BaseMetalake createMetalake(Long id, String name, String comment) {
     AuditInfo auditInfo =
         AuditInfo.builder().withCreator("creator").withCreateTime(Instant.now()).build();
-    return new BaseMetalake.Builder()
+    return BaseMetalake.builder()
         .withId(id)
         .withName(name)
         .withComment(comment)
@@ -1435,7 +1435,7 @@ public class TestRelationalEntityStore {
       Long id, String name, Namespace namespace, String comment) {
     AuditInfo auditInfo =
         AuditInfo.builder().withCreator("creator").withCreateTime(Instant.now()).build();
-    return new SchemaEntity.Builder()
+    return SchemaEntity.builder()
         .withId(id)
         .withName(name)
         .withNamespace(namespace)
@@ -1458,7 +1458,7 @@ public class TestRelationalEntityStore {
   private static TableEntity createTable(Long id, String name, Namespace namespace) {
     AuditInfo auditInfo =
         AuditInfo.builder().withCreator("creator").withCreateTime(Instant.now()).build();
-    return new TableEntity.Builder()
+    return TableEntity.builder()
         .withId(id)
         .withName(name)
         .withNamespace(namespace)
@@ -1477,7 +1477,7 @@ public class TestRelationalEntityStore {
       Long id, String name, Namespace namespace, String comment, String location) {
     AuditInfo auditInfo =
         AuditInfo.builder().withCreator("creator").withCreateTime(Instant.now()).build();
-    return new FilesetEntity.Builder()
+    return FilesetEntity.builder()
         .withId(id)
         .withName(name)
         .withNamespace(namespace)

--- a/core/src/test/java/com/datastrato/gravitino/storage/relational/utils/TestPOConverters.java
+++ b/core/src/test/java/com/datastrato/gravitino/storage/relational/utils/TestPOConverters.java
@@ -337,9 +337,7 @@ public class TestPOConverters {
     SchemaEntity schema =
         createSchema(
             1L, "test", Namespace.ofSchema("test_metalake", "test_catalog"), "this is test");
-    SchemaPO.Builder builder = new SchemaPO.Builder();
-    builder.withMetalakeId(1L);
-    builder.withCatalogId(1L);
+    SchemaPO.Builder builder = SchemaPO.builder().withMetalakeId(1L).withCatalogId(1L);
     SchemaPO initPO = POConverters.initializeSchemaPOWithVersion(schema, builder);
     assertEquals(1, initPO.getCurrentVersion());
     assertEquals(1, initPO.getLastVersion());
@@ -350,10 +348,8 @@ public class TestPOConverters {
   public void testInitTablePOVersion() {
     TableEntity tableEntity =
         createTable(1L, "test", Namespace.ofTable("test_metalake", "test_catalog", "test_schema"));
-    TablePO.Builder builder = new TablePO.Builder();
-    builder.withMetalakeId(1L);
-    builder.withCatalogId(1L);
-    builder.withSchemaId(1L);
+    TablePO.Builder builder =
+        TablePO.builder().withMetalakeId(1L).withCatalogId(1L).withSchemaId(1L);
     TablePO initPO = POConverters.initializeTablePOWithVersion(tableEntity, builder);
     assertEquals(1, initPO.getCurrentVersion());
     assertEquals(1, initPO.getLastVersion());
@@ -370,10 +366,8 @@ public class TestPOConverters {
             "this is test",
             "hdfs://localhost/test",
             new HashMap<>());
-    FilesetPO.Builder builder = new FilesetPO.Builder();
-    builder.withMetalakeId(1L);
-    builder.withCatalogId(1L);
-    builder.withSchemaId(1L);
+    FilesetPO.Builder builder =
+        FilesetPO.builder().withMetalakeId(1L).withCatalogId(1L).withSchemaId(1L);
     FilesetPO initPO = POConverters.initializeFilesetPOWithVersion(filesetEntity, builder);
     assertEquals(1, initPO.getCurrentVersion());
     assertEquals(1, initPO.getLastVersion());
@@ -416,9 +410,7 @@ public class TestPOConverters {
     SchemaEntity updatedSchema =
         createSchema(
             1L, "test", Namespace.ofSchema("test_metalake", "test_catalog"), "this is test2");
-    SchemaPO.Builder builder = new SchemaPO.Builder();
-    builder.withMetalakeId(1L);
-    builder.withCatalogId(1L);
+    SchemaPO.Builder builder = SchemaPO.builder().withMetalakeId(1L).withCatalogId(1L);
     SchemaPO initPO = POConverters.initializeSchemaPOWithVersion(schema, builder);
     SchemaPO updatePO = POConverters.updateSchemaPOWithVersion(initPO, updatedSchema);
     assertEquals(1, initPO.getCurrentVersion());
@@ -433,10 +425,8 @@ public class TestPOConverters {
         createTable(1L, "test", Namespace.ofTable("test_metalake", "test_catalog", "test_schema"));
     TableEntity updatedTable =
         createTable(1L, "test", Namespace.ofTable("test_metalake", "test_catalog", "test_schema"));
-    TablePO.Builder builder = new TablePO.Builder();
-    builder.withMetalakeId(1L);
-    builder.withCatalogId(1L);
-    builder.withSchemaId(1L);
+    TablePO.Builder builder =
+        TablePO.builder().withMetalakeId(1L).withCatalogId(1L).withSchemaId(1L);
     TablePO initPO = POConverters.initializeTablePOWithVersion(tableEntity, builder);
     TablePO updatePO = POConverters.updateTablePOWithVersion(initPO, updatedTable);
     assertEquals(1, initPO.getCurrentVersion());
@@ -478,10 +468,8 @@ public class TestPOConverters {
             "hdfs://localhost/test",
             properties);
 
-    FilesetPO.Builder builder = new FilesetPO.Builder();
-    builder.withMetalakeId(1L);
-    builder.withCatalogId(1L);
-    builder.withSchemaId(1L);
+    FilesetPO.Builder builder =
+        FilesetPO.builder().withMetalakeId(1L).withCatalogId(1L).withSchemaId(1L);
     FilesetPO initPO = POConverters.initializeFilesetPOWithVersion(filesetEntity, builder);
 
     // map has updated
@@ -520,7 +508,7 @@ public class TestPOConverters {
         AuditInfo.builder().withCreator("creator").withCreateTime(FIX_INSTANT).build();
     Map<String, String> properties = new HashMap<>();
     properties.put("key", "value");
-    return new BaseMetalake.Builder()
+    return BaseMetalake.builder()
         .withId(id)
         .withName(name)
         .withComment(comment)
@@ -536,7 +524,7 @@ public class TestPOConverters {
         AuditInfo.builder().withCreator("creator").withCreateTime(FIX_INSTANT).build();
     Map<String, String> properties = new HashMap<>();
     properties.put("key", "value");
-    return new MetalakePO.Builder()
+    return MetalakePO.builder()
         .withMetalakeId(id)
         .withMetalakeName(name)
         .withMetalakeComment(comment)
@@ -573,7 +561,7 @@ public class TestPOConverters {
         AuditInfo.builder().withCreator("creator").withCreateTime(FIX_INSTANT).build();
     Map<String, String> properties = new HashMap<>();
     properties.put("key", "value");
-    return new CatalogPO.Builder()
+    return CatalogPO.builder()
         .withCatalogId(id)
         .withCatalogName(name)
         .withMetalakeId(metalakeId)
@@ -594,7 +582,7 @@ public class TestPOConverters {
         AuditInfo.builder().withCreator("creator").withCreateTime(FIX_INSTANT).build();
     Map<String, String> properties = new HashMap<>();
     properties.put("key", "value");
-    return new SchemaEntity.Builder()
+    return SchemaEntity.builder()
         .withId(id)
         .withName(name)
         .withNamespace(namespace)
@@ -611,7 +599,7 @@ public class TestPOConverters {
         AuditInfo.builder().withCreator("creator").withCreateTime(FIX_INSTANT).build();
     Map<String, String> properties = new HashMap<>();
     properties.put("key", "value");
-    return new SchemaPO.Builder()
+    return SchemaPO.builder()
         .withSchemaId(id)
         .withSchemaName(name)
         .withMetalakeId(metalakeId)
@@ -628,7 +616,7 @@ public class TestPOConverters {
   private static TableEntity createTable(Long id, String name, Namespace namespace) {
     AuditInfo auditInfo =
         AuditInfo.builder().withCreator("creator").withCreateTime(FIX_INSTANT).build();
-    return new TableEntity.Builder()
+    return TableEntity.builder()
         .withId(id)
         .withName(name)
         .withNamespace(namespace)
@@ -641,7 +629,7 @@ public class TestPOConverters {
       throws JsonProcessingException {
     AuditInfo auditInfo =
         AuditInfo.builder().withCreator("creator").withCreateTime(FIX_INSTANT).build();
-    return new TablePO.Builder()
+    return TablePO.builder()
         .withTableId(id)
         .withTableName(name)
         .withMetalakeId(metalakeId)
@@ -663,7 +651,7 @@ public class TestPOConverters {
       Map<String, String> properties) {
     AuditInfo auditInfo =
         AuditInfo.builder().withCreator("creator").withCreateTime(FIX_INSTANT).build();
-    return new FilesetEntity.Builder()
+    return FilesetEntity.builder()
         .withId(id)
         .withName(name)
         .withNamespace(namespace)
@@ -686,7 +674,7 @@ public class TestPOConverters {
       throws JsonProcessingException {
     AuditInfo auditInfo =
         AuditInfo.builder().withCreator("creator").withCreateTime(FIX_INSTANT).build();
-    return new FilesetPO.Builder()
+    return FilesetPO.builder()
         .withFilesetId(id)
         .withFilesetName(name)
         .withMetalakeId(metalakeId)
@@ -712,7 +700,7 @@ public class TestPOConverters {
       String storageLocation,
       Map<String, String> properties)
       throws JsonProcessingException {
-    return new FilesetVersionPO.Builder()
+    return FilesetVersionPO.builder()
         .withId(id)
         .withMetalakeId(metalakeId)
         .withCatalogId(catalogId)

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,9 +18,6 @@ SONATYPE_PASSWORD = password
 #jdkVersion is used to specify the version of JDK to build and test Gravitino, current
 # supported version is 8, 11, and 17.
 jdkVersion = 8
-<<<<<<< HEAD
 
 # defaultScalaVersion is used to specify the version of Scala to build and test Gravitino
 defaultScalaVersion = 2.12
-=======
->>>>>>> 0b92804b (draft3)

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,9 @@ SONATYPE_PASSWORD = password
 #jdkVersion is used to specify the version of JDK to build and test Gravitino, current
 # supported version is 8, 11, and 17.
 jdkVersion = 8
+<<<<<<< HEAD
 
 # defaultScalaVersion is used to specify the version of Scala to build and test Gravitino
 defaultScalaVersion = 2.12
+=======
+>>>>>>> 0b92804b (draft3)

--- a/server/src/test/java/com/datastrato/gravitino/server/web/rest/TestMetalakeOperations.java
+++ b/server/src/test/java/com/datastrato/gravitino/server/web/rest/TestMetalakeOperations.java
@@ -102,7 +102,7 @@ public class TestMetalakeOperations extends JerseyTest {
     Instant now = Instant.now();
     AuditInfo info = AuditInfo.builder().withCreator("gravitino").withCreateTime(now).build();
     BaseMetalake metalake =
-        new BaseMetalake.Builder()
+        BaseMetalake.builder()
             .withName(metalakeName)
             .withId(id)
             .withAuditInfo(info)
@@ -136,7 +136,7 @@ public class TestMetalakeOperations extends JerseyTest {
     Instant now = Instant.now();
 
     BaseMetalake mockMetalake =
-        new BaseMetalake.Builder()
+        BaseMetalake.builder()
             .withId(1L)
             .withName("metalake")
             .withComment("comment")
@@ -185,7 +185,7 @@ public class TestMetalakeOperations extends JerseyTest {
     Instant now = Instant.now();
     AuditInfo info = AuditInfo.builder().withCreator("gravitino").withCreateTime(now).build();
     BaseMetalake metalake =
-        new BaseMetalake.Builder()
+        BaseMetalake.builder()
             .withName(metalakeName)
             .withId(id)
             .withAuditInfo(info)
@@ -260,7 +260,7 @@ public class TestMetalakeOperations extends JerseyTest {
     Instant now = Instant.now();
     AuditInfo info = AuditInfo.builder().withCreator("gravitino").withCreateTime(now).build();
     BaseMetalake metalake =
-        new BaseMetalake.Builder()
+        BaseMetalake.builder()
             .withName(metalakeName)
             .withId(id)
             .withAuditInfo(info)

--- a/server/src/test/java/com/datastrato/gravitino/server/web/rest/TestTableOperations.java
+++ b/server/src/test/java/com/datastrato/gravitino/server/web/rest/TestTableOperations.java
@@ -182,7 +182,7 @@ public class TestTableOperations extends JerseyTest {
   }
 
   private DistributionDTO createMockDistributionDTO(String columnName, int bucketNum) {
-    return  DistributionDTO.builder()
+    return DistributionDTO.builder()
         .withStrategy(Strategy.HASH)
         .withNumber(bucketNum)
         .withArgs(FieldReferenceDTO.of(columnName))

--- a/server/src/test/java/com/datastrato/gravitino/server/web/rest/TestTableOperations.java
+++ b/server/src/test/java/com/datastrato/gravitino/server/web/rest/TestTableOperations.java
@@ -182,7 +182,7 @@ public class TestTableOperations extends JerseyTest {
   }
 
   private DistributionDTO createMockDistributionDTO(String columnName, int bucketNum) {
-    return new DistributionDTO.Builder()
+    return  DistributionDTO.builder()
         .withStrategy(Strategy.HASH)
         .withNumber(bucketNum)
         .withArgs(FieldReferenceDTO.of(columnName))
@@ -191,7 +191,7 @@ public class TestTableOperations extends JerseyTest {
 
   private SortOrderDTO[] createMockSortOrderDTO(String columnName, SortDirection direction) {
     return new SortOrderDTO[] {
-      new SortOrderDTO.Builder()
+      SortOrderDTO.builder()
           .withDirection(direction)
           .withNullOrder(NullOrdering.NULLS_FIRST)
           .withSortTerm(FieldReferenceDTO.of(columnName))


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Standardize the invocation method for the Builder pattern 

### Why are the changes needed?

Make the code cleaner and more readable.

Fix: #1640 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

The IT ( `./gradlew build` ) can ensure the function is work.
  
