### PR TITLE
[#2608] improvement(IT): Splitting WEB-E2E IT into an alone Github Action

### DIFF
--- a/.github/workflows/backend-integration-test.yml
+++ b/.github/workflows/backend-integration-test.yml
@@ -1,0 +1,98 @@
+name: Backend Integration Test
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches: [ "main", "branch-*" ]
+  pull_request:
+    branches: [ "main", "branch-*" ]
+
+concurrency:
+  group: ${{ github.worklfow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_requests' }}
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            source_changes:
+              - .github/**
+              - api/**
+              - bin/**
+              - catalogs/**
+              - clients/**
+              - common/**
+              - conf/**
+              - core/**
+              - dev/**
+              - gradle/**
+              - integration-test/**
+              - meta/**
+              - server/**
+              - server-common/**
+              - spark-connector/**
+              - trino-connector/**
+              - web/**
+              - docs/open-api/**
+              - build.gradle.kts
+              - gradle.properties
+              - gradlew
+              - setting.gradle.kts
+    outputs:
+      source_changes: ${{ steps.filter.outputs.source_changes }}
+
+  # Integration test for AMD64 architecture
+  test-amd64-arch:
+    needs: changes
+    if: needs.changes.outputs.source_changes == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        architecture: [linux/amd64]
+        java-version: [ 8, 11, 17 ]
+        test-mode: [ embedded, deploy ]
+    env:
+      PLATFORM: ${{ matrix.architecture }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: 'temurin'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Package Gravitino
+        run: |
+          ./gradlew build -x test -PjdkVersion=${{ matrix.java-version }}
+          ./gradlew compileDistribution -x test -PjdkVersion=${{ matrix.java-version }}
+
+      - name: Setup debug Github Action
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'debug action') }}
+        uses: csexton/debugger-action@master
+
+      - name: Backend Integration Test
+        id: integrationTest
+        run: |
+          ./gradlew test --rerun-tasks -PskipTests -PtestMode=${{ matrix.test-mode }} -PjdkVersion=${{ matrix.java-version }} -PskipWebITs
+
+      - name: Upload integrate tests reports
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() && steps.integrationTest.outcome == 'failure' }}
+        with:
+          name: integrate test reports
+          path: |
+            build/reports
+            integration-test/build/integration-test.log
+            distribution/package/logs/gravitino-server.out
+            distribution/package/logs/gravitino-server.log
+            catalogs/**/*.log

--- a/.github/workflows/frontend-integration-test.yml
+++ b/.github/workflows/frontend-integration-test.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Frontend Integration Test
         id: integrationTest
         run: |
-          ./gradlew test --rerun-tasks -PskipTests -PtestMode=${{ matrix.test-mode }} -PjdkVersion=${{ matrix.java-version }} :integration-test:test --tests "com.datastrato.gravitino.integration.test.web.ui.**"
+          ./gradlew --rerun-tasks -PskipTests -PtestMode=${{ matrix.test-mode }} -PjdkVersion=${{ matrix.java-version }} :integration-test:test --tests "com.datastrato.gravitino.integration.test.web.ui.**"
 
       - name: Upload integrate tests reports
         uses: actions/upload-artifact@v3

--- a/.github/workflows/frontend-integration-test.yml
+++ b/.github/workflows/frontend-integration-test.yml
@@ -1,4 +1,4 @@
-name: Integration Test
+name: Frontend Integration Test
 
 # Controls when the workflow will run
 on:
@@ -56,10 +56,9 @@ jobs:
     strategy:
       matrix:
         architecture: [linux/amd64]
-        java-version: [ 8, 11, 17 ]
+        java-version: [ 8 ]
         test-mode: [ embedded, deploy ]
     env:
-      DOCKER_RUN_NAME: hive-amd64
       PLATFORM: ${{ matrix.architecture }}
     steps:
       - uses: actions/checkout@v3
@@ -81,10 +80,10 @@ jobs:
         if: ${{ contains(github.event.pull_request.labels.*.name, 'debug action') }}
         uses: csexton/debugger-action@master
 
-      - name: Integration Test
+      - name: Frontend Integration Test
         id: integrationTest
         run: |
-          ./gradlew test --rerun-tasks -PskipTests -PtestMode=${{ matrix.test-mode }} -PjdkVersion=${{ matrix.java-version }}
+          ./gradlew test --rerun-tasks -PskipTests -PtestMode=${{ matrix.test-mode }} -PjdkVersion=${{ matrix.java-version }} :integration-test:test --tests "com.datastrato.gravitino.integration.test.web.ui.**"
 
       - name: Upload integrate tests reports
         uses: actions/upload-artifact@v3

--- a/.github/workflows/frontend-integration-test.yml
+++ b/.github/workflows/frontend-integration-test.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         architecture: [linux/amd64]
-        java-version: [ 8 ]
+        java-version: [ 8, 11, 17 ]
         test-mode: [ embedded, deploy ]
     env:
       PLATFORM: ${{ matrix.architecture }}

--- a/docs/how-to-test.md
+++ b/docs/how-to-test.md
@@ -69,8 +69,9 @@ Deploy the Gravitino server locally to run the integration tests. Follow these s
 ## Skip tests
 
 * You can skip unit tests by using the `./gradlew build -PskipTests` command.
-* You can skip integration tests by using the `./gradlew build -PskipITs` command.
-* You can skip both unit tests and integration tests by using the `./gradlew build -x test` or `./gradlew build -PskipTests -PskipITs` commands.
+* You can skip backend and web frontend integration tests by using the `./gradlew build -PskipITs` command.
+* You can only skip web frontend integration tests by using the `./gradlew build -PskipWebITs` command.
+* You can skip both unit tests and all integration tests by using the `./gradlew build -x test` or `./gradlew build -PskipTests -PskipITs` commands.
 
 ## Docker test environment
 

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -135,9 +135,14 @@ dependencies {
 
 tasks.test {
   val skipITs = project.hasProperty("skipITs")
+  val skipWebITs = project.hasProperty("skipWebITs")
   if (skipITs) {
     exclude("**/integration/test/**")
   } else {
+    if (skipWebITs) {
+      exclude("**/integration/test/web/ui/**")
+    }
+
     dependsOn(":trino-connector:jar")
     dependsOn(":catalogs:catalog-lakehouse-iceberg:jar", ":catalogs:catalog-lakehouse-iceberg:runtimeJars")
     dependsOn(":catalogs:catalog-jdbc-mysql:jar", ":catalogs:catalog-jdbc-mysql:runtimeJars")
@@ -191,7 +196,6 @@ tasks.clean {
 
 tasks.register<JavaExec>("TrinoTest") {
   classpath = sourceSets["test"].runtimeClasspath
-  systemProperty("gravitino.log.path", buildDir.path + "/integration-test.log")
   mainClass.set("com.datastrato.gravitino.integration.test.trino.TrinoQueryTestTool")
 
   if (JavaVersion.current() > JavaVersion.VERSION_1_8) {

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/MetalakePageTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/MetalakePageTest.java
@@ -10,12 +10,12 @@ import org.junit.jupiter.api.Assertions;
 
 // TODO: Disable Test before fixed
 
-// import org.junit.jupiter.api.MethodOrderer;
-// import org.junit.jupiter.api.Order;
-// import org.junit.jupiter.api.Test;
-// import org.junit.jupiter.api.TestMethodOrder;
+ import org.junit.jupiter.api.MethodOrderer;
+ import org.junit.jupiter.api.Order;
+ import org.junit.jupiter.api.Test;
+ import org.junit.jupiter.api.TestMethodOrder;
 
-// @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+ @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class MetalakePageTest extends AbstractWebIT {
   MetalakePage metalakePage = new MetalakePage();
 
@@ -31,8 +31,8 @@ public class MetalakePageTest extends AbstractWebIT {
     metalakePage.submitHandleMetalakeBtn.click();
   }
 
-  //  @Test
-  //  @Order(0)
+  @Test
+  @Order(0)
   public void homePage() {
     String title = driver.getTitle();
     Assertions.assertEquals("Gravitino", title);

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/MetalakePageTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/MetalakePageTest.java
@@ -7,15 +7,12 @@ package com.datastrato.gravitino.integration.test.web.ui;
 import com.datastrato.gravitino.integration.test.web.ui.Pages.MetalakePage;
 import com.datastrato.gravitino.integration.test.web.ui.utils.AbstractWebIT;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
-// TODO: Disable Test before fixed
-
- import org.junit.jupiter.api.MethodOrderer;
- import org.junit.jupiter.api.Order;
- import org.junit.jupiter.api.Test;
- import org.junit.jupiter.api.TestMethodOrder;
-
- @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class MetalakePageTest extends AbstractWebIT {
   MetalakePage metalakePage = new MetalakePage();
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Add Gradle compile parameter `skipWebITs`
2. Splitting integration-test Github Action

### Why are the changes needed?

Run WEB E2E integration test in alone Github Action.

Fix: #2608 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

CI passed
