### PR TITLE
[#2402] test(spark-connector): Add the integration tests for CTAS and ITAS

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkCommonIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkCommonIT.java
@@ -31,7 +31,7 @@ import org.junit.platform.commons.util.StringUtils;
 public abstract class SparkCommonIT extends SparkEnvIT {
 
   // To generate test data for write&read table.
-  private static final Map<DataType, String> typeConstant =
+  protected static final Map<DataType, String> typeConstant =
       ImmutableMap.of(
           DataTypes.IntegerType,
           "2",
@@ -505,6 +505,75 @@ public abstract class SparkCommonIT extends SparkEnvIT {
     checkTableReadWrite(tableInfo);
   }
 
+  // Spark CTAS doesn't copy table properties and partition schema from source table.
+  @Test
+  void testCreateTableAsSelect() {
+    String tableName = "ctas_table";
+    dropTableIfExists(tableName);
+    createSimpleTable(tableName);
+    SparkTableInfo tableInfo = getTableInfo(tableName);
+    checkTableReadWrite(tableInfo);
+
+    String newTableName = "new_" + tableName;
+    dropTableIfExists(newTableName);
+    createTableAsSelect(tableName, newTableName);
+
+    SparkTableInfo newTableInfo = getTableInfo(newTableName);
+    SparkTableInfoChecker checker =
+        SparkTableInfoChecker.create().withName(newTableName).withColumns(getSimpleTableColumn());
+    checker.check(newTableInfo);
+
+    List<String> tableData = getTableData(newTableName);
+    Assertions.assertTrue(tableData.size() == 1);
+    Assertions.assertEquals(getExpectedTableData(newTableInfo), tableData.get(0));
+  }
+
+  @Test
+  void testInsertTableAsSelect() {
+    String tableName = "insert_select_table";
+    String newTableName = "new_" + tableName;
+
+    dropTableIfExists(tableName);
+    createSimpleTable(tableName);
+    SparkTableInfo tableInfo = getTableInfo(tableName);
+    checkTableReadWrite(tableInfo);
+
+    dropTableIfExists(newTableName);
+    createSimpleTable(newTableName);
+    insertTableAsSelect(tableName, newTableName);
+
+    SparkTableInfo newTableInfo = getTableInfo(newTableName);
+    String expectedTableData = getExpectedTableData(newTableInfo);
+    List<String> tableData = getTableData(newTableName);
+    Assertions.assertTrue(tableData.size() == 1);
+    Assertions.assertEquals(expectedTableData, tableData.get(0));
+  }
+
+  @Test
+  void testInsertDatasourceFormatPartitionTableAsSelect() {
+    String tableName = "insert_select_partition_table";
+    String newTableName = "new_" + tableName;
+    dropTableIfExists(tableName);
+    dropTableIfExists(newTableName);
+
+    createSimpleTable(tableName);
+    String createTableSql = getCreateSimpleTableString(newTableName);
+    createTableSql += "PARTITIONED BY (name, age)";
+    sql(createTableSql);
+
+    SparkTableInfo tableInfo = getTableInfo(tableName);
+    checkTableReadWrite(tableInfo);
+
+    insertTableAsSelect(tableName, newTableName);
+
+    SparkTableInfo newTableInfo = getTableInfo(newTableName);
+    checkPartitionDirExists(newTableInfo);
+    String expectedTableData = getExpectedTableData(newTableInfo);
+    List<String> tableData = getTableData(newTableName);
+    Assertions.assertTrue(tableData.size() == 1);
+    Assertions.assertEquals(expectedTableData, tableData.get(0));
+  }
+
   protected void checkPartitionDirExists(SparkTableInfo table) {
     Assertions.assertTrue(table.isPartitionTable(), "Not a partition table");
     String tableLocation = table.getTableLocation();
@@ -539,41 +608,44 @@ public abstract class SparkCommonIT extends SparkEnvIT {
     }
     sql(insertDataSQL);
 
-    // do something to match the query result:
-    // 1. remove "'" from values, such as 'a' is trans to a
-    // 2. remove "array" from values, such as array(1, 2, 3) is trans to [1, 2, 3]
-    // 3. remove "map" from values, such as map('a', 1, 'b', 2) is trans to {a=1, b=2}
-    // 4. remove "struct" from values, such as struct(1, 'a') is trans to 1,a
-    String checkValues =
-        table.getColumns().stream()
-            .map(columnInfo -> typeConstant.get(columnInfo.getType()))
-            .map(Object::toString)
-            .map(
-                s -> {
-                  String tmp = org.apache.commons.lang3.StringUtils.remove(s, "'");
-                  if (org.apache.commons.lang3.StringUtils.isEmpty(tmp)) {
-                    return tmp;
-                  } else if (tmp.startsWith("array")) {
-                    return tmp.replace("array", "").replace("(", "[").replace(")", "]");
-                  } else if (tmp.startsWith("map")) {
-                    return tmp.replace("map", "")
-                        .replace("(", "{")
-                        .replace(")", "}")
-                        .replace(", ", "=");
-                  } else if (tmp.startsWith("struct")) {
-                    return tmp.replace("struct", "")
-                        .replace("(", "")
-                        .replace(")", "")
-                        .replace(", ", ",");
-                  }
-                  return tmp;
-                })
-            .collect(Collectors.joining(","));
+    String checkValues = getExpectedTableData(table);
 
     List<String> queryResult = getTableData(name);
     Assertions.assertTrue(
         queryResult.size() == 1, "Should just one row, table content: " + queryResult);
     Assertions.assertEquals(checkValues, queryResult.get(0));
+  }
+
+  protected String getExpectedTableData(SparkTableInfo table) {
+    // Do something to match the query result:
+    // 1. remove "'" from values, such as 'a' is trans to a
+    // 2. remove "array" from values, such as array(1, 2, 3) is trans to [1, 2, 3]
+    // 3. remove "map" from values, such as map('a', 1, 'b', 2) is trans to {a=1, b=2}
+    // 4. remove "struct" from values, such as struct(1, 'a') is trans to 1,a
+    return table.getColumns().stream()
+        .map(columnInfo -> typeConstant.get(columnInfo.getType()))
+        .map(Object::toString)
+        .map(
+            s -> {
+              String tmp = org.apache.commons.lang3.StringUtils.remove(s, "'");
+              if (org.apache.commons.lang3.StringUtils.isEmpty(tmp)) {
+                return tmp;
+              } else if (tmp.startsWith("array")) {
+                return tmp.replace("array", "").replace("(", "[").replace(")", "]");
+              } else if (tmp.startsWith("map")) {
+                return tmp.replace("map", "")
+                    .replace("(", "{")
+                    .replace(")", "}")
+                    .replace(", ", "=");
+              } else if (tmp.startsWith("struct")) {
+                return tmp.replace("struct", "")
+                    .replace("(", "")
+                    .replace(")", "")
+                    .replace(", ", ",");
+              }
+              return tmp;
+            })
+        .collect(Collectors.joining(","));
   }
 
   protected String getCreateSimpleTableString(String tableName) {
@@ -595,7 +667,7 @@ public abstract class SparkCommonIT extends SparkEnvIT {
 
   // Helper method to create a simple table, and could use corresponding
   // getSimpleTableColumn to check table column.
-  private void createSimpleTable(String identifier) {
+  protected void createSimpleTable(String identifier) {
     String createTableSql = getCreateSimpleTableString(identifier);
     sql(createTableSql);
   }

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkEnvIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkEnvIT.java
@@ -128,6 +128,7 @@ public abstract class SparkEnvIT extends SparkUtilIT {
             .config("spark.plugins", GravitinoSparkPlugin.class.getName())
             .config(GravitinoSparkConfig.GRAVITINO_URI, gravitinoUri)
             .config(GravitinoSparkConfig.GRAVITINO_METALAKE, metalakeName)
+            .config("hive.exec.dynamic.partition.mode", "nonstrict")
             .config(
                 "spark.sql.warehouse.dir",
                 String.format(

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/spark/SparkUtilIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/spark/SparkUtilIT.java
@@ -131,6 +131,14 @@ public abstract class SparkUtilIT extends AbstractIT {
     }
   }
 
+  protected void createTableAsSelect(String tableName, String newName) {
+    sql(String.format("CREATE TABLE %s AS SELECT * FROM %s", newName, tableName));
+  }
+
+  protected void insertTableAsSelect(String tableName, String newName) {
+    sql(String.format("INSERT INTO TABLE %s SELECT * FROM %s", newName, tableName));
+  }
+
   private static String getSelectAllSql(String tableName) {
     return String.format("SELECT * FROM %s", tableName);
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
add integrate test for `create table as select xx` and `insert table select xx`

### Why are the changes needed?
Fix: #2402 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
IT
