### PR TITLE
[#2657] improvement: Skip signing for publishToMavenLocal.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -427,6 +427,11 @@ subprojects {
   }
 
   configure<SigningExtension> {
+    val taskNames = gradle.getStartParameter().getTaskNames()
+    taskNames.forEach() {
+      if (it.contains("publishToMavenLocal")) setRequired(false)
+    }
+
     val gpgId = System.getenv("GPG_ID")
     val gpgSecretKey = System.getenv("GPG_PRIVATE_KEY")
     val gpgKeyPassword = System.getenv("GPG_PASSPHRASE")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Skip signing when execute `./gradlew publishToMavenLocal` without gpg key.
If developer wants to generate signed file locally, it still can be generated by setting the env `GPG_ID`, `GPG_PRIVATE_KEY` and `GPG_PASSPHRASE`.

### Why are the changes needed?

Publish to local Maven repository should succeed even without signing a signature.

Fix: #2657

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
`./gradlew publishToMavenLocal`