### PR TITLE
[#2468] feat(kafka-catalog): support topic operations for Kafka catalog

### DIFF
--- a/catalogs/catalog-messaging-kafka/build.gradle.kts
+++ b/catalogs/catalog-messaging-kafka/build.gradle.kts
@@ -19,11 +19,11 @@ dependencies {
   implementation(libs.kafka.clients)
   implementation(libs.slf4j.api)
 
-  testImplementation(libs.junit.jupiter.api)
-  testImplementation(libs.mockito.core)
   testImplementation(libs.commons.io)
-  testImplementation(libs.kafka)
   testImplementation(libs.curator.test)
+  testImplementation(libs.junit.jupiter.api)
+  testImplementation(libs.kafka)
+  testImplementation(libs.mockito.core)
 
   testRuntimeOnly(libs.junit.jupiter.engine)
 }

--- a/catalogs/catalog-messaging-kafka/build.gradle.kts
+++ b/catalogs/catalog-messaging-kafka/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.mockito.core)
   testImplementation(libs.commons.io)
-  testImplementation(libs.kafka.get2().get12())
+  testImplementation(libs.kafka)
   testImplementation(libs.curator.test)
 
   testRuntimeOnly(libs.junit.jupiter.engine)

--- a/catalogs/catalog-messaging-kafka/build.gradle.kts
+++ b/catalogs/catalog-messaging-kafka/build.gradle.kts
@@ -16,10 +16,14 @@ dependencies {
   implementation(project(":common"))
 
   implementation(libs.guava)
+  implementation(libs.kafka.clients)
+  implementation(libs.slf4j.api)
 
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.mockito.core)
   testImplementation(libs.commons.io)
+  testImplementation(libs.kafka.get2().get12())
+  testImplementation(libs.curator.test)
 
   testRuntimeOnly(libs.junit.jupiter.engine)
 }

--- a/catalogs/catalog-messaging-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
+++ b/catalogs/catalog-messaging-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
@@ -306,7 +306,7 @@ public class KafkaCatalogOperations implements CatalogOperations, SupportsSchema
       return true;
     } catch (ExecutionException e) {
       if (e.getCause() instanceof UnknownTopicOrPartitionException) {
-        throw new NoSuchTopicException(e, "Topic %s does not exist", ident);
+        return false;
       } else {
         throw new RuntimeException("Failed to drop topic " + ident.name() + " from Kafka", e);
       }

--- a/catalogs/catalog-messaging-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
+++ b/catalogs/catalog-messaging-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
@@ -82,6 +82,7 @@ public class KafkaCatalogOperations implements CatalogOperations, SupportsSchema
       new KafkaSchemaPropertiesMetadata();
   private static final KafkaTopicPropertiesMetadata TOPIC_PROPERTIES_METADATA =
       new KafkaTopicPropertiesMetadata();
+  @VisibleForTesting static final String CLIENT_ID_TEMPLATE = "%s-%s.%s";
 
   private final EntityStore store;
   private final IdGenerator idGenerator;
@@ -127,7 +128,7 @@ public class KafkaCatalogOperations implements CatalogOperations, SupportsSchema
     // use gravitino catalog id as the admin client id
     adminClientConfig.put(
         AdminClientConfig.CLIENT_ID_CONFIG,
-        config.get(ID_KEY) + "-" + info.namespace() + "." + info.name());
+        String.format(CLIENT_ID_TEMPLATE, config.get(ID_KEY), info.namespace(), info.name()));
 
     createDefaultSchema();
     adminClient = AdminClient.create(adminClientConfig);

--- a/catalogs/catalog-messaging-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
+++ b/catalogs/catalog-messaging-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
@@ -125,7 +125,9 @@ public class KafkaCatalogOperations implements CatalogOperations, SupportsSchema
     adminClientConfig.put(
         AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, config.get(BOOTSTRAP_SERVERS));
     // use gravitino catalog id as the admin client id
-    adminClientConfig.put(AdminClientConfig.CLIENT_ID_CONFIG, config.get(ID_KEY));
+    adminClientConfig.put(
+        AdminClientConfig.CLIENT_ID_CONFIG,
+        config.get(ID_KEY) + "-" + info.namespace() + "." + info.name());
 
     createDefaultSchema();
     adminClient = AdminClient.create(adminClientConfig);

--- a/catalogs/catalog-messaging-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
+++ b/catalogs/catalog-messaging-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
@@ -394,7 +394,10 @@ public class KafkaCatalogOperations implements CatalogOperations, SupportsSchema
 
   @Override
   public void close() throws IOException {
-    adminClient.close();
+    if (adminClient != null) {
+      adminClient.close();
+      adminClient = null;
+    }
   }
 
   @Override

--- a/catalogs/catalog-messaging-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
+++ b/catalogs/catalog-messaging-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
@@ -172,7 +172,7 @@ public class KafkaCatalogOperations implements CatalogOperations, SupportsSchema
       properties.put(PARTITION_COUNT, String.valueOf(partitions));
       properties.put(REPLICATION_FACTOR, String.valueOf(replicationFactor));
     } catch (ExecutionException e) {
-      if (e.getCause() instanceof org.apache.kafka.common.errors.UnknownTopicOrPartitionException) {
+      if (e.getCause() instanceof UnknownTopicOrPartitionException) {
         throw new NoSuchTopicException(e, "Topic %s does not exist", ident);
       } else {
         throw new RuntimeException("Failed to load topic " + ident.name() + " from Kafka", e);
@@ -305,7 +305,7 @@ public class KafkaCatalogOperations implements CatalogOperations, SupportsSchema
       adminClient.deleteTopics(Collections.singleton(ident.name())).all().get();
       return true;
     } catch (ExecutionException e) {
-      if (e.getCause() instanceof org.apache.kafka.common.errors.UnknownTopicOrPartitionException) {
+      if (e.getCause() instanceof UnknownTopicOrPartitionException) {
         throw new NoSuchTopicException(e, "Topic %s does not exist", ident);
       } else {
         throw new RuntimeException("Failed to drop topic " + ident.name() + " from Kafka", e);

--- a/catalogs/catalog-messaging-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaTopic.java
+++ b/catalogs/catalog-messaging-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaTopic.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.catalog.kafka;
+
+import static com.datastrato.gravitino.catalog.kafka.KafkaTopicPropertiesMetadata.PARTITION_COUNT;
+
+import com.datastrato.gravitino.catalog.messaging.BaseTopic;
+import java.util.Optional;
+import org.apache.kafka.clients.admin.NewTopic;
+
+public class KafkaTopic extends BaseTopic {
+
+  public NewTopic toKafkaTopic(KafkaTopicPropertiesMetadata propertiesMetadata) {
+    Optional<Integer> partitionCount =
+        Optional.ofNullable((int) propertiesMetadata.getOrDefault(properties(), PARTITION_COUNT));
+    Optional<Short> replicationFactor =
+        Optional.ofNullable(
+            (short)
+                propertiesMetadata.getOrDefault(
+                    properties(), KafkaTopicPropertiesMetadata.REPLICATION_FACTOR));
+    return new NewTopic(name, partitionCount, replicationFactor);
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder extends BaseTopicBuilder<Builder, KafkaTopic> {
+
+    @Override
+    protected KafkaTopic internalBuild() {
+      KafkaTopic topic = new KafkaTopic();
+      topic.name = name;
+      topic.comment = comment;
+      topic.properties = properties;
+      topic.auditInfo = auditInfo;
+      return topic;
+    }
+  }
+}

--- a/catalogs/catalog-messaging-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaTopic.java
+++ b/catalogs/catalog-messaging-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaTopic.java
@@ -6,7 +6,7 @@ package com.datastrato.gravitino.catalog.kafka;
 
 import static com.datastrato.gravitino.catalog.kafka.KafkaTopicPropertiesMetadata.PARTITION_COUNT;
 
-import com.datastrato.gravitino.catalog.messaging.BaseTopic;
+import com.datastrato.gravitino.connector.BaseTopic;
 import java.util.Optional;
 import org.apache.kafka.clients.admin.NewTopic;
 

--- a/catalogs/catalog-messaging-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaTopicPropertiesMetadata.java
+++ b/catalogs/catalog-messaging-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaTopicPropertiesMetadata.java
@@ -6,12 +6,41 @@ package com.datastrato.gravitino.catalog.kafka;
 
 import com.datastrato.gravitino.connector.BasePropertiesMetadata;
 import com.datastrato.gravitino.connector.PropertyEntry;
-import java.util.Collections;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import java.util.List;
 import java.util.Map;
 
 public class KafkaTopicPropertiesMetadata extends BasePropertiesMetadata {
+  public static final String PARTITION_COUNT = "partition-count";
+  public static final String REPLICATION_FACTOR = "replication-factor";
+
+  private static final Map<String, PropertyEntry<?>> PROPERTIES_METADATA;
+
+  static {
+    List<PropertyEntry<?>> propertyEntries =
+        ImmutableList.of(
+            PropertyEntry.integerOptionalPropertyEntry(
+                PARTITION_COUNT,
+                "The number of partitions for the topic, if not specified, "
+                    + "will use the num.partition property in the broker",
+                true /* immutable */,
+                null /* default value */,
+                false /* hidden */),
+            // TODO: make REPLICATION_FACTOR mutable if needed
+            PropertyEntry.shortOptionalPropertyEntry(
+                REPLICATION_FACTOR,
+                "The number of replications for the topic, if not specified, "
+                    + "will use the default.replication.factor property in the broker",
+                true /* immutable */,
+                null /* default value */,
+                false /* hidden */));
+
+    PROPERTIES_METADATA = Maps.uniqueIndex(propertyEntries, PropertyEntry::getName);
+  }
+
   @Override
   protected Map<String, PropertyEntry<?>> specificPropertyEntries() {
-    return Collections.emptyMap();
+    return PROPERTIES_METADATA;
   }
 }

--- a/catalogs/catalog-messaging-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaTopicPropertiesMetadata.java
+++ b/catalogs/catalog-messaging-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaTopicPropertiesMetadata.java
@@ -24,7 +24,7 @@ public class KafkaTopicPropertiesMetadata extends BasePropertiesMetadata {
                 PARTITION_COUNT,
                 "The number of partitions for the topic, if not specified, "
                     + "will use the num.partition property in the broker",
-                true /* immutable */,
+                false /* immutable */,
                 null /* default value */,
                 false /* hidden */),
             // TODO: make REPLICATION_FACTOR mutable if needed

--- a/catalogs/catalog-messaging-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/TestKafkaCatalogOperations.java
+++ b/catalogs/catalog-messaging-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/TestKafkaCatalogOperations.java
@@ -12,6 +12,7 @@ import static com.datastrato.gravitino.Configs.ENTRY_KV_ROCKSDB_BACKEND_PATH;
 import static com.datastrato.gravitino.Configs.KV_DELETE_AFTER_TIME;
 import static com.datastrato.gravitino.Configs.STORE_TRANSACTION_MAX_SKEW_TIME;
 import static com.datastrato.gravitino.StringIdentifier.ID_KEY;
+import static com.datastrato.gravitino.catalog.kafka.KafkaCatalogOperations.CLIENT_ID_TEMPLATE;
 import static com.datastrato.gravitino.catalog.kafka.KafkaCatalogPropertiesMetadata.BOOTSTRAP_SERVERS;
 import static com.datastrato.gravitino.catalog.kafka.KafkaTopicPropertiesMetadata.PARTITION_COUNT;
 import static com.datastrato.gravitino.catalog.kafka.KafkaTopicPropertiesMetadata.REPLICATION_FACTOR;
@@ -130,7 +131,12 @@ public class TestKafkaCatalogOperations extends KafkaClusterEmbedded {
         MOCK_CATALOG_PROPERTIES.get(BOOTSTRAP_SERVERS),
         ops.adminClientConfig.get(BOOTSTRAP_SERVERS));
     Assertions.assertEquals(
-        MOCK_CATALOG_PROPERTIES.get(ID_KEY), ops.adminClientConfig.get("client.id"));
+        String.format(
+            CLIENT_ID_TEMPLATE,
+            MOCK_CATALOG_PROPERTIES.get(ID_KEY),
+            catalogEntity.namespace(),
+            catalogName),
+        ops.adminClientConfig.get("client.id"));
   }
 
   @Test

--- a/catalogs/catalog-messaging-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/TestKafkaCatalogOperations.java
+++ b/catalogs/catalog-messaging-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/TestKafkaCatalogOperations.java
@@ -365,12 +365,7 @@ public class TestKafkaCatalogOperations extends KafkaClusterEmbedded {
         "Topic metalake.test_kafka_catalog.default.test_drop_topic does not exist",
         exception.getMessage());
 
-    exception =
-        Assertions.assertThrows(
-            NoSuchTopicException.class, () -> kafkaCatalogOperations.dropTopic(ident));
-    Assertions.assertEquals(
-        "Topic metalake.test_kafka_catalog.default.test_drop_topic does not exist",
-        exception.getMessage());
+    Assertions.assertFalse(kafkaCatalogOperations.dropTopic(ident));
   }
 
   @Test

--- a/catalogs/catalog-messaging-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/TestKafkaCatalogOperations.java
+++ b/catalogs/catalog-messaging-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/TestKafkaCatalogOperations.java
@@ -13,6 +13,8 @@ import static com.datastrato.gravitino.Configs.KV_DELETE_AFTER_TIME;
 import static com.datastrato.gravitino.Configs.STORE_TRANSACTION_MAX_SKEW_TIME;
 import static com.datastrato.gravitino.StringIdentifier.ID_KEY;
 import static com.datastrato.gravitino.catalog.kafka.KafkaCatalogPropertiesMetadata.BOOTSTRAP_SERVERS;
+import static com.datastrato.gravitino.catalog.kafka.KafkaTopicPropertiesMetadata.PARTITION_COUNT;
+import static com.datastrato.gravitino.catalog.kafka.KafkaTopicPropertiesMetadata.REPLICATION_FACTOR;
 
 import com.datastrato.gravitino.Config;
 import com.datastrato.gravitino.Configs;
@@ -21,7 +23,13 @@ import com.datastrato.gravitino.EntityStore;
 import com.datastrato.gravitino.EntityStoreFactory;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
+import com.datastrato.gravitino.catalog.kafka.embeddedKafka.KafkaClusterEmbedded;
 import com.datastrato.gravitino.connector.BasePropertiesMetadata;
+import com.datastrato.gravitino.exceptions.NoSuchSchemaException;
+import com.datastrato.gravitino.exceptions.NoSuchTopicException;
+import com.datastrato.gravitino.exceptions.TopicAlreadyExistsException;
+import com.datastrato.gravitino.messaging.Topic;
+import com.datastrato.gravitino.messaging.TopicChange;
 import com.datastrato.gravitino.meta.AuditInfo;
 import com.datastrato.gravitino.meta.CatalogEntity;
 import com.datastrato.gravitino.rel.Schema;
@@ -32,7 +40,6 @@ import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Map;
-import java.util.UUID;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -40,15 +47,15 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public class TestKafkaCatalogOperations {
+public class TestKafkaCatalogOperations extends KafkaClusterEmbedded {
 
   private static final String ROCKS_DB_STORE_PATH =
-      "/tmp/gravitino_test_entityStore_" + UUID.randomUUID().toString().replace("-", "");
+      "/tmp/gravitino_test_entityStore_" + genRandomString();
   private static final String METALAKE_NAME = "metalake";
   private static final String CATALOG_NAME = "test_kafka_catalog";
+  private static final String DEFAULT_SCHEMA_NAME = "default";
   private static final Map<String, String> MOCK_CATALOG_PROPERTIES =
-      ImmutableMap.of(
-          BOOTSTRAP_SERVERS, "localhost:9092", ID_KEY, "gravitino.v1.uid33220758755757000");
+      ImmutableMap.of(BOOTSTRAP_SERVERS, brokerList(), ID_KEY, "gravitino.v1.uid33220758755757000");
   private static EntityStore store;
   private static IdGenerator idGenerator;
   private static CatalogEntity kafkaCatalogEntity;
@@ -90,8 +97,10 @@ public class TestKafkaCatalogOperations {
 
   @AfterAll
   public static void tearDown() throws IOException {
-    store.close();
-    FileUtils.deleteDirectory(FileUtils.getFile(ROCKS_DB_STORE_PATH));
+    if (store != null) {
+      store.close();
+      FileUtils.deleteDirectory(FileUtils.getFile(ROCKS_DB_STORE_PATH));
+    }
   }
 
   @Test
@@ -143,13 +152,13 @@ public class TestKafkaCatalogOperations {
     ops.initialize(MOCK_CATALOG_PROPERTIES, catalogEntity.toCatalogInfo());
 
     Assertions.assertNotNull(ops.defaultSchemaIdent);
-    Assertions.assertEquals("default", ops.defaultSchemaIdent.name());
+    Assertions.assertEquals(DEFAULT_SCHEMA_NAME, ops.defaultSchemaIdent.name());
     Assertions.assertEquals(
         METALAKE_NAME + "." + catalogName, ops.defaultSchemaIdent.namespace().toString());
 
     Assertions.assertTrue(ops.schemaExists(ops.defaultSchemaIdent));
     Schema schema = ops.loadSchema(ops.defaultSchemaIdent);
-    Assertions.assertEquals("default", schema.name());
+    Assertions.assertEquals(DEFAULT_SCHEMA_NAME, schema.name());
   }
 
   @Test
@@ -167,10 +176,10 @@ public class TestKafkaCatalogOperations {
 
   @Test
   public void testLoadSchema() {
-    NameIdentifier ident = NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, "default");
+    NameIdentifier ident = NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, DEFAULT_SCHEMA_NAME);
     Schema schema = kafkaCatalogOperations.loadSchema(ident);
 
-    Assertions.assertEquals("default", schema.name());
+    Assertions.assertEquals(DEFAULT_SCHEMA_NAME, schema.name());
     Assertions.assertEquals(
         "The default schema of Kafka catalog including all topics", schema.comment());
     Assertions.assertEquals(2, schema.properties().size());
@@ -186,7 +195,7 @@ public class TestKafkaCatalogOperations {
             IllegalArgumentException.class,
             () ->
                 kafkaCatalogOperations.alterSchema(
-                    NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, "default"),
+                    NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, DEFAULT_SCHEMA_NAME),
                     SchemaChange.removeProperty("key1")));
     Assertions.assertEquals("Cannot alter the default schema", exception.getMessage());
 
@@ -208,7 +217,7 @@ public class TestKafkaCatalogOperations {
             IllegalArgumentException.class,
             () ->
                 kafkaCatalogOperations.dropSchema(
-                    NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, "default"), true));
+                    NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, DEFAULT_SCHEMA_NAME), true));
     Assertions.assertEquals("Cannot drop the default schema", exception.getMessage());
 
     NameIdentifier ident = NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, "test_schema");
@@ -218,5 +227,180 @@ public class TestKafkaCatalogOperations {
             () -> kafkaCatalogOperations.dropSchema(ident, true));
     Assertions.assertEquals(
         "Kafka catalog does not support schema deletion", exception.getMessage());
+  }
+
+  @Test
+  public void testCreateTopic() {
+    NameIdentifier ident =
+        NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, DEFAULT_SCHEMA_NAME, "test_create_topic");
+    String comment = "test comment";
+    Map<String, String> properties = ImmutableMap.of(PARTITION_COUNT, "3", REPLICATION_FACTOR, "1");
+    Topic createdTopic = kafkaCatalogOperations.createTopic(ident, comment, null, properties);
+    Assertions.assertNotNull(createdTopic);
+    Assertions.assertEquals(ident.name(), createdTopic.name());
+    Assertions.assertEquals("3", createdTopic.properties().get(PARTITION_COUNT));
+    Assertions.assertEquals("1", createdTopic.properties().get(REPLICATION_FACTOR));
+  }
+
+  @Test
+  public void testCreateTopicException() {
+    Map<String, String> properties = ImmutableMap.of(PARTITION_COUNT, "3", REPLICATION_FACTOR, "1");
+
+    Exception exception =
+        Assertions.assertThrows(
+            TopicAlreadyExistsException.class,
+            () ->
+                kafkaCatalogOperations.createTopic(
+                    NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, DEFAULT_SCHEMA_NAME, TOPIC_1),
+                    null,
+                    null,
+                    properties));
+    Assertions.assertEquals(
+        "Topic metalake.test_kafka_catalog.default.kafka-test-topic-1 already exists",
+        exception.getMessage());
+
+    exception =
+        Assertions.assertThrows(
+            NoSuchSchemaException.class,
+            () ->
+                kafkaCatalogOperations.createTopic(
+                    NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, "test_schema", "error_topic"),
+                    null,
+                    null,
+                    properties));
+    Assertions.assertEquals(
+        "Schema metalake.test_kafka_catalog.test_schema does not exist", exception.getMessage());
+
+    Map<String, String> wrongProperties =
+        ImmutableMap.of(PARTITION_COUNT, "3", REPLICATION_FACTOR, "3");
+    exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                kafkaCatalogOperations.createTopic(
+                    NameIdentifier.of(
+                        METALAKE_NAME, CATALOG_NAME, DEFAULT_SCHEMA_NAME, "error_topic"),
+                    null,
+                    null,
+                    wrongProperties));
+    Assertions.assertTrue(
+        exception.getMessage().contains("Invalid replication factor for topic"),
+        exception.getMessage());
+  }
+
+  @Test
+  public void testLoadTopic() {
+    Topic topic =
+        kafkaCatalogOperations.loadTopic(
+            NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, DEFAULT_SCHEMA_NAME, TOPIC_1));
+    Assertions.assertNotNull(topic);
+    Assertions.assertEquals(TOPIC_1, topic.name());
+    Assertions.assertEquals("1", topic.properties().get(PARTITION_COUNT));
+    Assertions.assertEquals("1", topic.properties().get(REPLICATION_FACTOR));
+  }
+
+  @Test
+  public void testLoadTopicException() {
+    Exception exception =
+        Assertions.assertThrows(
+            NoSuchTopicException.class,
+            () ->
+                kafkaCatalogOperations.loadTopic(
+                    NameIdentifier.of(
+                        METALAKE_NAME, CATALOG_NAME, DEFAULT_SCHEMA_NAME, "error_topic")));
+    Assertions.assertEquals(
+        "Topic metalake.test_kafka_catalog.default.error_topic does not exist",
+        exception.getMessage());
+  }
+
+  @Test
+  public void testListTopics() {
+    NameIdentifier[] topics =
+        kafkaCatalogOperations.listTopics(
+            Namespace.of(METALAKE_NAME, CATALOG_NAME, DEFAULT_SCHEMA_NAME));
+    Assertions.assertTrue(topics.length > 0);
+
+    Exception exception =
+        Assertions.assertThrows(
+            NoSuchSchemaException.class,
+            () ->
+                kafkaCatalogOperations.listTopics(
+                    Namespace.of(METALAKE_NAME, CATALOG_NAME, "error_schema")));
+    Assertions.assertEquals(
+        "Schema metalake.test_kafka_catalog.error_schema does not exist", exception.getMessage());
+  }
+
+  @Test
+  public void testDropTopic() {
+    NameIdentifier ident =
+        NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, DEFAULT_SCHEMA_NAME, "test_drop_topic");
+    Map<String, String> properties = ImmutableMap.of(PARTITION_COUNT, "3", REPLICATION_FACTOR, "1");
+    kafkaCatalogOperations.createTopic(ident, null, null, properties);
+    Assertions.assertNotNull(kafkaCatalogOperations.loadTopic(ident));
+
+    Assertions.assertTrue(kafkaCatalogOperations.dropTopic(ident));
+    Exception exception =
+        Assertions.assertThrows(
+            NoSuchTopicException.class, () -> kafkaCatalogOperations.loadTopic(ident));
+    Assertions.assertEquals(
+        "Topic metalake.test_kafka_catalog.default.test_drop_topic does not exist",
+        exception.getMessage());
+
+    exception =
+        Assertions.assertThrows(
+            NoSuchTopicException.class, () -> kafkaCatalogOperations.dropTopic(ident));
+    Assertions.assertEquals(
+        "Topic metalake.test_kafka_catalog.default.test_drop_topic does not exist",
+        exception.getMessage());
+  }
+
+  @Test
+  public void testAlterTopic() {
+    NameIdentifier ident =
+        NameIdentifier.of(METALAKE_NAME, CATALOG_NAME, DEFAULT_SCHEMA_NAME, "test_alter_topic");
+    Map<String, String> properties =
+        ImmutableMap.of(PARTITION_COUNT, "2", REPLICATION_FACTOR, "1", "tag", "test");
+    Topic createdTopic = kafkaCatalogOperations.createTopic(ident, null, null, properties);
+
+    Topic alteredTopic =
+        kafkaCatalogOperations.alterTopic(
+            ident,
+            TopicChange.updateComment("new comment"),
+            TopicChange.setProperty(PARTITION_COUNT, "3"),
+            TopicChange.removeProperty("tag"));
+    Assertions.assertEquals(createdTopic.name(), alteredTopic.name());
+    Assertions.assertEquals("new comment", alteredTopic.comment());
+    Assertions.assertEquals("3", alteredTopic.properties().get(PARTITION_COUNT));
+    Assertions.assertEquals("1", alteredTopic.properties().get(REPLICATION_FACTOR));
+    Assertions.assertFalse(alteredTopic.properties().containsKey("tag"));
+
+    // test exception
+    Exception exception =
+        Assertions.assertThrows(
+            NoSuchTopicException.class,
+            () ->
+                kafkaCatalogOperations.alterTopic(
+                    NameIdentifier.of(
+                        METALAKE_NAME, CATALOG_NAME, DEFAULT_SCHEMA_NAME, "error_topic"),
+                    TopicChange.updateComment("new comment")));
+    Assertions.assertEquals(
+        "Topic metalake.test_kafka_catalog.default.error_topic does not exist",
+        exception.getMessage());
+
+    exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                kafkaCatalogOperations.alterTopic(
+                    ident, TopicChange.removeProperty(PARTITION_COUNT)));
+    Assertions.assertEquals("Cannot remove partition count", exception.getMessage());
+
+    exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                kafkaCatalogOperations.alterTopic(
+                    ident, TopicChange.setProperty(PARTITION_COUNT, "1")));
+    Assertions.assertEquals("Cannot reduce partition count from 3 to 1", exception.getMessage());
   }
 }

--- a/catalogs/catalog-messaging-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/embeddedKafka/KafkaClusterEmbedded.java
+++ b/catalogs/catalog-messaging-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/embeddedKafka/KafkaClusterEmbedded.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.catalog.kafka.embeddedKafka;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.Properties;
+import java.util.UUID;
+import kafka.server.KafkaConfig;
+import kafka.server.KafkaConfig$;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class KafkaClusterEmbedded {
+  public static final String TOPIC_1 = "kafka-test-topic-1";
+  public static final String TOPIC_2 = "kafka-test-topic-2";
+  public static final String TOPIC_3 = "kafka-test-topic-3";
+
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaClusterEmbedded.class);
+  private static ZooKeeperEmbedded zookeeper;
+  private static KafkaEmbedded broker;
+
+  /** Creates and starts the cluster. */
+  @BeforeAll
+  public static void start() throws Exception {
+    LOG.info("Initiating embedded Kafka cluster startup");
+    LOG.info("Starting a ZooKeeper instance...");
+    zookeeper = new ZooKeeperEmbedded();
+    LOG.info("ZooKeeper instance is running at {}", zookeeper.connectString());
+
+    Properties brokerConfig = initBrokerConfig();
+    LOG.info(
+        "Starting a Kafka instance on port {} ...",
+        brokerConfig.getProperty(KafkaConfig.ListenersProp()));
+    broker = new KafkaEmbedded(brokerConfig);
+    LOG.info(
+        "Kafka instance is running at {}, connected to ZooKeeper at {}",
+        broker.brokerList(),
+        broker.zookeeperConnect());
+
+    // Create initial topics
+    broker.createTopic(TOPIC_1);
+    broker.createTopic(TOPIC_2);
+    broker.createTopic(TOPIC_3);
+  }
+
+  @AfterAll
+  public static void stop() throws IOException {
+    LOG.info("Stopping embedded Kafka cluster");
+    if (broker != null) {
+      broker.stop();
+    }
+
+    if (zookeeper != null) {
+      zookeeper.stop();
+    }
+
+    LOG.info("Embedded Kafka cluster stopped");
+  }
+
+  protected static String genRandomString() {
+    return UUID.randomUUID().toString().replace("-", "");
+  }
+
+  public static String brokerList() {
+    return broker.brokerList();
+  }
+
+  private static Properties initBrokerConfig() {
+    Properties configs = new Properties();
+    configs.put(KafkaConfig$.MODULE$.ZkConnectProp(), zookeeper.connectString());
+    configs.put(KafkaConfig$.MODULE$.ZkSessionTimeoutMsProp(), 30 * 1000);
+    configs.put(KafkaConfig$.MODULE$.ZkConnectionTimeoutMsProp(), 60 * 1000);
+    configs.put(KafkaConfig$.MODULE$.DeleteTopicEnableProp(), true);
+    configs.put(KafkaConfig$.MODULE$.LogCleanerDedupeBufferSizeProp(), 2 * 1024 * 1024L);
+    configs.put(KafkaConfig$.MODULE$.GroupMinSessionTimeoutMsProp(), 0);
+    configs.put(KafkaConfig$.MODULE$.OffsetsTopicReplicationFactorProp(), (short) 1);
+    configs.put(KafkaConfig$.MODULE$.OffsetsTopicPartitionsProp(), 1);
+    configs.put(KafkaConfig$.MODULE$.AutoCreateTopicsEnableProp(), true);
+    // Find a random port
+    try (ServerSocket socket = new ServerSocket(0)) {
+      socket.setReuseAddress(true);
+      configs.put(
+          KafkaConfig.ListenersProp(),
+          String.format("PLAINTEXT://127.0.0.1:%s", socket.getLocalPort()));
+    } catch (IOException e) {
+      throw new RuntimeException("Can't find a port to start embedded Kafka broker", e);
+    }
+    return configs;
+  }
+}

--- a/catalogs/catalog-messaging-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/embeddedKafka/KafkaEmbedded.java
+++ b/catalogs/catalog-messaging-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/embeddedKafka/KafkaEmbedded.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.catalog.kafka.embeddedKafka;
+
+import static com.datastrato.gravitino.catalog.kafka.embeddedKafka.KafkaClusterEmbedded.genRandomString;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import kafka.cluster.EndPoint;
+import kafka.server.KafkaConfig;
+import kafka.server.KafkaConfig$;
+import kafka.server.KafkaServer;
+import org.apache.commons.io.FileUtils;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.utils.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Option;
+
+public class KafkaEmbedded {
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaEmbedded.class);
+  private static final String LOG_DIR = "/tmp/gravitino_test_embeddedKafka_" + genRandomString();
+
+  private final Properties effectiveConfig;
+  private final KafkaServer kafka;
+
+  public KafkaEmbedded(final Properties config) {
+    effectiveConfig = effectiveConfigFrom(config);
+    final boolean loggingEnabled = true;
+
+    final KafkaConfig kafkaConfig = new KafkaConfig(effectiveConfig, loggingEnabled);
+    LOG.info("Starting embedded Kafka broker (with ZK ensemble at {}) ...", zookeeperConnect());
+    kafka = new KafkaServer(kafkaConfig, Time.SYSTEM, Option.apply("embedded-kafka-broker"), false);
+    kafka.startup();
+    LOG.info(
+        "Startup of embedded Kafka broker at {} completed (with ZK ensemble at {}) ...",
+        brokerList(),
+        zookeeperConnect());
+  }
+
+  public void createTopic(String topic) {
+    Properties properties = new Properties();
+    properties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList());
+
+    try (AdminClient adminClient = AdminClient.create(properties)) {
+      NewTopic newTopic = new NewTopic(topic, 1, (short) 1);
+      adminClient.createTopics(Collections.singletonList(newTopic)).all().get();
+    } catch (InterruptedException | ExecutionException e) {
+      throw new RuntimeException("Failed to create topic " + topic, e);
+    }
+  }
+
+  /**
+   * This broker's `metadata.broker.list` value. Example: `127.0.0.1:9092`.
+   *
+   * <p>You can use this to tell Kafka producers and consumers how to connect to this instance.
+   */
+  public String brokerList() {
+    final EndPoint endPoint = kafka.advertisedListeners().head();
+    final String hostname = endPoint.host() == null ? "" : endPoint.host();
+
+    return String.join(
+        ":",
+        hostname,
+        Integer.toString(
+            kafka.boundPort(ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT))));
+  }
+
+  /** The ZooKeeper connection string aka `zookeeper.connect`. */
+  public String zookeeperConnect() {
+    return effectiveConfig.getProperty("zookeeper.connect");
+  }
+
+  /** Stop the broker. */
+  public void stop() throws IOException {
+    LOG.info(
+        "Shutting down embedded Kafka broker at {} (with ZK ensemble at {}) ...",
+        brokerList(),
+        zookeeperConnect());
+    kafka.shutdown();
+    kafka.awaitShutdown();
+    FileUtils.deleteDirectory(FileUtils.getFile(LOG_DIR));
+    LOG.info(
+        "Shutdown of embedded Kafka broker at {} completed (with ZK ensemble at {}) ...",
+        brokerList(),
+        zookeeperConnect());
+  }
+
+  private Properties effectiveConfigFrom(final Properties initialConfig) {
+    final Properties effectiveConfig = new Properties();
+    effectiveConfig.put(KafkaConfig$.MODULE$.BrokerIdProp(), 0);
+    effectiveConfig.put(KafkaConfig$.MODULE$.NumPartitionsProp(), 1);
+    effectiveConfig.put(KafkaConfig$.MODULE$.AutoCreateTopicsEnableProp(), true);
+    effectiveConfig.put(KafkaConfig$.MODULE$.MessageMaxBytesProp(), 1000000);
+    effectiveConfig.put(KafkaConfig$.MODULE$.ControlledShutdownEnableProp(), true);
+
+    effectiveConfig.putAll(initialConfig);
+    effectiveConfig.setProperty(KafkaConfig$.MODULE$.LogDirProp(), LOG_DIR);
+    return effectiveConfig;
+  }
+}

--- a/catalogs/catalog-messaging-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/embeddedKafka/ZooKeeperEmbedded.java
+++ b/catalogs/catalog-messaging-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/embeddedKafka/ZooKeeperEmbedded.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.catalog.kafka.embeddedKafka;
+
+import java.io.IOException;
+import org.apache.curator.test.TestingServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ZooKeeperEmbedded {
+  private static final Logger LOG = LoggerFactory.getLogger(ZooKeeperEmbedded.class);
+  private final TestingServer server;
+
+  /**
+   * Creates and starts a ZooKeeper instance.
+   *
+   * @throws Exception if an error occurs during ZooKeeper startup
+   */
+  public ZooKeeperEmbedded() throws Exception {
+    LOG.info("Starting embedded ZooKeeper server...");
+    this.server = new TestingServer();
+    LOG.info(
+        "Embedded ZooKeeper server at {} uses the temp directory at {}",
+        server.getConnectString(),
+        server.getTempDirectory());
+  }
+
+  public void stop() throws IOException {
+    LOG.info("Shutting down embedded ZooKeeper server at {} ...", server.getConnectString());
+    server.close();
+    LOG.info("Shutdown of embedded ZooKeeper server at {} completed", server.getConnectString());
+  }
+
+  /**
+   * The ZooKeeper connection string aka `zookeeper.connect` in `hostnameOrIp:port` format. Example:
+   * `127.0.0.1:2181`.
+   *
+   * <p>You can use this to e.g. tell Kafka brokers how to connect to this instance.
+   */
+  public String connectString() {
+    return server.getConnectString();
+  }
+}

--- a/core/src/main/java/com/datastrato/gravitino/catalog/messaging/BaseTopic.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/messaging/BaseTopic.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.catalog.messaging;
+
+import com.datastrato.gravitino.Audit;
+import com.datastrato.gravitino.messaging.Topic;
+import com.datastrato.gravitino.meta.AuditInfo;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+public abstract class BaseTopic implements Topic {
+
+  protected String name;
+  @Nullable protected String comment;
+  @Nullable protected Map<String, String> properties;
+  protected Audit auditInfo;
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Nullable
+  @Override
+  public String comment() {
+    return comment;
+  }
+
+  @Override
+  public Map<String, String> properties() {
+    return properties;
+  }
+
+  @Override
+  public Audit auditInfo() {
+    return auditInfo;
+  }
+
+  interface Builder<SELF extends Builder<SELF, T>, T extends BaseTopic> {
+
+    SELF withName(String name);
+
+    SELF withComment(String comment);
+
+    SELF withProperties(Map<String, String> properties);
+
+    SELF withAuditInfo(AuditInfo auditInfo);
+
+    T build();
+  }
+
+  public abstract static class BaseTopicBuilder<
+          SELF extends BaseTopicBuilder<SELF, T>, T extends BaseTopic>
+      implements Builder<SELF, T> {
+    protected String name;
+    protected String comment;
+    protected Map<String, String> properties;
+    protected AuditInfo auditInfo;
+
+    @Override
+    public SELF withName(String name) {
+      this.name = name;
+      return self();
+    }
+
+    @Override
+    public SELF withComment(String comment) {
+      this.comment = comment;
+      return self();
+    }
+
+    @Override
+    public SELF withProperties(Map<String, String> properties) {
+      this.properties = properties;
+      return self();
+    }
+
+    @Override
+    public SELF withAuditInfo(AuditInfo auditInfo) {
+      this.auditInfo = auditInfo;
+      return self();
+    }
+
+    @Override
+    public T build() {
+      T t = internalBuild();
+      return t;
+    }
+
+    private SELF self() {
+      return (SELF) this;
+    }
+
+    protected abstract T internalBuild();
+  }
+}

--- a/core/src/main/java/com/datastrato/gravitino/connector/BaseTopic.java
+++ b/core/src/main/java/com/datastrato/gravitino/connector/BaseTopic.java
@@ -5,39 +5,55 @@
 package com.datastrato.gravitino.connector;
 
 import com.datastrato.gravitino.Audit;
+import com.datastrato.gravitino.annotation.Evolving;
 import com.datastrato.gravitino.messaging.Topic;
 import com.datastrato.gravitino.meta.AuditInfo;
 import java.util.Map;
 import javax.annotation.Nullable;
 
+/** An abstract class representing a base topic in a messaging system. */
+@Evolving
 public abstract class BaseTopic implements Topic {
 
   protected String name;
+
   @Nullable protected String comment;
+
   @Nullable protected Map<String, String> properties;
+
   protected Audit auditInfo;
 
+  /** @return The name of the topic. */
   @Override
   public String name() {
     return name;
   }
 
+  /** @return The comment or description for the topic. */
   @Nullable
   @Override
   public String comment() {
     return comment;
   }
 
+  /** @return The associated properties of the topic. */
   @Override
   public Map<String, String> properties() {
     return properties;
   }
 
+  /** @return The audit information for the topic. */
   @Override
   public Audit auditInfo() {
     return auditInfo;
   }
 
+  /**
+   * Builder interface for {@link BaseTopic}.
+   *
+   * @param <SELF> The type of the builder.
+   * @param <T> The type of the topic being built.
+   */
   interface Builder<SELF extends Builder<SELF, T>, T extends BaseTopic> {
 
     SELF withName(String name);
@@ -51,6 +67,13 @@ public abstract class BaseTopic implements Topic {
     T build();
   }
 
+  /**
+   * An abstract class implementing the builder interface for {@link BaseTopic}. This class should
+   * be extended by the concrete topic builders.
+   *
+   * @param <SELF> The type of the builder.
+   * @param <T> The type of the topic being built.
+   */
   public abstract static class BaseTopicBuilder<
           SELF extends BaseTopicBuilder<SELF, T>, T extends BaseTopic>
       implements Builder<SELF, T> {
@@ -59,30 +82,59 @@ public abstract class BaseTopic implements Topic {
     protected Map<String, String> properties;
     protected AuditInfo auditInfo;
 
+    /**
+     * Sets the name of the topic.
+     *
+     * @param name The name of the topic.
+     * @return The builder instance.
+     */
     @Override
     public SELF withName(String name) {
       this.name = name;
       return self();
     }
 
+    /**
+     * Sets the comment of the topic.
+     *
+     * @param comment The comment or description for the topic.
+     * @return The builder instance.
+     */
     @Override
     public SELF withComment(String comment) {
       this.comment = comment;
       return self();
     }
 
+    /**
+     * Sets the associated properties of the topic.
+     *
+     * @param properties The associated properties of the topic.
+     * @return The builder instance.
+     */
     @Override
     public SELF withProperties(Map<String, String> properties) {
       this.properties = properties;
       return self();
     }
 
+    /**
+     * Sets the audit information for the topic.
+     *
+     * @param auditInfo The audit information for the topic.
+     * @return The builder instance.
+     */
     @Override
     public SELF withAuditInfo(AuditInfo auditInfo) {
       this.auditInfo = auditInfo;
       return self();
     }
 
+    /**
+     * Builds the topic with the provided attributes.
+     *
+     * @return The built topic instance.
+     */
     @Override
     public T build() {
       T t = internalBuild();
@@ -93,6 +145,12 @@ public abstract class BaseTopic implements Topic {
       return (SELF) this;
     }
 
+    /**
+     * Builds the concrete instance of the topic with the provided attributes.
+     *
+     * @return The concrete instance of the topic.
+     */
+    @Evolving
     protected abstract T internalBuild();
   }
 }

--- a/core/src/main/java/com/datastrato/gravitino/connector/BaseTopic.java
+++ b/core/src/main/java/com/datastrato/gravitino/connector/BaseTopic.java
@@ -2,7 +2,7 @@
  * Copyright 2024 Datastrato Pvt Ltd.
  * This software is licensed under the Apache License version 2.
  */
-package com.datastrato.gravitino.catalog.messaging;
+package com.datastrato.gravitino.connector;
 
 import com.datastrato.gravitino.Audit;
 import com.datastrato.gravitino.messaging.Topic;

--- a/core/src/main/java/com/datastrato/gravitino/connector/PropertyEntry.java
+++ b/core/src/main/java/com/datastrato/gravitino/connector/PropertyEntry.java
@@ -222,6 +222,28 @@ public final class PropertyEntry<T> {
         .build();
   }
 
+  public static PropertyEntry<Short> shortPropertyEntry(
+      String name,
+      String description,
+      boolean required,
+      boolean immutable,
+      Short defaultValue,
+      boolean hidden,
+      boolean reserved) {
+    return new Builder<Short>()
+        .withName(name)
+        .withDescription(description)
+        .withRequired(required)
+        .withImmutable(immutable)
+        .withJavaType(Short.class)
+        .withDefaultValue(defaultValue)
+        .withDecoder(Short::parseShort)
+        .withEncoder(String::valueOf)
+        .withHidden(hidden)
+        .withReserved(reserved)
+        .build();
+  }
+
   public static PropertyEntry<String> stringReservedPropertyEntry(
       String name, String description, boolean hidden) {
     return stringPropertyEntry(name, description, false, true, null, hidden, true);
@@ -262,6 +284,11 @@ public final class PropertyEntry<T> {
   public static PropertyEntry<String> stringOptionalPropertyEntry(
       String name, String description, boolean immutable, String defaultValue, boolean hidden) {
     return stringPropertyEntry(name, description, false, immutable, defaultValue, hidden, false);
+  }
+
+  public static PropertyEntry<Short> shortOptionalPropertyEntry(
+      String name, String description, boolean immutable, Short defaultValue, boolean hidden) {
+    return shortPropertyEntry(name, description, false, immutable, defaultValue, hidden, false);
   }
 
   public static PropertyEntry<Integer> integerOptionalPropertyEntry(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,6 +50,8 @@ rauschig = "1.2.0"
 mybatis = "3.5.6"
 h2db = "1.4.200"
 kyuubi = "1.8.0"
+kafka = "3.4.0"
+curator = "2.12.0"
 
 protobuf-plugin = "0.9.2"
 spotless-plugin = '6.11.0'
@@ -152,6 +154,9 @@ minikdc = { group = "org.apache.hadoop", name = "hadoop-minikdc", version.ref = 
 immutables-value = { module = "org.immutables:value", version.ref = "immutables-value" }
 commons-cli = { group = "commons-cli", name = "commons-cli", version.ref = "commons-cli" }
 sun-activation = { group = "com.sun.activation", name = "javax.activation", version.ref = "sun-activation-version" }
+kafka-clients = { group = "org.apache.kafka", name = "kafka-clients", version.ref = "kafka" }
+kafka_2_12 = { group = "org.apache.kafka", name = "kafka_2.12", version.ref = "kafka" }
+curator-test = { group = "org.apache.curator", name = "curator-test", version.ref = "curator"}
 
 selenium = { group = "org.seleniumhq.selenium", name = "selenium-java", version.ref = "selenium" }
 rauschig = { group = "org.rauschig", name = "jarchivelib", version.ref = "rauschig" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -155,7 +155,7 @@ immutables-value = { module = "org.immutables:value", version.ref = "immutables-
 commons-cli = { group = "commons-cli", name = "commons-cli", version.ref = "commons-cli" }
 sun-activation = { group = "com.sun.activation", name = "javax.activation", version.ref = "sun-activation-version" }
 kafka-clients = { group = "org.apache.kafka", name = "kafka-clients", version.ref = "kafka" }
-kafka_2_12 = { group = "org.apache.kafka", name = "kafka_2.12", version.ref = "kafka" }
+kafka = { group = "org.apache.kafka", name = "kafka_2.12", version.ref = "kafka" }
 curator-test = { group = "org.apache.curator", name = "curator-test", version.ref = "curator"}
 
 selenium = { group = "org.seleniumhq.selenium", name = "selenium-java", version.ref = "selenium" }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add the topic operations support for the Kafka catalog.


### Why are the changes needed?

This is a part of the work to support messaging management in Gravitino

Fix: #2468 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

Add UTs to cover the codes.
