### PR TITLE
[#2525] fix(catalog-hive): Fix classNotFoundError in the Caffeine removal listener

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/utils/ClientPoolImpl.java
+++ b/core/src/main/java/com/datastrato/gravitino/utils/ClientPoolImpl.java
@@ -36,7 +36,7 @@ public abstract class ClientPoolImpl<C, E extends Exception>
   private final Object signal = new Object();
   private final boolean retryByDefault;
   private volatile int currentSize;
-  private boolean closed;
+  private volatile boolean closed;
 
   public ClientPoolImpl(int poolSize, Class<? extends E> reconnectExc, boolean retryByDefault) {
     this.poolSize = poolSize;
@@ -89,6 +89,12 @@ public abstract class ClientPoolImpl<C, E extends Exception>
 
   @Override
   public void close() {
+    // To avoid closing it repeatedly, we add a judgment that if it has been closed,
+    // we do not need to close it anymore.
+    if (closed) {
+      return;
+    }
+
     this.closed = true;
     try {
       while (currentSize > 0) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Close `HiveClientPool` before closing the class loader as the removal listener is asynchronous and can't make this guarantee.

### Why are the changes needed?

It's bugs that need to be fixed.

Fix: #2525 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Test locally. 
