### PR TITLE
[#2598] Fix: Fix HDFS IP resolution for Docker Desktop

### DIFF
--- a/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
+++ b/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
@@ -111,6 +111,7 @@ public class ContainerSuite implements Closeable {
             .withExtraHosts(
                 ImmutableMap.<String, String>builder()
                     .put("host.docker.internal", "host-gateway")
+                    .put("gravitino-ci-hive", hiveContainerIp)
                     .build())
             .withFilesToMount(
                 ImmutableMap.<String, String>builder()

--- a/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
+++ b/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
@@ -111,7 +111,7 @@ public class ContainerSuite implements Closeable {
             .withExtraHosts(
                 ImmutableMap.<String, String>builder()
                     .put("host.docker.internal", "host-gateway")
-                    .put("gravitino-ci-hive", hiveContainerIp)
+                    .put(HiveContainer.HOST_NAME, hiveContainerIp)
                     .build())
             .withFilesToMount(
                 ImmutableMap.<String, String>builder()


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix HDFS client IP address resolution when using Docker Desktop. Originally it may resolve to invalid domain name causing error.

### Why are the changes needed?
Fix: #2598

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.

