### PR TITLE
[#2501]feat(core): Support specifying package path to load the package from different path

### DIFF
--- a/docs/gravitino-server-config.md
+++ b/docs/gravitino-server-config.md
@@ -24,19 +24,19 @@ The `gravitino.conf` file lists the configuration items in the following table. 
 
 ### Gravitino HTTP Server configuration
 
-| Configuration item                                    | Description                                                                                                                                                                       | Default value                                                                | Required | Since version |
-|-------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|----------|---------------|
+| Configuration item                                    | Description                                                                                                                                                                           | Default value                                                                | Required | Since version |
+|-------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|----------|---------------|
 | `gravitino.server.webserver.host`                     | The host of the Gravitino server.                                                                                                                                                     | `0.0.0.0`                                                                    | No       | 0.1.0         |
-| `gravitino.server.webserver.httpPort`                 | The port on which the Gravitino server listens for incoming connections.                                                                                                          | `8090`                                                                       | No       | 0.1.0         |
+| `gravitino.server.webserver.httpPort`                 | The port on which the Gravitino server listens for incoming connections.                                                                                                              | `8090`                                                                       | No       | 0.1.0         |
 | `gravitino.server.webserver.minThreads`               | The minimum number of threads in the thread pool used by the Jetty webserver. `minThreads` is 8 if the value is less than 8.                                                          | `Math.max(Math.min(Runtime.getRuntime().availableProcessors() * 2, 100), 8)` | No       | 0.2.0         |
 | `gravitino.server.webserver.maxThreads`               | The maximum number of threads in the thread pool used by the Jetty webserver. `maxThreads` is 8 if the value is less than 8, and `maxThreads` must be great or equal to `minThreads`. | `Math.max(Runtime.getRuntime().availableProcessors() * 4, 400)`              | No       | 0.1.0         |
 | `gravitino.server.webserver.threadPoolWorkQueueSize`  | The size of the queue in the thread pool used by the Jetty webserver.                                                                                                                 | `100`                                                                        | No       | 0.1.0         |
-| `gravitino.server.webserver.stopTimeout`              | Time in milliseconds to gracefully shut down the Jetty webserver, for more, please see `org.eclipse.jetty.server.Server#setStopTimeout`.                                           | `30000`                                                                      | No       | 0.2.0         |
-| `gravitino.server.webserver.idleTimeout`              | The timeout in milliseconds of idle connections.                                                                                                                                  | `30000`                                                                      | No       | 0.2.0         |
-| `gravitino.server.webserver.requestHeaderSize`        | Maximum size of HTTP requests.                                                                                                                                                    | `131072`                                                                     | No       | 0.1.0         |
-| `gravitino.server.webserver.responseHeaderSize`       | Maximum size of HTTP responses.                                                                                                                                                   | `131072`                                                                     | No       | 0.1.0         |
-| `gravitino.server.shutdown.timeout`                   | Time in milliseconds to gracefully shut down of the Gravitino webserver.                                                                                                           | `3000`                                                                       | No       | 0.2.0         |
-| `gravitino.server.webserver.customFilters`            | Comma-separated list of filter class names to apply to the API.                                                                                                                  | (none)                                                                       | No       | 0.4.0         |
+| `gravitino.server.webserver.stopTimeout`              | Time in milliseconds to gracefully shut down the Jetty webserver, for more, please see `org.eclipse.jetty.server.Server#setStopTimeout`.                                              | `30000`                                                                      | No       | 0.2.0         |
+| `gravitino.server.webserver.idleTimeout`              | The timeout in milliseconds of idle connections.                                                                                                                                      | `30000`                                                                      | No       | 0.2.0         |
+| `gravitino.server.webserver.requestHeaderSize`        | Maximum size of HTTP requests.                                                                                                                                                        | `131072`                                                                     | No       | 0.1.0         |
+| `gravitino.server.webserver.responseHeaderSize`       | Maximum size of HTTP responses.                                                                                                                                                       | `131072`                                                                     | No       | 0.1.0         |
+| `gravitino.server.shutdown.timeout`                   | Time in milliseconds to gracefully shut down of the Gravitino webserver.                                                                                                              | `3000`                                                                       | No       | 0.2.0         |
+| `gravitino.server.webserver.customFilters`            | Comma-separated list of filter class names to apply to the API.                                                                                                                       | (none)                                                                       | No       | 0.4.0         |
 
 The filter in the customFilters should be a standard javax servlet filter.
 You can also specify filter parameters by setting configuration entries of the form `gravitino.server.webserver.<class name of filter>.param.<param name>=<value>`.
@@ -63,9 +63,9 @@ We strongly recommend that you change the default value of `gravitino.entity.sto
 
 ### Catalog configuration
 
-| Configuration item                           | Description                                                                                                                                                                                       | Default value | Required | Since version |
-|----------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|----------|---------------|
-| `gravitino.catalog.cache.evictionIntervalMs` | The interval in milliseconds to evict the catalog cache; default 3600000ms(1h).                                                                                                                    | `3600000`     | No       | 0.1.0         |
+| Configuration item                           | Description                                                                                                                                                                                         | Default value | Required | Since version |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|----------|---------------|
+| `gravitino.catalog.cache.evictionIntervalMs` | The interval in milliseconds to evict the catalog cache; default 3600000ms(1h).                                                                                                                     | `3600000`     | No       | 0.1.0         |
 | `gravitino.catalog.classloader.isolated`     | Whether to use an isolated classloader for catalog. If `true`, an isolated classloader loads all catalog-related libraries and configurations, not the AppClassLoader. The default value is `true`. | `true`        | No       | 0.1.0         |
 
 ### Auxiliary service configuration
@@ -84,19 +84,31 @@ Refer to [security](security.md) for HTTPS and authentication configurations.
 
 There are three types of catalog properties:
 
-1. **Gravitino-defined properties**: These properties simplify the catalog creation process.
-2. **Properties with the `gravitino.bypass.` prefix**: These properties aren't managed by Gravitino; instead, they bypass the underlying system for advanced usage.
-3. **Other properties**: Stored in Gravitino storage, these properties don't bypass the underlying system.
+1. **Gravitino defined properties**: Gravitino defines these properties as the necessary
+   configurations for the catalog to work properly.
+2. **Properties with the `gravitino.bypass.` prefix**: These properties are not managed by
+   Gravitino and pass directly to the underlying system for advanced usage.
+3. **Other properties**: Gravitino doesn't leverage these properties, just store them. Users
+   can use them for their own purposes.
 
-Catalog properties are either defined in catalog configuration files as default values or specified explicitly when creating a catalog.
+Catalog properties are either defined in catalog configuration files as default values or
+specified as `properties` explicitly when creating a catalog.
 
 :::info
-Explicit specifications take precedence over formal configurations.
-:::
+The catalog properties explicitly specified in the `properties` field take precedence over the
+default values in the catalog configuration file.
 
-:::caution
 These rules only apply to the catalog properties and don't affect the schema or table properties.
 :::
+
+Below is a list of catalog properties that will be used all Gravitino catalogs:
+
+| Configuration item | Description                                                                                                         | Default value | Required | Since version |
+|--------------------|---------------------------------------------------------------------------------------------------------------------|---------------|----------|---------------|
+| `package`          | The path of the catalog package. Gravitino leverages this path to load the related catalog libs and configurations. | (none)        | No       | 0.5.0         |
+
+
+The following table lists the catalog specific properties and their default paths:
 
 | catalog provider    | catalog properties                                                                      | catalog properties configuration file path               |
 |---------------------|-----------------------------------------------------------------------------------------|----------------------------------------------------------|

--- a/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/util/PrintFuncNameExtension.java
+++ b/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/util/PrintFuncNameExtension.java
@@ -15,7 +15,7 @@ public class PrintFuncNameExtension implements BeforeEachCallback, AfterEachCall
 
   @Override
   public void beforeEach(ExtensionContext context) {
-    LOG.info("===== Entry test: {} =====", context.getDisplayName());
+    LOG.info("===== Enter test: {} =====", context.getDisplayName());
   }
 
   @Override

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/client/CatalogIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/client/CatalogIT.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+
+package com.datastrato.gravitino.integration.test.client;
+
+import com.datastrato.gravitino.Catalog;
+import com.datastrato.gravitino.NameIdentifier;
+import com.datastrato.gravitino.client.GravitinoMetalake;
+import com.datastrato.gravitino.integration.test.container.ContainerSuite;
+import com.datastrato.gravitino.integration.test.container.HiveContainer;
+import com.datastrato.gravitino.integration.test.util.AbstractIT;
+import com.datastrato.gravitino.integration.test.util.GravitinoITUtils;
+import com.google.common.collect.Maps;
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Tag("gravitino-docker-it")
+public class CatalogIT extends AbstractIT {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CatalogIT.class);
+
+  private static final ContainerSuite containerSuite = ContainerSuite.getInstance();
+
+  private static final String metalakeName = GravitinoITUtils.genRandomName("catalog_it_metalake");
+
+  private static GravitinoMetalake metalake;
+
+  private static String hmsUri;
+
+  @BeforeAll
+  public static void startUp() {
+    containerSuite.startHiveContainer();
+    hmsUri =
+        String.format(
+            "thrift://%s:%d",
+            containerSuite.getHiveContainer().getContainerIpAddress(),
+            HiveContainer.HIVE_METASTORE_PORT);
+
+    NameIdentifier ident = NameIdentifier.of(metalakeName);
+    Assertions.assertFalse(client.metalakeExists(ident));
+    metalake = client.createMetalake(ident, "metalake comment", Collections.emptyMap());
+    Assertions.assertTrue(client.metalakeExists(ident));
+  }
+
+  @AfterAll
+  public static void tearDown() {
+    client.dropMetalake(NameIdentifier.of(metalakeName));
+
+    if (client != null) {
+      client.close();
+      client = null;
+    }
+
+    try {
+      closer.close();
+    } catch (Exception e) {
+      LOG.error("Exception in closing CloseableGroup", e);
+    }
+  }
+
+  @Test
+  public void testCreateCatalog() {
+    String catalogName = GravitinoITUtils.genRandomName("catalog");
+    NameIdentifier catalogIdent = NameIdentifier.of(metalakeName, catalogName);
+    Assertions.assertFalse(metalake.catalogExists(catalogIdent));
+
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("metastore.uris", hmsUri);
+    Catalog catalog =
+        metalake.createCatalog(
+            catalogIdent, Catalog.Type.RELATIONAL, "hive", "catalog comment", properties);
+    Assertions.assertTrue(metalake.catalogExists(catalogIdent));
+
+    Assertions.assertEquals(catalogName, catalog.name());
+    Assertions.assertEquals(Catalog.Type.RELATIONAL, catalog.type());
+    Assertions.assertEquals("hive", catalog.provider());
+    Assertions.assertEquals("catalog comment", catalog.comment());
+    Assertions.assertTrue(catalog.properties().containsKey("metastore.uris"));
+
+    metalake.dropCatalog(catalogIdent);
+  }
+
+  @Test
+  @DisabledIfSystemProperty(named = "testMode", matches = "embedded")
+  public void testCreateCatalogWithPackage() {
+    String catalogName = GravitinoITUtils.genRandomName("catalog");
+    NameIdentifier catalogIdent = NameIdentifier.of(metalakeName, catalogName);
+    Assertions.assertFalse(metalake.catalogExists(catalogIdent));
+
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("metastore.uris", hmsUri);
+
+    String gravitinoHome = System.getenv("GRAVITINO_HOME");
+    Assertions.assertNotNull(gravitinoHome);
+    String packagePath = String.join(File.separator, gravitinoHome, "catalogs", "hive");
+    properties.put("package", packagePath);
+
+    Catalog catalog =
+        metalake.createCatalog(
+            catalogIdent, Catalog.Type.RELATIONAL, "hive", "catalog comment", properties);
+    Assertions.assertTrue(metalake.catalogExists(catalogIdent));
+
+    Assertions.assertEquals(catalogName, catalog.name());
+    Assertions.assertEquals(Catalog.Type.RELATIONAL, catalog.type());
+    Assertions.assertEquals("hive", catalog.provider());
+    Assertions.assertEquals("catalog comment", catalog.comment());
+    Assertions.assertTrue(catalog.properties().containsKey("package"));
+
+    metalake.dropCatalog(catalogIdent);
+
+    // Test using invalid package path
+    String catalogName1 = GravitinoITUtils.genRandomName("catalog");
+    NameIdentifier catalogIdent1 = NameIdentifier.of(metalakeName, catalogName1);
+    properties.put("package", "/tmp/none_exist_path_to_package");
+    Exception exception = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            metalake.createCatalog(
+                catalogIdent1, Catalog.Type.RELATIONAL, "hive", "catalog comment", properties));
+    Assertions.assertTrue(
+        exception.getMessage().contains("Invalid package path: /tmp/none_exist_path_to_package"));
+  }
+}

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/client/MetalakeIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/client/MetalakeIT.java
@@ -122,7 +122,7 @@ public class MetalakeIT extends AbstractIT {
   }
 
   @Test
-  public void testAlterNonExistantMetalake() {
+  public void testAlterNonExistentMetalake() {
     String newName = RandomNameUtils.genRandomName("newmetaname");
 
     client.createMetalake(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add `package` support for catalog property. This property `package` is used to specify the external path for the catalog package. Users can leverage this to specify the external catalog.

### Why are the changes needed?

With this PR, a user could specify the package path for the catalog. So for a user-built catalog, it can be configured to use by Gravitino without needing to put the package into Gravitino.

Fix: #2501 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Add ITs to verify this.
