### PR TITLE
[#2647] improvement(server): use read lock in list api

### DIFF
--- a/server/src/main/java/com/datastrato/gravitino/server/web/rest/CatalogOperations.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/rest/CatalogOperations.java
@@ -67,7 +67,7 @@ public class CatalogOperations {
             // Lock the root and the metalake with WRITE lock to ensure the consistency of the list.
             return TreeLockUtils.doWithTreeLock(
                 NameIdentifier.of(metalake),
-                LockType.WRITE,
+                LockType.READ,
                 () -> {
                   if (verbose) {
                     Catalog[] catalogs = manager.listCatalogsInfo(catalogNS);
@@ -95,7 +95,7 @@ public class CatalogOperations {
             NameIdentifier ident = NameIdentifier.ofCatalog(metalake, request.getName());
             Catalog catalog =
                 TreeLockUtils.doWithTreeLock(
-                    ident,
+                    NameIdentifier.ofMetalake(metalake),
                     LockType.WRITE,
                     () ->
                         manager.createCatalog(
@@ -149,7 +149,9 @@ public class CatalogOperations {
                     .toArray(CatalogChange[]::new);
             Catalog catalog =
                 TreeLockUtils.doWithTreeLock(
-                    ident, LockType.WRITE, () -> manager.alterCatalog(ident, changes));
+                    NameIdentifier.ofMetalake(metalakeName),
+                    LockType.WRITE,
+                    () -> manager.alterCatalog(ident, changes));
             return Utils.ok(new CatalogResponse(DTOConverters.toDTO(catalog)));
           });
 
@@ -171,7 +173,9 @@ public class CatalogOperations {
             NameIdentifier ident = NameIdentifier.ofCatalog(metalakeName, catalogName);
             boolean dropped =
                 TreeLockUtils.doWithTreeLock(
-                    ident, LockType.WRITE, () -> manager.dropCatalog(ident));
+                    NameIdentifier.ofMetalake(metalakeName),
+                    LockType.WRITE,
+                    () -> manager.dropCatalog(ident));
             if (!dropped) {
               LOG.warn("Failed to drop catalog {} under metalake {}", catalogName, metalakeName);
             }

--- a/server/src/main/java/com/datastrato/gravitino/server/web/rest/FilesetOperations.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/rest/FilesetOperations.java
@@ -67,7 +67,7 @@ public class FilesetOperations {
             NameIdentifier[] idents =
                 TreeLockUtils.doWithTreeLock(
                     NameIdentifier.of(metalake, catalog, schema),
-                    LockType.WRITE,
+                    LockType.READ,
                     () -> dispatcher.listFilesets(filesetNS));
             return Utils.ok(new EntityListResponse(idents));
           });
@@ -96,7 +96,7 @@ public class FilesetOperations {
 
             Fileset fileset =
                 TreeLockUtils.doWithTreeLock(
-                    ident,
+                    NameIdentifier.ofSchema(metalake, catalog, schema),
                     LockType.WRITE,
                     () ->
                         dispatcher.createFileset(
@@ -162,7 +162,9 @@ public class FilesetOperations {
                     .toArray(FilesetChange[]::new);
             Fileset t =
                 TreeLockUtils.doWithTreeLock(
-                    ident, LockType.WRITE, () -> dispatcher.alterFileset(ident, changes));
+                    NameIdentifier.ofSchema(metalake, catalog, schema),
+                    LockType.WRITE,
+                    () -> dispatcher.alterFileset(ident, changes));
             return Utils.ok(new FilesetResponse(DTOConverters.toDTO(t)));
           });
 
@@ -188,7 +190,9 @@ public class FilesetOperations {
             NameIdentifier ident = NameIdentifier.ofFileset(metalake, catalog, schema, fileset);
             boolean dropped =
                 TreeLockUtils.doWithTreeLock(
-                    ident, LockType.WRITE, () -> dispatcher.dropFileset(ident));
+                    NameIdentifier.ofSchema(metalake, catalog, schema),
+                    LockType.WRITE,
+                    () -> dispatcher.dropFileset(ident));
             if (!dropped) {
               LOG.warn("Failed to drop fileset {} under schema {}", fileset, schema);
             }

--- a/server/src/main/java/com/datastrato/gravitino/server/web/rest/MetalakeOperations.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/rest/MetalakeOperations.java
@@ -66,7 +66,7 @@ public class MetalakeOperations {
           httpRequest,
           () -> {
             BaseMetalake[] metalakes =
-                TreeLockUtils.doWithRootTreeLock(LockType.WRITE, manager::listMetalakes);
+                TreeLockUtils.doWithRootTreeLock(LockType.READ, manager::listMetalakes);
             MetalakeDTO[] metalakeDTOS =
                 Arrays.stream(metalakes).map(DTOConverters::toDTO).toArray(MetalakeDTO[]::new);
             return Utils.ok(new MetalakeListResponse(metalakeDTOS));
@@ -90,8 +90,7 @@ public class MetalakeOperations {
             request.validate();
             NameIdentifier ident = NameIdentifier.ofMetalake(request.getName());
             BaseMetalake metalake =
-                TreeLockUtils.doWithTreeLock(
-                    ident,
+                TreeLockUtils.doWithRootTreeLock(
                     LockType.WRITE,
                     () ->
                         manager.createMetalake(
@@ -144,8 +143,8 @@ public class MetalakeOperations {
                     .map(MetalakeUpdateRequest::metalakeChange)
                     .toArray(MetalakeChange[]::new);
             BaseMetalake updatedMetalake =
-                TreeLockUtils.doWithTreeLock(
-                    identifier, LockType.WRITE, () -> manager.alterMetalake(identifier, changes));
+                TreeLockUtils.doWithRootTreeLock(
+                    LockType.WRITE, () -> manager.alterMetalake(identifier, changes));
             return Utils.ok(new MetalakeResponse(DTOConverters.toDTO(updatedMetalake)));
           });
 
@@ -166,8 +165,8 @@ public class MetalakeOperations {
           () -> {
             NameIdentifier identifier = NameIdentifier.ofMetalake(metalakeName);
             boolean dropped =
-                TreeLockUtils.doWithTreeLock(
-                    identifier, LockType.WRITE, () -> manager.dropMetalake(identifier));
+                TreeLockUtils.doWithRootTreeLock(
+                    LockType.WRITE, () -> manager.dropMetalake(identifier));
             if (!dropped) {
               LOG.warn("Failed to drop metalake by name {}", metalakeName);
             }

--- a/server/src/main/java/com/datastrato/gravitino/server/web/rest/SchemaOperations.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/rest/SchemaOperations.java
@@ -70,7 +70,7 @@ public class SchemaOperations {
             NameIdentifier[] idents =
                 TreeLockUtils.doWithTreeLock(
                     NameIdentifier.of(metalake, catalog),
-                    LockType.WRITE,
+                    LockType.READ,
                     () -> dispatcher.listSchemas(schemaNS));
             return Utils.ok(new EntityListResponse(idents));
           });
@@ -95,7 +95,7 @@ public class SchemaOperations {
             NameIdentifier ident = NameIdentifier.ofSchema(metalake, catalog, request.getName());
             Schema schema =
                 TreeLockUtils.doWithTreeLock(
-                    ident,
+                    NameIdentifier.ofCatalog(metalake, catalog),
                     LockType.WRITE,
                     () ->
                         dispatcher.createSchema(
@@ -156,7 +156,9 @@ public class SchemaOperations {
                     .toArray(SchemaChange[]::new);
             Schema s =
                 TreeLockUtils.doWithTreeLock(
-                    ident, LockType.WRITE, () -> dispatcher.alterSchema(ident, changes));
+                    NameIdentifier.ofCatalog(metalake, catalog),
+                    LockType.WRITE,
+                    () -> dispatcher.alterSchema(ident, changes));
             return Utils.ok(new SchemaResponse(DTOConverters.toDTO(s)));
           });
 
@@ -182,7 +184,9 @@ public class SchemaOperations {
             NameIdentifier ident = NameIdentifier.ofSchema(metalake, catalog, schema);
             boolean dropped =
                 TreeLockUtils.doWithTreeLock(
-                    ident, LockType.WRITE, () -> dispatcher.dropSchema(ident, cascade));
+                    NameIdentifier.ofCatalog(metalake, catalog),
+                    LockType.WRITE,
+                    () -> dispatcher.dropSchema(ident, cascade));
             if (!dropped) {
               LOG.warn("Fail to drop schema {} under namespace {}", schema, ident.namespace());
             }

--- a/server/src/main/java/com/datastrato/gravitino/server/web/rest/TableOperations.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/rest/TableOperations.java
@@ -71,7 +71,7 @@ public class TableOperations {
             NameIdentifier[] idents =
                 TreeLockUtils.doWithTreeLock(
                     NameIdentifier.of(metalake, catalog, schema),
-                    LockType.WRITE,
+                    LockType.READ,
                     () -> dispatcher.listTables(tableNS));
             return Utils.ok(new EntityListResponse(idents));
           });
@@ -100,7 +100,7 @@ public class TableOperations {
 
             Table table =
                 TreeLockUtils.doWithTreeLock(
-                    ident,
+                    NameIdentifier.of(metalake, catalog, schema),
                     LockType.WRITE,
                     () ->
                         dispatcher.createTable(
@@ -169,7 +169,9 @@ public class TableOperations {
                     .toArray(TableChange[]::new);
             Table t =
                 TreeLockUtils.doWithTreeLock(
-                    ident, LockType.WRITE, () -> dispatcher.alterTable(ident, changes));
+                    NameIdentifier.of(metalake, catalog, schema),
+                    LockType.WRITE,
+                    () -> dispatcher.alterTable(ident, changes));
             return Utils.ok(new TableResponse(DTOConverters.toDTO(t)));
           });
 
@@ -196,7 +198,7 @@ public class TableOperations {
             NameIdentifier ident = NameIdentifier.ofTable(metalake, catalog, schema, table);
             boolean dropped =
                 TreeLockUtils.doWithTreeLock(
-                    ident,
+                    NameIdentifier.of(metalake, catalog, schema),
                     LockType.WRITE,
                     () -> purge ? dispatcher.purgeTable(ident) : dispatcher.dropTable(ident));
             if (!dropped) {

--- a/server/src/main/java/com/datastrato/gravitino/server/web/rest/TopicOperations.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/rest/TopicOperations.java
@@ -65,7 +65,7 @@ public class TopicOperations {
             NameIdentifier[] topics =
                 TreeLockUtils.doWithTreeLock(
                     NameIdentifier.of(metalake, catalog, schema),
-                    LockType.WRITE,
+                    LockType.READ,
                     () -> dispatcher.listTopics(topicNS));
             return Utils.ok(new EntityListResponse(topics));
           });
@@ -99,7 +99,7 @@ public class TopicOperations {
 
             Topic topic =
                 TreeLockUtils.doWithTreeLock(
-                    ident,
+                    NameIdentifier.ofSchema(metalake, catalog, schema),
                     LockType.WRITE,
                     () ->
                         dispatcher.createTopic(
@@ -166,7 +166,9 @@ public class TopicOperations {
 
             Topic t =
                 TreeLockUtils.doWithTreeLock(
-                    ident, LockType.WRITE, () -> dispatcher.alterTopic(ident, changes));
+                    NameIdentifier.ofSchema(metalake, catalog, schema),
+                    LockType.WRITE,
+                    () -> dispatcher.alterTopic(ident, changes));
             return Utils.ok(new TopicResponse(DTOConverters.toDTO(t)));
           });
     } catch (Exception e) {
@@ -192,7 +194,9 @@ public class TopicOperations {
             NameIdentifier ident = NameIdentifier.ofTopic(metalake, catalog, schema, topic);
             boolean dropped =
                 TreeLockUtils.doWithTreeLock(
-                    ident, LockType.WRITE, () -> dispatcher.dropTopic(ident));
+                    NameIdentifier.ofSchema(metalake, catalog, schema),
+                    LockType.WRITE,
+                    () -> dispatcher.dropTopic(ident));
 
             if (!dropped) {
               LOG.warn("Failed to drop topic {} under schema {}", topic, schema);


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Change lock method in metalake/catalog/schema/table/fileset opertaions.
Use solution 1 in #2260 

```
list -> parent read lock
create -> parent write lock
load -> itself read lock
alter -> parent write lock
drop -> parent write lock
```

### Why are the changes needed?

Applicable to scenarios where list requests are more frequent than create/update requests

Fix: #2647

### Does this PR introduce _any_ user-facing change?

Nothing

### How was this patch tested?

test detail in https://docs.google.com/document/d/1GPynb8SbxcIU2s6h3W-mPqeRVqmv0ac9_rBJm63awqs/edit#heading=h.v6mlybfhntc
