### PR TITLE
[#2719] fix(python):  Fix the problem about getting `python` version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -521,7 +521,8 @@ tasks.rat {
     "web/pnpm-lock.yaml",
     "**/LICENSE.*",
     "**/NOTICE.*",
-    "clients/client-python/.pytest_cache/*"
+    "clients/client-python/.pytest_cache/*",
+    ".pytest_cache/*"
   )
 
   // Add .gitignore excludes to the Apache Rat exclusion list.

--- a/clients/client-python/build.gradle.kts
+++ b/clients/client-python/build.gradle.kts
@@ -3,28 +3,70 @@
  * This software is licensed under the Apache License version 2.
  */
 
+import org.gradle.internal.os.OperatingSystem
+import java.io.IOException
+
 tasks.withType(Exec::class) {
   workingDir = file("${project.projectDir}")
 }
 
+val os = OperatingSystem.current()
+val pythonExecutable = if (os.isWindows) {
+  if (execOrNull("where python") != null) {
+    "python"
+  } else if (execOrNull("where python3") != null) {
+    "python3"
+  } else {
+    throw IllegalStateException("Python not found, please install it first...")
+  }
+} else {
+  if (execOrNull("which python") != null) {
+    "python"
+  } else if (execOrNull("which python3") != null) {
+    "python3"
+  } else {
+    throw IllegalStateException("Python not found, please install it first...")
+  }
+}
+println(": $pythonExecutable")
+
+fun execOrNull(command: String): String? {
+  return try {
+    val parts = command.split("\\s".toRegex())
+    val proc = ProcessBuilder(*parts.toTypedArray())
+      .redirectOutput(ProcessBuilder.Redirect.PIPE)
+      .redirectError(ProcessBuilder.Redirect.PIPE)
+      .start()
+
+    proc.waitFor(1, TimeUnit.MINUTES)
+    if (proc.exitValue() != 0) {
+      null
+    } else {
+      proc.inputStream.bufferedReader().readText().trim()
+    }
+  } catch (e: IOException) {
+    null
+  }
+}
+
 tasks {
   val pythonVersion by registering(Exec::class) {
-    commandLine("python", "--version")
+    commandLine("bash", "-c", "$pythonExecutable --version")
   }
 
   val installPip by registering(Exec::class) {
     dependsOn(pythonVersion)
-    commandLine("python", "-m", "pip", "install", "--upgrade", "pip")
+    commandLine("bash", "-c", "$pythonExecutable -m pip install --upgrade pip")
   }
 
   val installDeps by registering(Exec::class) {
     dependsOn(installPip)
-    commandLine("python", "-m", "pip", "install", "-r", "requirements.txt")
+    commandLine("bash", "-c", "$pythonExecutable -m pip install -r requirements.txt")
   }
 
   val pyTest by registering(Exec::class) {
     dependsOn(installDeps)
-    commandLine("pytest", "${project.projectDir}/tests")
+    commandLine("bash", "-c", "$pythonExecutable -m pytest ${project.projectDir}/tests")
   }
 
   test {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Modify the mechanism to check for python commands and support `python` and `python3`

### Why are the changes needed?

By default, MacOs install Python3. We should remove the requirement for users to manually install Python. 

Fix: #2719

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Existing test.
