### PR TITLE
[#2737] fix(catalog-jdbc-mysql): MySqlColumnDefaultValueConverter DATE conversion failed.

### DIFF
--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/converter/JdbcColumnDefaultValueConverter.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/converter/JdbcColumnDefaultValueConverter.java
@@ -19,6 +19,8 @@ public class JdbcColumnDefaultValueConverter {
   protected static final String NULL = "NULL";
   protected static final DateTimeFormatter DATE_TIME_FORMATTER =
       DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+  protected static final DateTimeFormatter DATE_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
   public String fromGravitino(Expression defaultValue) {
     if (DEFAULT_VALUE_NOT_SET.equals(defaultValue)) {

--- a/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/converter/MysqlColumnDefaultValueConverter.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/converter/MysqlColumnDefaultValueConverter.java
@@ -77,7 +77,7 @@ public class MysqlColumnDefaultValueConverter extends JdbcColumnDefaultValueConv
                 Integer.parseInt(type.getColumnSize()),
                 Integer.parseInt(type.getScale())));
       case DATE:
-        return Literals.dateLiteral(LocalDate.parse(columnDefaultValue, DATE_TIME_FORMATTER));
+        return Literals.dateLiteral(LocalDate.parse(columnDefaultValue, DATE_FORMATTER));
       case TIME:
         return Literals.timeLiteral(LocalTime.parse(columnDefaultValue, DATE_TIME_FORMATTER));
       case TIMESTAMP:

--- a/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
@@ -464,6 +464,7 @@ public class CatalogMysqlIT extends AbstractIT {
             + "  date_col_2 date,\n"
             + "  date_col_3 date DEFAULT (CURRENT_DATE + INTERVAL 1 YEAR),\n"
             + "  date_col_4 date DEFAULT (CURRENT_DATE),\n"
+            + "  date_col_5 date DEFAULT '2024-04-01',\n"
             + "  timestamp_col_1 timestamp default '2012-12-31 11:30:45',\n"
             + "  timestamp_col_2 timestamp default 19830905,\n"
             + "  decimal_6_2_col_1 decimal(6, 2) default 1.2\n"
@@ -517,6 +518,10 @@ public class CatalogMysqlIT extends AbstractIT {
           break;
         case "date_col_4":
           Assertions.assertEquals(UnparsedExpression.of("curdate()"), column.defaultValue());
+          break;
+        case "date_col_5":
+          Assertions.assertEquals(
+              Literals.of("2024-04-01", Types.DateType.get()), column.defaultValue());
           break;
         case "timestamp_col_1":
           Assertions.assertEquals(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix a bug for a Date string as column default value in MySqlColumnDefaultValueConverter

### Why are the changes needed?
Use date pattern for such a date type value.

Fix: #2737

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
UT covered, which is added by charliecheng630