### PR TITLE
[#1488]: fix(CI): make jacoco report work properly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,11 +93,16 @@ jobs:
           path:
             build/reports
 
+      - name: Get Jacoco report paths
+        id: jacoco-paths
+        run: |
+          paths=$(find ${{ github.workspace }} -name jacocoTestReport.xml | tr '\n' ',')
+          echo "paths=$paths" >> "$GITHUB_OUTPUT"
       - name: Jacoco Report to PR
         id: jacoco
         uses: madrapps/jacoco-report@v1.6.1
         with:
-          paths: ${{ github.workspace }}/**/build/reports/jacoco/test/jacocoTestReport.xml
+          paths: ${{ steps.jacoco-paths.outputs.paths }}
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 40
           min-coverage-changed-files: 60

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,10 @@ jobs:
     timeout-minutes: 30
     needs: changes
     if: needs.changes.outputs.source_changes == 'true'
+    permissions:
+      packages: read
+      contents: read
+      pull-requests: write
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/integration-test-common/build.gradle.kts
+++ b/integration-test-common/build.gradle.kts
@@ -36,7 +36,12 @@ dependencies {
 }
 
 tasks.test {
-  useJUnitPlatform()
+  val skipITs = project.hasProperty("skipITs")
+  if (skipITs) {
+    exclude("**/integration/test/**")
+  } else {
+    useJUnitPlatform()
+  }
 }
 
 val testJar by tasks.registering(Jar::class) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Skip tests in integration-test-common if `-PskipITs` is passed
2. Use proper jacoco report paths
3. Add pull-requests write permissions in workflow

### Why are the changes needed?

1. Refer to https://github.com/datastrato/gravitino/issues/1488#issuecomment-2027228429
2. The reports didn't include the submodules, like `catalogs/catalog-jdbc-postgresql`, `clients/client-java`, etc. 
3. If the write permission is not enable, it will get error msg `Error: HttpError: Resource not accessible by integration`

Fix: #1488

### Does this PR introduce _any_ user-facing change?
N/A
### How was this patch tested?
N/A