### PR TITLE
[#2472] refactor:enable ClassCanBeStatic error-prone

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -278,6 +278,7 @@ subprojects {
         "BoxedPrimitiveEquality",
         "ChainingConstructorIgnoresParameter",
         "CheckNotNullMultipleTimes",
+        "ClassCanBeStatic",
         "CollectionIncompatibleType",
         "CollectionToArraySafeParameter",
         "ComparingThisWithNull",

--- a/common/src/main/java/com/datastrato/gravitino/Config.java
+++ b/common/src/main/java/com/datastrato/gravitino/Config.java
@@ -240,7 +240,7 @@ public abstract class Config {
   }
 
   /** The DeprecatedConfig class represents a configuration entry that has been deprecated. */
-  private class DeprecatedConfig {
+  private static class DeprecatedConfig {
     private final String key;
     private final String version;
     private final String deprecationMessage;

--- a/common/src/test/java/com/datastrato/gravitino/TestConfig.java
+++ b/common/src/test/java/com/datastrato/gravitino/TestConfig.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 
 public class TestConfig {
 
-  class DummyConfig extends Config {
+  static class DummyConfig extends Config {
     public DummyConfig(boolean loadSystemProperties) {
       super(loadSystemProperties);
     }

--- a/core/src/test/java/com/datastrato/gravitino/utils/TestClientPool.java
+++ b/core/src/test/java/com/datastrato/gravitino/utils/TestClientPool.java
@@ -58,7 +58,7 @@ public class TestClientPool {
     assertEquals(2, clientPool.poolSize());
   }
 
-  private final class ClientPoolImplExtension extends ClientPoolImpl<ClientMock, Exception> {
+  private static final class ClientPoolImplExtension extends ClientPoolImpl<ClientMock, Exception> {
     private ClientPoolImplExtension(
         int poolSize, Class<? extends Exception> reconnectExc, boolean retryByDefault) {
       super(poolSize, reconnectExc, retryByDefault);

--- a/trino-connector/src/test/java/com/datastrato/gravitino/trino/connector/GravitinoMockServer.java
+++ b/trino-connector/src/test/java/com/datastrato/gravitino/trino/connector/GravitinoMockServer.java
@@ -602,7 +602,7 @@ public class GravitinoMockServer implements AutoCloseable {
     }
   }
 
-  class Metalake {
+  static class Metalake {
     GravitinoMetalake metalake;
     Map<String, Catalog> catalogs = new HashMap<>();
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

- enable ClassCanBeStatic error-prone
- An inner class should be static unless it references members of its enclosing class. See more details at https://errorprone.info/bugpattern/ClassCanBeStatic

### Why are the changes needed?

Fix: #2472 

### Does this PR introduce _any_ user-facing change?
- no

### How was this patch tested?
- `./gradle build`
