### PR TITLE
[#2706] improvement(core): Enables isolated class loaders to be cleaned

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/CatalogManager.java
@@ -137,6 +137,8 @@ public class CatalogManager implements SupportsCatalogs, Closeable {
       }
 
       classLoader.close();
+      // Let GC can collect the class loader.
+      classLoader = null;
     }
 
     private SupportsSchemas asSchemas() {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Set the class loaders to null explicitly , making them collective. 

### Why are the changes needed?

We need to assure GC can collect them, or OOM may happens.

Fix: #2706 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

![image](https://github.com/datastrato/gravitino/assets/15794564/784cf521-acd8-4ecf-ab23-c6a81ce783a7)

