### PR TITLE
[#2577 ]fix (trino-connector): Compatible create Page interfaces with the version of Trino-435

### DIFF
--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/system/table/GravitinoSystemTableCatalog.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/system/table/GravitinoSystemTableCatalog.java
@@ -4,21 +4,20 @@
  */
 package com.datastrato.gravitino.trino.connector.system.table;
 
-import static io.trino.spi.block.MapValueBuilder.buildMapValue;
+import static com.datastrato.gravitino.trino.connector.GravitinoErrorCode.GRAVITINO_ILLEGAL_ARGUMENT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 
 import com.datastrato.gravitino.trino.connector.catalog.CatalogConnectorManager;
 import com.datastrato.gravitino.trino.connector.metadata.GravitinoCatalog;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import io.trino.spi.Page;
-import io.trino.spi.block.Block;
+import io.trino.spi.TrinoException;
 import io.trino.spi.block.BlockBuilder;
-import io.trino.spi.block.MapBlockBuilder;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.SchemaTableName;
-import io.trino.spi.type.MapType;
-import io.trino.spi.type.TypeOperators;
 import java.util.List;
 
 /** An implementation of the catalog system table */
@@ -27,15 +26,13 @@ public class GravitinoSystemTableCatalog extends GravitinoSystemTable {
   public static final SchemaTableName TABLE_NAME =
       new SchemaTableName(SYSTEM_TABLE_SCHEMA_NAME, "catalog");
 
-  private static final MapType STRING_MAPTYPE = new MapType(VARCHAR, VARCHAR, new TypeOperators());
-
   private static final ConnectorTableMetadata TABLE_METADATA =
       new ConnectorTableMetadata(
           TABLE_NAME,
           List.of(
               ColumnMetadata.builder().setName("name").setType(VARCHAR).build(),
               ColumnMetadata.builder().setName("provider").setType(VARCHAR).build(),
-              ColumnMetadata.builder().setName("properties").setType(STRING_MAPTYPE).build()));
+              ColumnMetadata.builder().setName("properties").setType(VARCHAR).build()));
 
   private final CatalogConnectorManager catalogConnectorManager;
 
@@ -50,28 +47,25 @@ public class GravitinoSystemTableCatalog extends GravitinoSystemTable {
 
     BlockBuilder nameColumnBuilder = VARCHAR.createBlockBuilder(null, size);
     BlockBuilder providerColumnBuilder = VARCHAR.createBlockBuilder(null, size);
-    MapBlockBuilder propertyColumnBuilder = STRING_MAPTYPE.createBlockBuilder(null, size);
+    BlockBuilder propertyColumnBuilder = VARCHAR.createBlockBuilder(null, size);
 
     for (GravitinoCatalog catalog : catalogs) {
       Preconditions.checkNotNull(catalog, "catalog should not be null");
 
       VARCHAR.writeString(nameColumnBuilder, catalog.getFullName());
       VARCHAR.writeString(providerColumnBuilder, catalog.getProvider());
-      Block mapValue =
-          buildMapValue(
-              STRING_MAPTYPE,
-              catalog.getProperties().size(),
-              (keyBuilder, valueBuilder) ->
-                  catalog
-                      .getProperties()
-                      .forEach(
-                          (key, value) -> {
-                            VARCHAR.writeString(keyBuilder, key);
-                            VARCHAR.writeString(valueBuilder, value);
-                          }));
-      STRING_MAPTYPE.writeObject(propertyColumnBuilder, mapValue);
+      try {
+        VARCHAR.writeString(
+            propertyColumnBuilder, new ObjectMapper().writeValueAsString(catalog.getProperties()));
+      } catch (JsonProcessingException e) {
+        throw new TrinoException(GRAVITINO_ILLEGAL_ARGUMENT, "Invalid property format", e); //
+      }
     }
-    return new Page(size, nameColumnBuilder, providerColumnBuilder, propertyColumnBuilder);
+    return new Page(
+        size,
+        nameColumnBuilder.build(),
+        providerColumnBuilder.build(),
+        propertyColumnBuilder.build());
   }
 
   @Override

--- a/trino-connector/src/test/java/com/datastrato/gravitino/trino/connector/TestGravitinoConnector.java
+++ b/trino-connector/src/test/java/com/datastrato/gravitino/trino/connector/TestGravitinoConnector.java
@@ -20,7 +20,6 @@ import io.trino.testing.QueryRunner;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
@@ -271,7 +270,7 @@ public class TestGravitinoConnector extends AbstractTestQueryFramework {
     MaterializedRow row = expectedRows.get(0);
     assertEquals(row.getField(0), "test.memory");
     assertEquals(row.getField(1), "memory");
-    assertEquals(row.getField(2), Map.of("max_ttl", "10"));
+    assertEquals(row.getField(2), "{\"max_ttl\":\"10\"}");
   }
 
   private TableName createTestTable(String fullTableName) throws Exception {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Trino-435 changed the SPI interfaces of the BlockBuilder and Page classes. We have switched to using the unmodified API..

### Why are the changes needed?

Fix: #2577

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

UT, Manunally testing in Trino-435
