### PR TITLE
[#2618] fix(doc): Remove description field in fileset openapi doc

### DIFF
--- a/docs/open-api/filesets.yaml
+++ b/docs/open-api/filesets.yaml
@@ -157,10 +157,6 @@ components:
         name:
           type: string
           description: The name of the fileset
-        description:
-          type: string
-          description: The description of the fileset
-          nullable: true
         type:
           type: string
           description: The type of the fileset
@@ -188,10 +184,6 @@ components:
         name:
           type: string
           description: The name of the fileset
-        description:
-          type: string
-          description: The description of the fileset
-          nullable: true
         type:
           type: string
           description: The type of the fileset
@@ -342,7 +334,6 @@ components:
     FilesetCreateRequest:
       value: {
         "name": "fileset1",
-        "description": "This is a fileset",
         "type": "managed",
         "comment": "This is a comment",
         "storageLocation": "s3://bucket/path",
@@ -357,7 +348,6 @@ components:
         "code": 0,
         "fileset" : {
           "name": "fileset1",
-          "description": "This is a fileset",
           "type": "managed",
           "comment": "This is a comment",
           "storageLocation": "s3://bucket/path",
@@ -387,7 +377,3 @@ components:
             "java.lang.NoSuchFilesetException: Fileset does not exist"
         ]
       }
-
-
-
-


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove the "description" field in Fileset related APIs.

### Why are the changes needed?

Because the `description` field does not exist in the related APIs, it should be removed, otherwise, it will lead to an issue.

Fix: #2618 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually verification.
