### PR TITLE
#2671 fix: exclude pytest_cache from rat test

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -517,7 +517,8 @@ tasks.rat {
     "web/package-lock.json",
     "web/pnpm-lock.yaml",
     "**/LICENSE.*",
-    "**/NOTICE.*"
+    "**/NOTICE.*",
+    "clients/client-python/.pytest_cache/*"
   )
 
   // Add .gitignore excludes to the Apache Rat exclusion list.


### PR DESCRIPTION

### What changes were proposed in this pull request?

Exclude a hidden folder from gradle rat test.

### Why are the changes needed?

It will make the gradle build failed in local, once the user run pytest for the python client.

Fix: # 2671

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

After applying the patch, gradle build will success after running pytest.
