### PR TITLE
[#2748] fix(CI): free up disk space, because doris container need more than 16GB disk …

### DIFF
--- a/.github/workflows/cron-integration-test.yml
+++ b/.github/workflows/cron-integration-test.yml
@@ -49,7 +49,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.source_changes == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       matrix:
         architecture: [linux/amd64]
@@ -77,6 +77,10 @@ jobs:
       - name: Setup debug Github Action
         if: ${{ contains(github.event.pull_request.labels.*.name, 'debug action') }}
         uses: csexton/debugger-action@master
+
+      - name: Free up disk space
+        run: |
+          dev/ci/util_free_space.sh
 
       - name: Integration Test
         id: integrationTest


### PR DESCRIPTION
### What changes were proposed in this pull request?

Free up disk space

### Why are the changes needed?

Because doris container need more than 16GB disk size

Fix: #2731 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

CI