### PR TITLE
[#2570][#2559] refactor(web): Displaying a fallback while content is loading for each small module, upgrade axios to v1.6.8

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -27,7 +27,7 @@
     "@mui/x-tree-view": "^6.17.0",
     "@reduxjs/toolkit": "^1.9.7",
     "antd": "^5.13.3",
-    "axios": "^1.6.5",
+    "axios": "^1.6.8",
     "chroma-js": "^2.4.2",
     "clsx": "^2.0.0",
     "dayjs": "^1.11.10",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -39,8 +39,8 @@ dependencies:
     specifier: ^5.13.3
     version: 5.13.3(react-dom@18.2.0)(react@18.2.0)
   axios:
-    specifier: ^1.6.5
-    version: 1.6.5
+    specifier: ^1.6.8
+    version: 1.6.8
   chroma-js:
     specifier: ^2.4.2
     version: 2.4.2
@@ -1454,10 +1454,10 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /axios@1.6.5:
-    resolution: {integrity: sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==}
+  /axios@1.6.8:
+    resolution: {integrity: sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==}
     dependencies:
-      follow-redirects: 1.15.4
+      follow-redirects: 1.15.6
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -2305,8 +2305,8 @@ packages:
     resolution: {integrity: sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==}
     dev: true
 
-  /follow-redirects@1.15.4:
-    resolution: {integrity: sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==}
+  /follow-redirects@1.15.6:
+    resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'

--- a/web/src/app/layout.js
+++ b/web/src/app/layout.js
@@ -5,13 +5,8 @@
 
 import '@/lib/styles/globals.css'
 
-import { Suspense } from 'react'
-
 import { NavigationEvents } from './rootLayout/navigation-events'
-
 import Provider from '@/lib/provider'
-
-import Loading from './rootLayout/Loading'
 import Layout from './rootLayout/Layout'
 import StyledToast from '../components/StyledToast'
 
@@ -19,7 +14,7 @@ export const metadata = {
   title: 'Gravitino',
   description: 'A high-performance, geo-distributed and federated metadata lake.',
   icons: {
-    icon: '/ui/icons/gravitino.svg'
+    icon: process.env.NEXT_PUBLIC_BASE_PATH + '/icons/gravitino.svg'
   }
 }
 
@@ -28,10 +23,8 @@ const RootLayout = ({ children }) => {
     <html lang='en' suppressHydrationWarning>
       <body>
         <Provider>
-          <Suspense fallback={<Loading />}>
-            <NavigationEvents />
-            <Layout>{children}</Layout>
-          </Suspense>
+          <NavigationEvents />
+          <Layout>{children}</Layout>
         </Provider>
         <StyledToast />
       </body>

--- a/web/src/app/metalakes/CreateMetalakeDialog.js
+++ b/web/src/app/metalakes/CreateMetalakeDialog.js
@@ -4,6 +4,7 @@
  */
 
 import { useState, forwardRef, useEffect } from 'react'
+import { updateMetalake } from '@/lib/store/metalakes'
 
 import {
   Box,
@@ -53,7 +54,7 @@ const Transition = forwardRef(function Transition(props, ref) {
 })
 
 const CreateMetalakeDialog = props => {
-  const { open, setOpen, data = {}, updateMetalake, type = 'create' } = props
+  const { open, setOpen, data = {}, type = 'create' } = props
 
   const dispatch = useAppDispatch()
 

--- a/web/src/app/metalakes/TableBody.js
+++ b/web/src/app/metalakes/TableBody.js
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2023 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+
+import { useState, useEffect, Fragment } from 'react'
+
+import Link from 'next/link'
+
+import { Box, Typography, Portal, Tooltip } from '@mui/material'
+import { DataGrid, GridActionsCellItem, GridToolbar } from '@mui/x-data-grid'
+import {
+  VisibilityOutlined as ViewIcon,
+  EditOutlined as EditIcon,
+  DeleteOutlined as DeleteIcon
+} from '@mui/icons-material'
+
+import { formatToDateTime } from '@/lib/utils/date'
+import { useAppDispatch, useAppSelector } from '@/lib/hooks/useStore'
+import { fetchMetalakes, setFilteredMetalakes, deleteMetalake, resetTree } from '@/lib/store/metalakes'
+import ConfirmDeleteDialog from '@/components/ConfirmDeleteDialog'
+
+const TableBody = props => {
+  const { value, setOpenDialog, setDialogData, setDialogType, setDrawerData, setOpenDrawer } = props
+
+  const dispatch = useAppDispatch()
+  const store = useAppSelector(state => state.metalakes)
+  const [paginationModel, setPaginationModel] = useState({ page: 0, pageSize: 10 })
+
+  const [openConfirmDelete, setOpenConfirmDelete] = useState(false)
+  const [confirmCacheData, setConfirmCacheData] = useState(null)
+
+  const handleDeleteMetalake = name => () => {
+    setOpenConfirmDelete(true)
+    setConfirmCacheData(name)
+  }
+
+  const handleConfirmDeleteSubmit = () => {
+    if (confirmCacheData) {
+      dispatch(deleteMetalake(confirmCacheData))
+      setOpenConfirmDelete(false)
+    }
+  }
+
+  const handleCloseConfirm = () => {
+    setOpenConfirmDelete(false)
+    setConfirmCacheData(null)
+  }
+
+  const handleShowEditDialog = data => () => {
+    setDialogType('update')
+    setOpenDialog(true)
+    setDialogData(data)
+  }
+
+  const handleShowDetails = row => () => {
+    setDrawerData(row)
+    setOpenDrawer(true)
+  }
+
+  const handleClickLink = () => {
+    dispatch(resetTree())
+  }
+
+  useEffect(() => {
+    dispatch(fetchMetalakes())
+  }, [dispatch])
+
+  useEffect(() => {
+    const filteredData = store.metalakes
+      .filter(i => i.name.toLowerCase().includes(value.toLowerCase()))
+      .sort((a, b) => {
+        if (a.name.toLowerCase() === value.toLowerCase()) return -1
+        if (b.name.toLowerCase() === value.toLowerCase()) return 1
+
+        return 0
+      })
+
+    dispatch(setFilteredMetalakes(filteredData))
+  }, [dispatch, store.metalakes, value])
+
+  /** @type {import('@mui/x-data-grid').GridColDef[]} */
+  const columns = [
+    {
+      flex: 0.2,
+      minWidth: 230,
+      disableColumnMenu: true,
+      filterable: true,
+      type: 'string',
+      field: 'name',
+      headerName: 'Name',
+      renderCell: ({ row }) => {
+        const { name } = row
+
+        return (
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            <Tooltip title={name} placement='right'>
+              <Typography
+                noWrap
+                component={Link}
+                href={`/metalakes?metalake=${name}`}
+                onClick={() => handleClickLink()}
+                sx={{
+                  fontWeight: 500,
+                  color: 'primary.main',
+                  textDecoration: 'none',
+                  maxWidth: 240,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  '&:hover': { color: 'primary.main', textDecoration: 'underline' }
+                }}
+              >
+                {name}
+              </Typography>
+            </Tooltip>
+          </Box>
+        )
+      }
+    },
+    {
+      flex: 0.15,
+      minWidth: 150,
+      disableColumnMenu: true,
+      type: 'string',
+      field: 'createdBy',
+      valueGetter: params => `${params.row.audit?.creator}`,
+      headerName: 'Created by',
+      renderCell: ({ row }) => {
+        return (
+          <Typography noWrap sx={{ color: 'text.secondary' }}>
+            {row.audit?.creator}
+          </Typography>
+        )
+      }
+    },
+    {
+      flex: 0.15,
+      minWidth: 150,
+      disableColumnMenu: true,
+      type: 'dateTime',
+      field: 'createdAt',
+      valueGetter: params => new Date(params.row.audit?.createTime),
+      headerName: 'Created at',
+      renderCell: ({ row }) => {
+        return (
+          <Typography title={row.audit?.createTime} noWrap sx={{ color: 'text.secondary' }}>
+            {formatToDateTime(row.audit?.createTime)}
+          </Typography>
+        )
+      }
+    },
+    {
+      flex: 0.1,
+      minWidth: 90,
+      type: 'actions',
+      headerName: 'Actions',
+      field: 'actions',
+      getActions: ({ id, row }) => [
+        <GridActionsCellItem
+          key='details'
+          label='Details'
+          title='Details'
+          data-refer={`view-metalake-${row.name}`}
+          icon={<ViewIcon viewBox='0 0 24 22' />}
+          onClick={handleShowDetails(row)}
+          sx={{
+            '& svg': {
+              fontSize: '24px'
+            }
+          }}
+        />,
+        <GridActionsCellItem
+          key='edit'
+          label='Edit'
+          title='Edit'
+          data-refer={`edit-metalake-${row.name}`}
+          icon={<EditIcon />}
+          onClick={handleShowEditDialog(row)}
+          sx={{
+            '& svg': {
+              fontSize: '24px'
+            }
+          }}
+        />,
+        <GridActionsCellItem
+          key='delete'
+          icon={<DeleteIcon />}
+          label='Delete'
+          title='Delete'
+          data-refer={`delete-metalake-${row.name}`}
+          onClick={handleDeleteMetalake(row.name)}
+          sx={{
+            '& svg': {
+              fontSize: '24px',
+              color: theme => theme.palette.error.light
+            }
+          }}
+        />
+      ]
+    }
+  ]
+
+  function TableToolbar(props) {
+    return (
+      <>
+        <Fragment>
+          <Portal container={() => document.getElementById('filter-panel')}>
+            <Box className={`twc-flex twc-w-full twc-justify-between`}>
+              <GridToolbar {...props} />
+            </Box>
+          </Portal>
+        </Fragment>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <DataGrid
+        disableColumnSelector
+        disableDensitySelector
+        slots={{ toolbar: TableToolbar }}
+        slotProps={{
+          toolbar: {
+            printOptions: { disableToolbarButton: true },
+            csvOptions: { disableToolbarButton: true }
+          }
+        }}
+        sx={{
+          '& .MuiDataGrid-virtualScroller': {
+            minHeight: 36
+          },
+          maxHeight: 'calc(100vh - 23.2rem)'
+        }}
+        getRowId={row => row?.name}
+        rows={store.filteredMetalakes}
+        columns={columns}
+        disableRowSelectionOnClick
+        onCellClick={(params, event) => event.stopPropagation()}
+        onRowClick={(params, event) => event.stopPropagation()}
+        pageSizeOptions={[10, 25, 50]}
+        paginationModel={paginationModel}
+        onPaginationModelChange={setPaginationModel}
+      />
+      <ConfirmDeleteDialog
+        open={openConfirmDelete}
+        setOpen={setOpenConfirmDelete}
+        confirmCacheData={confirmCacheData}
+        handleClose={handleCloseConfirm}
+        handleConfirmDeleteSubmit={handleConfirmDeleteSubmit}
+      />
+    </>
+  )
+}
+
+export default TableBody

--- a/web/src/app/metalakes/layout.js
+++ b/web/src/app/metalakes/layout.js
@@ -7,28 +7,11 @@
 
 import { Grid, Typography } from '@mui/material'
 import { useSearchParams } from 'next/navigation'
-import { useEffect, useState } from 'react'
 import Metalake from './metalake/MetalakeView.js'
 
 const MetalakesView = ({ children }) => {
   const searchParams = useSearchParams()
-
-  const [, setRouteParams] = useState({})
-
   const metalakeName = searchParams.get('metalake')
-  const catalogName = searchParams.get('catalog')
-  const schemaName = searchParams.get('schema')
-  const tableName = searchParams.get('table')
-
-  useEffect(() => {
-    const takeParams = {
-      metalake: metalakeName,
-      catalog: catalogName,
-      schema: schemaName,
-      table: tableName
-    }
-    setRouteParams(takeParams)
-  }, [metalakeName, catalogName, schemaName, tableName])
 
   return (
     <>

--- a/web/src/app/metalakes/metalake/MetalakePageLeftBar.js
+++ b/web/src/app/metalakes/metalake/MetalakePageLeftBar.js
@@ -6,8 +6,14 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
-import MetalakeTree from './MetalakeTree'
 import { Box } from '@mui/material'
+import dynamic from 'next/dynamic'
+import Loading from '@/app/rootLayout/Loading'
+
+const DynamicMetalakeTree = dynamic(() => import('./MetalakeTree'), {
+  loading: () => <Loading />,
+  ssr: false
+})
 
 const MetalakePageLeftBar = () => {
   const treeWrapper = useRef(null)
@@ -27,7 +33,7 @@ const MetalakePageLeftBar = () => {
       sx={{ p: theme => theme.spacing(2.5, 2.5, 2.5), height: `calc(100% - 1.5rem)` }}
       ref={treeWrapper}
     >
-      <MetalakeTree height={height} />
+      <DynamicMetalakeTree height={height} />
     </Box>
   )
 }

--- a/web/src/app/metalakes/metalake/MetalakeView.js
+++ b/web/src/app/metalakes/metalake/MetalakeView.js
@@ -29,33 +29,34 @@ const MetalakeView = () => {
   const dispatch = useAppDispatch()
   const searchParams = useSearchParams()
 
-  const routeParams = {
-    metalake: searchParams.get('metalake'),
-    catalog: searchParams.get('catalog'),
-    schema: searchParams.get('schema'),
-    table: searchParams.get('table')
-  }
+  const paramsSize = [...searchParams.keys()].length
 
   useEffect(() => {
+    const routeParams = {
+      metalake: searchParams.get('metalake'),
+      catalog: searchParams.get('catalog'),
+      schema: searchParams.get('schema'),
+      table: searchParams.get('table')
+    }
     if ([...searchParams.keys()].length) {
       const { metalake, catalog, schema, table } = routeParams
 
-      if (metalake) {
+      if (paramsSize === 1 && metalake) {
         dispatch(fetchCatalogs({ init: true, page: 'metalakes', metalake }))
         dispatch(getMetalakeDetails({ metalake }))
       }
 
-      if (catalog) {
+      if (paramsSize === 2 && catalog) {
         dispatch(fetchSchemas({ init: true, page: 'catalogs', metalake, catalog }))
         dispatch(getCatalogDetails({ metalake, catalog }))
       }
 
-      if (catalog && schema) {
+      if (paramsSize === 3 && catalog && schema) {
         dispatch(fetchTables({ init: true, page: 'schemas', metalake, catalog, schema }))
         dispatch(getSchemaDetails({ metalake, catalog, schema }))
       }
 
-      if (catalog && schema && table) {
+      if (paramsSize === 4 && catalog && schema && table) {
         dispatch(getTableDetails({ init: true, metalake, catalog, schema, table }))
       }
     }
@@ -73,7 +74,7 @@ const MetalakeView = () => {
     )
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(routeParams)])
+  }, [searchParams])
 
   return (
     <Box className={'metalake-template'} style={{ height: 'calc(100vh - 11rem)' }}>

--- a/web/src/app/metalakes/page.js
+++ b/web/src/app/metalakes/page.js
@@ -5,228 +5,30 @@
 
 'use client'
 
-import { useEffect, useCallback, useState, Fragment } from 'react'
-
-import Link from 'next/link'
-
-import { Box, Grid, Card, Typography, Portal, Tooltip } from '@mui/material'
-import { DataGrid, GridActionsCellItem, GridToolbar } from '@mui/x-data-grid'
-import {
-  VisibilityOutlined as ViewIcon,
-  EditOutlined as EditIcon,
-  DeleteOutlined as DeleteIcon
-} from '@mui/icons-material'
-
-import { useAppDispatch, useAppSelector } from '@/lib/hooks/useStore'
-import { fetchMetalakes, setFilteredMetalakes, deleteMetalake, updateMetalake, resetTree } from '@/lib/store/metalakes'
-
-import { formatToDateTime } from '@/lib/utils/date'
+import { useCallback, useState } from 'react'
+import { Grid, Card } from '@mui/material'
 import TableHeader from './TableHeader'
 import DetailsDrawer from '@/components/DetailsDrawer'
 import CreateMetalakeDialog from './CreateMetalakeDialog'
-import ConfirmDeleteDialog from '@/components/ConfirmDeleteDialog'
+import dynamic from 'next/dynamic'
+import Loading from '@/app/rootLayout/Loading'
 
-function TableToolbar(props) {
-  return (
-    <>
-      <Fragment>
-        <Portal container={() => document.getElementById('filter-panel')}>
-          <Box className={`twc-flex twc-w-full twc-justify-between`}>
-            <GridToolbar {...props} />
-          </Box>
-        </Portal>
-      </Fragment>
-    </>
-  )
-}
+const DynamicTableBody = dynamic(() => import('./TableBody'), {
+  loading: () => <Loading height={'200px'} />,
+  ssr: false
+})
 
 const MetalakeList = () => {
-  const dispatch = useAppDispatch()
-  const store = useAppSelector(state => state.metalakes)
-
   const [value, setValue] = useState('')
-  const [paginationModel, setPaginationModel] = useState({ page: 0, pageSize: 10 })
   const [openDrawer, setOpenDrawer] = useState(false)
   const [drawerData, setDrawerData] = useState()
   const [openDialog, setOpenDialog] = useState(false)
   const [dialogData, setDialogData] = useState({})
   const [dialogType, setDialogType] = useState('create')
-  const [openConfirmDelete, setOpenConfirmDelete] = useState(false)
-  const [confirmCacheData, setConfirmCacheData] = useState(null)
-
-  const handleDeleteMetalake = name => () => {
-    setOpenConfirmDelete(true)
-    setConfirmCacheData(name)
-  }
-
-  const handleConfirmDeleteSubmit = () => {
-    if (confirmCacheData) {
-      dispatch(deleteMetalake(confirmCacheData))
-      setOpenConfirmDelete(false)
-    }
-  }
-
-  const handleCloseConfirm = () => {
-    setOpenConfirmDelete(false)
-    setConfirmCacheData(null)
-  }
-
-  const handleShowEditDialog = data => () => {
-    setDialogType('update')
-    setOpenDialog(true)
-    setDialogData(data)
-  }
 
   const handleFilter = useCallback(val => {
     setValue(val)
   }, [])
-
-  const handleShowDetails = row => () => {
-    setDrawerData(row)
-    setOpenDrawer(true)
-  }
-
-  const handleClickLink = () => {
-    dispatch(resetTree())
-  }
-
-  useEffect(() => {
-    dispatch(fetchMetalakes())
-  }, [dispatch])
-
-  useEffect(() => {
-    const filteredData = store.metalakes
-      .filter(i => i.name.toLowerCase().includes(value.toLowerCase()))
-      .sort((a, b) => {
-        if (a.name.toLowerCase() === value.toLowerCase()) return -1
-        if (b.name.toLowerCase() === value.toLowerCase()) return 1
-
-        return 0
-      })
-
-    dispatch(setFilteredMetalakes(filteredData))
-  }, [dispatch, store.metalakes, value])
-
-  /** @type {import('@mui/x-data-grid').GridColDef[]} */
-  const columns = [
-    {
-      flex: 0.2,
-      minWidth: 230,
-      disableColumnMenu: true,
-      filterable: true,
-      type: 'string',
-      field: 'name',
-      headerName: 'Name',
-      renderCell: ({ row }) => {
-        const { name } = row
-
-        return (
-          <Box sx={{ display: 'flex', alignItems: 'center' }}>
-            <Tooltip title={name} placement='right'>
-              <Typography
-                noWrap
-                component={Link}
-                href={`/metalakes?metalake=${name}`}
-                onClick={() => handleClickLink()}
-                sx={{
-                  fontWeight: 500,
-                  color: 'primary.main',
-                  textDecoration: 'none',
-                  maxWidth: 240,
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  '&:hover': { color: 'primary.main', textDecoration: 'underline' }
-                }}
-              >
-                {name}
-              </Typography>
-            </Tooltip>
-          </Box>
-        )
-      }
-    },
-    {
-      flex: 0.15,
-      minWidth: 150,
-      disableColumnMenu: true,
-      type: 'string',
-      field: 'createdBy',
-      valueGetter: params => `${params.row.audit?.creator}`,
-      headerName: 'Created by',
-      renderCell: ({ row }) => {
-        return (
-          <Typography noWrap sx={{ color: 'text.secondary' }}>
-            {row.audit?.creator}
-          </Typography>
-        )
-      }
-    },
-    {
-      flex: 0.15,
-      minWidth: 150,
-      disableColumnMenu: true,
-      type: 'dateTime',
-      field: 'createdAt',
-      valueGetter: params => new Date(params.row.audit?.createTime),
-      headerName: 'Created at',
-      renderCell: ({ row }) => {
-        return (
-          <Typography title={row.audit?.createTime} noWrap sx={{ color: 'text.secondary' }}>
-            {formatToDateTime(row.audit?.createTime)}
-          </Typography>
-        )
-      }
-    },
-    {
-      flex: 0.1,
-      minWidth: 90,
-      type: 'actions',
-      headerName: 'Actions',
-      field: 'actions',
-      getActions: ({ id, row }) => [
-        <GridActionsCellItem
-          key='details'
-          label='Details'
-          title='Details'
-          data-refer={`view-metalake-${row.name}`}
-          icon={<ViewIcon viewBox='0 0 24 22' />}
-          onClick={handleShowDetails(row)}
-          sx={{
-            '& svg': {
-              fontSize: '24px'
-            }
-          }}
-        />,
-        <GridActionsCellItem
-          key='edit'
-          label='Edit'
-          title='Edit'
-          data-refer={`edit-metalake-${row.name}`}
-          icon={<EditIcon />}
-          onClick={handleShowEditDialog(row)}
-          sx={{
-            '& svg': {
-              fontSize: '24px'
-            }
-          }}
-        />,
-        <GridActionsCellItem
-          key='delete'
-          icon={<DeleteIcon />}
-          label='Delete'
-          title='Delete'
-          data-refer={`delete-metalake-${row.name}`}
-          onClick={handleDeleteMetalake(row.name)}
-          sx={{
-            '& svg': {
-              fontSize: '24px',
-              color: theme => theme.palette.error.light
-            }
-          }}
-        />
-      ]
-    }
-  ]
 
   return (
     <Grid container spacing={6}>
@@ -239,48 +41,18 @@ const MetalakeList = () => {
             setDialogData={setDialogData}
             setDialogType={setDialogType}
           />
-          <DataGrid
-            disableColumnSelector
-            disableDensitySelector
-            slotProps={{
-              toolbar: {
-                printOptions: { disableToolbarButton: true },
-                csvOptions: { disableToolbarButton: true }
-              }
-            }}
-            sx={{
-              '& .MuiDataGrid-virtualScroller': {
-                minHeight: 36
-              },
-              maxHeight: 'calc(100vh - 23.2rem)'
-            }}
-            getRowId={row => row?.name}
-            rows={store.filteredMetalakes}
-            columns={columns}
-            disableRowSelectionOnClick
-            onCellClick={(params, event) => event.stopPropagation()}
-            onRowClick={(params, event) => event.stopPropagation()}
-            pageSizeOptions={[10, 25, 50]}
-            paginationModel={paginationModel}
-            onPaginationModelChange={setPaginationModel}
+          <DynamicTableBody
+            value={value}
+            setOpenDialog={setOpenDialog}
+            setDialogData={setDialogData}
+            setDialogType={setDialogType}
+            setOpenDrawer={setOpenDrawer}
+            setDrawerData={setDrawerData}
           />
           <DetailsDrawer openDrawer={openDrawer} setOpenDrawer={setOpenDrawer} drawerData={drawerData} />
         </Card>
       </Grid>
-      <CreateMetalakeDialog
-        open={openDialog}
-        setOpen={setOpenDialog}
-        updateMetalake={updateMetalake}
-        data={dialogData}
-        type={dialogType}
-      />
-      <ConfirmDeleteDialog
-        open={openConfirmDelete}
-        setOpen={setOpenConfirmDelete}
-        confirmCacheData={confirmCacheData}
-        handleClose={handleCloseConfirm}
-        handleConfirmDeleteSubmit={handleConfirmDeleteSubmit}
-      />
+      <CreateMetalakeDialog open={openDialog} setOpen={setOpenDialog} data={dialogData} type={dialogType} />
     </Grid>
   )
 }

--- a/web/src/app/rootLayout/AppBar.js
+++ b/web/src/app/rootLayout/AppBar.js
@@ -25,7 +25,7 @@ const AppBar = () => {
       <Box className={'layout-navbar twc-w-full'}>
         <Toolbar className={'navbar-content-container twc-mx-auto [@media(min-width:1440px)]:twc-max-w-[1440px]'}>
           <Box className={'app-bar-content twc-w-full twc-flex twc-items-center twc-justify-between'}>
-            <Link href='/' className={'twc-flex twc-items-center twc-no-underline twc-mr-8'}>
+            <Link href='/metalakes' className={'twc-flex twc-items-center twc-no-underline twc-mr-8'}>
               <Image
                 src={process.env.NEXT_PUBLIC_BASE_PATH + '/icons/gravitino.svg'}
                 width={32}

--- a/web/src/app/rootLayout/Layout.js
+++ b/web/src/app/rootLayout/Layout.js
@@ -5,16 +5,20 @@
 
 'use client'
 
-import dynamic from 'next/dynamic'
-
 import { Box, Fab } from '@mui/material'
 
 import Icon from '@/components/Icon'
 
 import AppBar from './AppBar'
 import Footer from './Footer'
-import MainContent from './MainContent'
+import Loading from './Loading'
 import ScrollToTop from './ScrollToTop'
+import dynamic from 'next/dynamic'
+
+const DynamicMainContent = dynamic(() => import('./MainContent'), {
+  loading: () => <Loading />,
+  ssr: false
+})
 
 const Layout = ({ children, scrollToTop }) => {
   return (
@@ -26,7 +30,7 @@ const Layout = ({ children, scrollToTop }) => {
           }
         />
         <AppBar />
-        <MainContent>{children}</MainContent>
+        <DynamicMainContent>{children}</DynamicMainContent>
         <Footer />
         {scrollToTop ? (
           scrollToTop(props)
@@ -43,4 +47,5 @@ const Layout = ({ children, scrollToTop }) => {
 }
 
 // ** use dynamic export instead of export default Layout
-export default dynamic(() => Promise.resolve(Layout), { ssr: false })
+// export default dynamic(() => Promise.resolve(Layout), { ssr: false })
+export default Layout

--- a/web/src/app/rootLayout/Layout.js
+++ b/web/src/app/rootLayout/Layout.js
@@ -46,6 +46,4 @@ const Layout = ({ children, scrollToTop }) => {
   )
 }
 
-// ** use dynamic export instead of export default Layout
-// export default dynamic(() => Promise.resolve(Layout), { ssr: false })
 export default Layout

--- a/web/src/app/rootLayout/Loading.js
+++ b/web/src/app/rootLayout/Loading.js
@@ -7,10 +7,12 @@
 
 import { Box, CircularProgress } from '@mui/material'
 
-const Loading = () => {
+const Loading = ({ height }) => {
+  const heightParams = height ? `twc-h-[${height}]` : 'twc-h-[full]'
+
   return (
-    <Box className={`twc-h-[100vh] twc-flex twc-items-center twc-flex-col twc-justify-center`}>
-      <CircularProgress disableShrink sx={{ mt: 6 }} />
+    <Box className={`${heightParams} twc-grow twc-flex twc-items-center twc-flex-col twc-justify-center`}>
+      <CircularProgress disableShrink sx={{ mt: 6, mb: 6 }} />
     </Box>
   )
 }

--- a/web/src/app/rootLayout/Loading.js
+++ b/web/src/app/rootLayout/Loading.js
@@ -12,7 +12,7 @@ const Loading = ({ height }) => {
 
   return (
     <Box className={`${heightParams} twc-grow twc-flex twc-items-center twc-flex-col twc-justify-center`}>
-      <CircularProgress disableShrink sx={{ mt: 6, mb: 6 }} />
+      <CircularProgress disableShrink sx={{ my: 6 }} />
     </Box>
   )
 }

--- a/web/src/lib/provider/session.js
+++ b/web/src/lib/provider/session.js
@@ -8,6 +8,7 @@
 import { createContext, useEffect, useState, useContext } from 'react'
 
 import { useRouter } from 'next/navigation'
+import { useSearchParams } from 'next/navigation'
 
 import { useAppDispatch } from '@/lib/hooks/useStore'
 import { initialVersion } from '@/lib/store/sys'
@@ -31,6 +32,16 @@ const AuthProvider = ({ children }) => {
 
   const token = (typeof window !== 'undefined' && localStorage.getItem('accessToken')) || null
   const version = (typeof window !== 'undefined' && localStorage.getItem('version')) || null
+  const searchParams = useSearchParams()
+  const paramsSize = [...searchParams.keys()].length
+
+  const goToMetalakeListPage = () => {
+    if (paramsSize) {
+      router.refresh()
+    } else {
+      router.push('/metalakes')
+    }
+  }
 
   const dispatch = useAppDispatch()
 
@@ -38,15 +49,15 @@ const AuthProvider = ({ children }) => {
     const initAuth = async () => {
       const [authConfigsErr, resAuthConfigs] = await to(dispatch(getAuthConfigs()))
       const { authType } = resAuthConfigs.payload
-
+      
       if (authType === 'simple') {
         dispatch(initialVersion())
-        router.push('/metalakes')
+        goToMetalakeListPage()
       } else if (authType === 'oauth') {
         if (token) {
           dispatch(setAuthToken(token))
           dispatch(initialVersion())
-          router.push('/metalakes')
+          goToMetalakeListPage()
         } else {
           router.push('/login')
         }

--- a/web/src/lib/provider/session.js
+++ b/web/src/lib/provider/session.js
@@ -49,7 +49,7 @@ const AuthProvider = ({ children }) => {
     const initAuth = async () => {
       const [authConfigsErr, resAuthConfigs] = await to(dispatch(getAuthConfigs()))
       const { authType } = resAuthConfigs.payload
-      
+
       if (authType === 'simple') {
         dispatch(initialVersion())
         goToMetalakeListPage()


### PR DESCRIPTION
…odule and fix load table data issues

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

1. Displaying a fallback while content is loading for the main content
    Displaying a fallback while content is loading for metalakes list table body module
    Displaying a fallback while content is loading for catalog tree list modul
![UILoading](https://github.com/datastrato/gravitino/assets/9210625/0911c818-ee1b-400d-9b58-3af764a59363)

2. Define metadata icon src path based on the operating environment

3. Fix some issue of inconsistent behaviour
- Smooth display of loaded data
- Preserve search parameters when strongly refreshing a page
![fixbugs](https://github.com/datastrato/gravitino/assets/9210625/dd94fce7-4ee0-4c76-a40e-94e4a87f5ecc)


### Why are the changes needed?

An instant loading state is fallback UI that is shown immediately upon navigation.
You can pre-render loading indicators such as skeletons and spinners.
This helps users understand the app is responding and provides a better user experience.

Fix issue because of the need for consistent behaviour after refactoring

Fix: #2570, #2559

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?
Will run e2e test after PR #2534 merged
