### PR TITLE
[#2480][#2698]feat(web): add metalake select to the right-up corner

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
@@ -169,7 +169,6 @@ public class CatalogsPageTest extends AbstractWebIT {
     Assertions.assertTrue(catalogsPage.verifyEmptyCatalog());
   }
 
-
   @Test
   @Order(11)
   public void testBackHomePage() throws InterruptedException {

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
@@ -28,6 +28,7 @@ public class CatalogsPageTest extends AbstractWebIT {
   CatalogsPage catalogsPage = new CatalogsPage();
 
   private static final String metalakeName = "metalake_name";
+  private static final String metalakeSelectName = "metalake_select_name";
   String catalogName = "catalog_name";
   String modifiedCatalogName = catalogName + "_edited";
   String schemaName = "default";
@@ -63,6 +64,12 @@ public class CatalogsPageTest extends AbstractWebIT {
     clickAndWait(metalakePage.createMetalakeBtn);
     metalakePage.setMetalakeNameField(metalakeName);
     clickAndWait(metalakePage.submitHandleMetalakeBtn);
+
+    // Create another metalake for select option
+    clickAndWait(metalakePage.createMetalakeBtn);
+    metalakePage.setMetalakeNameField(metalakeSelectName);
+    clickAndWait(metalakePage.submitHandleMetalakeBtn);
+
     metalakePage.clickMetalakeLink(metalakeName);
     // Create catalog
     clickAndWait(catalogsPage.createCatalogBtn);
@@ -145,6 +152,16 @@ public class CatalogsPageTest extends AbstractWebIT {
 
   @Test
   @Order(9)
+  public void testSelectMetalake() throws InterruptedException {
+    catalogsPage.metalakeSelectChange(metalakeSelectName);
+    Assertions.assertTrue(catalogsPage.verifyEmptyCatalog());
+
+    catalogsPage.metalakeSelectChange(metalakeName);
+    Assertions.assertTrue(catalogsPage.verifyCreateHiveCatalog(modifiedCatalogName));
+  }
+
+  @Test
+  @Order(10)
   public void testDeleteCatalog() throws InterruptedException {
     catalogsPage.clickBreadCrumbsToCatalogs();
     catalogsPage.clickDeleteCatalogBtn(modifiedCatalogName);
@@ -152,8 +169,9 @@ public class CatalogsPageTest extends AbstractWebIT {
     Assertions.assertTrue(catalogsPage.verifyEmptyCatalog());
   }
 
+
   @Test
-  @Order(10)
+  @Order(11)
   public void testBackHomePage() throws InterruptedException {
     clickAndWait(catalogsPage.backHomeBtn);
     Assertions.assertTrue(catalogsPage.verifyBackHomePage());

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
@@ -23,6 +23,9 @@ public class CatalogsPage extends AbstractWebIT {
   @FindBy(xpath = "//*[@data-refer='back-home-btn']")
   public WebElement backHomeBtn;
 
+  @FindBy(xpath = "//*[@data-refer='select-metalake']")
+  public WebElement metalakeSelect;
+
   @FindBy(xpath = "//div[@data-refer='table-grid']")
   public WebElement tableGrid;
 
@@ -88,6 +91,17 @@ public class CatalogsPage extends AbstractWebIT {
 
   public CatalogsPage() {
     PageFactory.initElements(driver, this);
+  }
+
+  public void metalakeSelectChange(String metalakeName) {
+    try {
+      clickAndWait(metalakeSelect);
+      String keyPath = "//li[@data-refer='select-option-" + metalakeName + "']";
+      WebElement selectOption = driver.findElement(By.xpath(keyPath));
+      clickAndWait(selectOption);
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+    }
   }
 
   public void setCatalogNameField(String nameField) {

--- a/web/src/app/rootLayout/AppBar.js
+++ b/web/src/app/rootLayout/AppBar.js
@@ -8,12 +8,29 @@
 import Link from 'next/link'
 import Image from 'next/image'
 
-import { Box, AppBar as MuiAppBar, Toolbar, Stack, Typography } from '@mui/material'
+import { Box, AppBar as MuiAppBar, Toolbar, Stack, Typography, FormControl, InputLabel, Select, MenuItem } from '@mui/material'
 
 import VersionView from './VersionView'
 import LogoutButton from './Logout'
+import { useSearchParams } from 'next/navigation'
+import { useRouter } from 'next/navigation'
+import { useAppSelector } from '@/lib/hooks/useStore'
+
+import { useState, useEffect } from 'react'
 
 const AppBar = () => {
+  const searchParams = useSearchParams()
+  const metalake = searchParams.get('metalake')
+  const store = useAppSelector(state => state.metalakes)
+  const [metalakes, setMetalakes] = useState([])
+  const router = useRouter()
+
+  useEffect(() => {
+    const metalakeItems = store.metalakes
+      .map(i => i.name)
+    setMetalakes(metalakeItems)
+  }, [store.metalakes])
+
   return (
     <MuiAppBar
       elevation={6}
@@ -43,6 +60,22 @@ const AppBar = () => {
             </Link>
             <Box className={'app-bar-content-right twc-flex twc-items-center'}>
               <Stack direction='row' spacing={2} alignItems='center'>
+                {metalake ? (<FormControl fullWidth size="small">
+                  <InputLabel id='select-metalake'>Metalake</InputLabel>
+                  <Select
+                    labelId='select-metalake'
+                    id='select-metalake'
+                    data-refer='select-metalake'
+                    value={metalake}
+                    label='Metalake'
+                  >
+                    {metalakes.map((item) => {
+                      return (
+                        <MenuItem value={item} key={item} onClick={() => router.push('/metalakes?metalake=' + item)}>{item}</MenuItem>
+                      )
+                    })}
+                  </Select>
+                </FormControl>): null}
                 <VersionView />
                 <LogoutButton />
               </Stack>

--- a/web/src/app/rootLayout/AppBar.js
+++ b/web/src/app/rootLayout/AppBar.js
@@ -8,7 +8,17 @@
 import Link from 'next/link'
 import Image from 'next/image'
 
-import { Box, AppBar as MuiAppBar, Toolbar, Stack, Typography, FormControl, InputLabel, Select, MenuItem } from '@mui/material'
+import {
+  Box,
+  AppBar as MuiAppBar,
+  Toolbar,
+  Stack,
+  Typography,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem
+} from '@mui/material'
 
 import VersionView from './VersionView'
 import LogoutButton from './Logout'
@@ -26,8 +36,7 @@ const AppBar = () => {
   const router = useRouter()
 
   useEffect(() => {
-    const metalakeItems = store.metalakes
-      .map(i => i.name)
+    const metalakeItems = store.metalakes.map(i => i.name)
     setMetalakes(metalakeItems)
   }, [store.metalakes])
 
@@ -60,22 +69,26 @@ const AppBar = () => {
             </Link>
             <Box className={'app-bar-content-right twc-flex twc-items-center'}>
               <Stack direction='row' spacing={2} alignItems='center'>
-                {metalake ? (<FormControl fullWidth size="small">
-                  <InputLabel id='select-metalake'>Metalake</InputLabel>
-                  <Select
-                    labelId='select-metalake'
-                    id='select-metalake'
-                    data-refer='select-metalake'
-                    value={metalake}
-                    label='Metalake'
-                  >
-                    {metalakes.map((item) => {
-                      return (
-                        <MenuItem value={item} key={item} onClick={() => router.push('/metalakes?metalake=' + item)}>{item}</MenuItem>
-                      )
-                    })}
-                  </Select>
-                </FormControl>): null}
+                {metalake ? (
+                  <FormControl fullWidth size='small'>
+                    <InputLabel id='select-metalake'>Metalake</InputLabel>
+                    <Select
+                      labelId='select-metalake'
+                      id='select-metalake'
+                      data-refer='select-metalake'
+                      value={metalake}
+                      label='Metalake'
+                    >
+                      {metalakes.map(item => {
+                        return (
+                          <MenuItem value={item} key={item} onClick={() => router.push('/metalakes?metalake=' + item)}>
+                            {item}
+                          </MenuItem>
+                        )
+                      })}
+                    </Select>
+                  </FormControl>
+                ) : null}
                 <VersionView />
                 <LogoutButton />
               </Stack>

--- a/web/src/app/rootLayout/AppBar.js
+++ b/web/src/app/rootLayout/AppBar.js
@@ -24,7 +24,8 @@ import VersionView from './VersionView'
 import LogoutButton from './Logout'
 import { useSearchParams } from 'next/navigation'
 import { useRouter } from 'next/navigation'
-import { useAppSelector } from '@/lib/hooks/useStore'
+import { useAppSelector, useAppDispatch } from '@/lib/hooks/useStore'
+import { fetchMetalakes } from '@/lib/store/metalakes'
 
 import { useState, useEffect } from 'react'
 
@@ -32,10 +33,14 @@ const AppBar = () => {
   const searchParams = useSearchParams()
   const metalake = searchParams.get('metalake')
   const store = useAppSelector(state => state.metalakes)
+  const dispatch = useAppDispatch()
   const [metalakes, setMetalakes] = useState([])
   const router = useRouter()
 
   useEffect(() => {
+    if (!store.metalakes.length) {
+      dispatch(fetchMetalakes())
+    }
     const metalakeItems = store.metalakes.map(i => i.name)
     setMetalakes(metalakeItems)
   }, [store.metalakes])
@@ -81,7 +86,12 @@ const AppBar = () => {
                     >
                       {metalakes.map(item => {
                         return (
-                          <MenuItem value={item} key={item} onClick={() => router.push('/metalakes?metalake=' + item)}>
+                          <MenuItem
+                            value={item}
+                            key={item}
+                            data-refer={'select-option-' + item}
+                            onClick={() => router.push('/metalakes?metalake=' + item)}
+                          >
                             {item}
                           </MenuItem>
                         )

--- a/web/src/app/rootLayout/VersionView.js
+++ b/web/src/app/rootLayout/VersionView.js
@@ -12,7 +12,7 @@ const VersionView = () => {
   const store = useAppSelector(state => state.sys)
 
   return (
-    <Typography variant='subtitle2' id='gravitino_version' sx={{ width: 200 }}>
+    <Typography variant='subtitle2' id='gravitino_version' className={'twc-flex twc-justify-end'} sx={{ width: 200 }}>
       {store.version}
     </Typography>
   )

--- a/web/src/app/rootLayout/VersionView.js
+++ b/web/src/app/rootLayout/VersionView.js
@@ -12,7 +12,7 @@ const VersionView = () => {
   const store = useAppSelector(state => state.sys)
 
   return (
-    <Typography variant='subtitle2' id='gravitino_version'>
+    <Typography variant='subtitle2' id='gravitino_version' sx={{ width: 200 }}>
       {store.version}
     </Typography>
   )

--- a/web/src/lib/store/metalakes/index.js
+++ b/web/src/lib/store/metalakes/index.js
@@ -176,6 +176,7 @@ export const fetchCatalogs = createAsyncThunk(
   'appMetalakes/fetchCatalogs',
   async ({ init, update, page, metalake }, { getState, dispatch }) => {
     if (init) {
+      dispatch(resetTree())
       dispatch(resetTableData())
       dispatch(setTableLoading(true))
     }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Add  the metalake selection/dropdown to the right-up corner, see the picture below. 
![metalake](https://github.com/datastrato/gravitino/assets/9210625/e4c3a51c-a8b6-473b-bbf7-e29f3389a029)


### Why are the changes needed?

Now the entry page is clearer for the user, he can quickly start with the catalog. Only when he wants to edit, switch metalake, can he easily find that in the right-up corner.

Fix: #2480, #2698

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?
run the e2e test local
![metalake_e2e](https://github.com/datastrato/gravitino/assets/9210625/76b4e9b3-375d-4eab-a293-8c44cd070995)


