### PR TITLE
[#2650] feat(spark-connector): support UpdateColumnDefaultValue in AlterTable for spark connector

### DIFF
--- a/api/src/main/java/com/datastrato/gravitino/rel/TableChange.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/TableChange.java
@@ -1439,21 +1439,22 @@ public interface TableChange {
     }
 
     /**
-     * Retrieves the field name of the column whose position is being updated.
+     * Retrieves the field name of the column whose default value is being updated.
      *
      * @return An array of strings representing the field name.
      */
-    public String[] getFieldName() {
+    @Override
+    public String[] fieldName() {
       return fieldName;
     }
 
     /**
-     * Retrieves the new position for the column.
+     * Retrieves the new default value for the column.
      *
      * @return The new default value of the column.
      */
     public String newDefaultValue() {
-      return this.newDefaultValue;
+      return newDefaultValue;
     }
 
     /**
@@ -1483,11 +1484,6 @@ public interface TableChange {
       int result = Objects.hash(newDefaultValue);
       result = 31 * result + Arrays.hashCode(fieldName);
       return result;
-    }
-
-    @Override
-    public String[] fieldName() {
-      return fieldName;
     }
   }
 

--- a/api/src/main/java/com/datastrato/gravitino/rel/TableChange.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/TableChange.java
@@ -397,20 +397,7 @@ public interface TableChange {
   static TableChange updateColumnPosition(String[] fieldName, ColumnPosition newPosition) {
     return new UpdateColumnPosition(fieldName, newPosition);
   }
-  /**
-   * Create a TableChange for updating the default value of a field.
-   *
-   * <p>The name is used to find the field to update.
-   *
-   * <p>If the field does not exist, the change will result in an {@link IllegalArgumentException}.
-   *
-   * @param fieldName The field name of the column to update.
-   * @param newDefaultValue The new default value.
-   * @return A TableChange for the update.
-   */
-  static TableChange updateColumnDefaultValue(String[] fieldName, String newDefaultValue) {
-    return new UpdateColumnDefaultValue(fieldName, newDefaultValue);
-  }
+
   /**
    * Create a TableChange for deleting a field.
    *
@@ -1419,71 +1406,6 @@ public interface TableChange {
     @Override
     public String[] fieldName() {
       return fieldName;
-    }
-  }
-
-  /**
-   * A TableChange to update the default of a field.
-   *
-   * <p>The field names are used to find the field to update.
-   *
-   * <p>If the field does not exist, the change must result in an {@link IllegalArgumentException}.
-   */
-  final class UpdateColumnDefaultValue implements ColumnChange {
-    private final String[] fieldName;
-    private final String newDefaultValue;
-
-    private UpdateColumnDefaultValue(String[] fieldName, String newDefaultValue) {
-      this.fieldName = fieldName;
-      this.newDefaultValue = newDefaultValue;
-    }
-
-    /**
-     * Retrieves the field name of the column whose default value is being updated.
-     *
-     * @return An array of strings representing the field name.
-     */
-    @Override
-    public String[] fieldName() {
-      return fieldName;
-    }
-
-    /**
-     * Retrieves the new default value for the column.
-     *
-     * @return The new default value of the column.
-     */
-    public String newDefaultValue() {
-      return newDefaultValue;
-    }
-
-    /**
-     * Compares this UpdateColumnDefaultValue instance with another object for equality. The
-     * comparison is based on the field name array and the new default value.
-     *
-     * @param o The object to compare with this instance.
-     * @return true if the given object represents the same default value update; false otherwise.
-     */
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-      UpdateColumnDefaultValue that = (UpdateColumnDefaultValue) o;
-      return Arrays.equals(fieldName, that.fieldName)
-          && Objects.equals(newDefaultValue, that.newDefaultValue);
-    }
-
-    /**
-     * Generates a hash code for this UpdateColumnDefaultValue instance. The hash code is based on
-     * both the hierarchical field name and the new default value.
-     *
-     * @return A hash code value for this default value update operation.
-     */
-    @Override
-    public int hashCode() {
-      int result = Objects.hash(newDefaultValue);
-      result = 31 * result + Arrays.hashCode(fieldName);
-      return result;
     }
   }
 

--- a/api/src/main/java/com/datastrato/gravitino/rel/TableChange.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/TableChange.java
@@ -397,7 +397,20 @@ public interface TableChange {
   static TableChange updateColumnPosition(String[] fieldName, ColumnPosition newPosition) {
     return new UpdateColumnPosition(fieldName, newPosition);
   }
-
+  /**
+   * Create a TableChange for updating the default value of a field.
+   *
+   * <p>The name is used to find the field to update.
+   *
+   * <p>If the field does not exist, the change will result in an {@link IllegalArgumentException}.
+   *
+   * @param fieldName The field name of the column to update.
+   * @param newDefaultValue The new default value.
+   * @return A TableChange for the update.
+   */
+  static TableChange updateColumnDefaultValue(String[] fieldName, String newDefaultValue) {
+    return new UpdateColumnDefaultValue(fieldName, newDefaultValue);
+  }
   /**
    * Create a TableChange for deleting a field.
    *
@@ -1399,6 +1412,75 @@ public interface TableChange {
     @Override
     public int hashCode() {
       int result = Objects.hash(position);
+      result = 31 * result + Arrays.hashCode(fieldName);
+      return result;
+    }
+
+    @Override
+    public String[] fieldName() {
+      return fieldName;
+    }
+  }
+
+  /**
+   * A TableChange to update the default of a field.
+   *
+   * <p>The field names are used to find the field to update.
+   *
+   * <p>If the field does not exist, the change must result in an {@link IllegalArgumentException}.
+   */
+  final class UpdateColumnDefaultValue implements ColumnChange {
+    private final String[] fieldName;
+    private final String newDefaultValue;
+
+    private UpdateColumnDefaultValue(String[] fieldName, String newDefaultValue) {
+      this.fieldName = fieldName;
+      this.newDefaultValue = newDefaultValue;
+    }
+
+    /**
+     * Retrieves the field name of the column whose position is being updated.
+     *
+     * @return An array of strings representing the field name.
+     */
+    public String[] getFieldName() {
+      return fieldName;
+    }
+
+    /**
+     * Retrieves the new position for the column.
+     *
+     * @return The new default value of the column.
+     */
+    public String newDefaultValue() {
+      return this.newDefaultValue;
+    }
+
+    /**
+     * Compares this UpdateColumnDefaultValue instance with another object for equality. The
+     * comparison is based on the field name array and the new default value.
+     *
+     * @param o The object to compare with this instance.
+     * @return true if the given object represents the same default value update; false otherwise.
+     */
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      UpdateColumnDefaultValue that = (UpdateColumnDefaultValue) o;
+      return Arrays.equals(fieldName, that.fieldName)
+          && Objects.equals(newDefaultValue, that.newDefaultValue);
+    }
+
+    /**
+     * Generates a hash code for this UpdateColumnDefaultValue instance. The hash code is based on
+     * both the hierarchical field name and the new default value.
+     *
+     * @return A hash code value for this default value update operation.
+     */
+    @Override
+    public int hashCode() {
+      int result = Objects.hash(newDefaultValue);
       result = 31 * result + Arrays.hashCode(fieldName);
       return result;
     }

--- a/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/catalog/GravitinoCatalog.java
+++ b/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/catalog/GravitinoCatalog.java
@@ -13,6 +13,7 @@ import com.datastrato.gravitino.exceptions.NonEmptySchemaException;
 import com.datastrato.gravitino.exceptions.SchemaAlreadyExistsException;
 import com.datastrato.gravitino.rel.Schema;
 import com.datastrato.gravitino.rel.SchemaChange;
+import com.datastrato.gravitino.rel.expressions.literals.Literals;
 import com.datastrato.gravitino.spark.connector.ConnectorConstants;
 import com.datastrato.gravitino.spark.connector.GravitinoCatalogAdaptor;
 import com.datastrato.gravitino.spark.connector.GravitinoCatalogAdaptorFactory;
@@ -423,7 +424,8 @@ public class GravitinoCatalog implements TableCatalog, SupportsNamespaces {
       TableChange.UpdateColumnDefaultValue updateColumnDefaultValue =
           (TableChange.UpdateColumnDefaultValue) change;
       return com.datastrato.gravitino.rel.TableChange.updateColumnDefaultValue(
-          updateColumnDefaultValue.fieldNames(), updateColumnDefaultValue.newDefaultValue());
+          updateColumnDefaultValue.fieldNames(),
+          Literals.stringLiteral(updateColumnDefaultValue.newDefaultValue()));
     } else {
       throw new UnsupportedOperationException(
           String.format("Unsupported table change %s", change.getClass().getName()));

--- a/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/catalog/GravitinoCatalog.java
+++ b/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/catalog/GravitinoCatalog.java
@@ -419,6 +419,11 @@ public class GravitinoCatalog implements TableCatalog, SupportsNamespaces {
           (TableChange.UpdateColumnNullability) change;
       return com.datastrato.gravitino.rel.TableChange.updateColumnNullability(
           updateColumnNullability.fieldNames(), updateColumnNullability.nullable());
+    } else if (change instanceof TableChange.UpdateColumnDefaultValue) {
+      TableChange.UpdateColumnDefaultValue updateColumnDefaultValue =
+          (TableChange.UpdateColumnDefaultValue) change;
+      return com.datastrato.gravitino.rel.TableChange.updateColumnDefaultValue(
+          updateColumnDefaultValue.fieldNames(), updateColumnDefaultValue.newDefaultValue());
     } else {
       throw new UnsupportedOperationException(
           String.format("Unsupported table change %s", change.getClass().getName()));

--- a/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/catalog/TestTransformTableChange.java
+++ b/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/catalog/TestTransformTableChange.java
@@ -5,6 +5,7 @@
 
 package com.datastrato.gravitino.spark.connector.catalog;
 
+import com.datastrato.gravitino.rel.expressions.literals.Literals;
 import org.apache.spark.sql.connector.catalog.ColumnDefaultValue;
 import org.apache.spark.sql.connector.catalog.TableChange;
 import org.apache.spark.sql.connector.expressions.LiteralValue;
@@ -243,7 +244,9 @@ public class TestTransformTableChange {
         sparkUpdateColumnNullability.fieldNames(), gravitinoUpdateColumnNullability.fieldName());
     Assertions.assertEquals(
         sparkUpdateColumnNullability.nullable(), gravitinoUpdateColumnNullability.nullable());
+  }
 
+  @Test
   void testUpdateColumnDefaultValue() {
     String[] fieldNames = new String[] {"col"};
     String newDedauleValue = "col_default_value";
@@ -263,7 +266,8 @@ public class TestTransformTableChange {
 
     Assertions.assertArrayEquals(
         sparkUpdateColumnDefaultValue.fieldNames(), gravitinoUpdateColumnDefaultValue.fieldName());
-    Assertions.assertTrue(
-        newDedauleValue.equalsIgnoreCase(gravitinoUpdateColumnDefaultValue.newDefaultValue()));
+    Assertions.assertEquals(
+        Literals.stringLiteral(newDedauleValue),
+        gravitinoUpdateColumnDefaultValue.getNewDefaultValue());
   }
 }

--- a/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/catalog/TestTransformTableChange.java
+++ b/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/catalog/TestTransformTableChange.java
@@ -243,5 +243,27 @@ public class TestTransformTableChange {
         sparkUpdateColumnNullability.fieldNames(), gravitinoUpdateColumnNullability.fieldName());
     Assertions.assertEquals(
         sparkUpdateColumnNullability.nullable(), gravitinoUpdateColumnNullability.nullable());
+
+  void testUpdateColumnDefaultValue() {
+    String[] fieldNames = new String[] {"col"};
+    String newDedauleValue = "col_default_value";
+    TableChange.UpdateColumnDefaultValue sparkUpdateColumnDefaultValue =
+        (TableChange.UpdateColumnDefaultValue)
+            TableChange.updateColumnDefaultValue(fieldNames, newDedauleValue);
+
+    com.datastrato.gravitino.rel.TableChange gravitinoChange =
+        GravitinoCatalog.transformTableChange(sparkUpdateColumnDefaultValue);
+
+    Assertions.assertTrue(
+        gravitinoChange
+            instanceof com.datastrato.gravitino.rel.TableChange.UpdateColumnDefaultValue);
+    com.datastrato.gravitino.rel.TableChange.UpdateColumnDefaultValue
+        gravitinoUpdateColumnDefaultValue =
+            (com.datastrato.gravitino.rel.TableChange.UpdateColumnDefaultValue) gravitinoChange;
+
+    Assertions.assertArrayEquals(
+        sparkUpdateColumnDefaultValue.fieldNames(), gravitinoUpdateColumnDefaultValue.fieldName());
+    Assertions.assertTrue(
+        newDedauleValue.equalsIgnoreCase(gravitinoUpdateColumnDefaultValue.newDefaultValue()));
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

(Please outline the changes and how this PR fixes the issue.)

### Why are the changes needed?

support UpdateColumnDefaultValue in AlterTable for spark connector.

Fix: #2650 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

New UTs.
