### PR TITLE
[#2614] improve(web): Add web UI support for Kafka catalog

### DIFF
--- a/web/src/app/metalakes/metalake/rightContent/CreateCatalogDialog.js
+++ b/web/src/app/metalakes/metalake/rightContent/CreateCatalogDialog.js
@@ -36,7 +36,7 @@ import { yupResolver } from '@hookform/resolvers/yup'
 
 import { groupBy } from 'lodash-es'
 import { genUpdates } from '@/lib/utils'
-import { providers } from '@/lib/utils/initial'
+import { types, providers } from '@/lib/utils/initial'
 import { nameRegex, keyRegex } from '@/lib/utils/regex'
 import { useSearchParams } from 'next/navigation'
 
@@ -58,7 +58,7 @@ const schema = yup.object().shape({
       nameRegex,
       'This field must start with a letter or underscore, and can only contain letters, numbers, and underscores'
     ),
-  type: yup.mixed().oneOf(['relational', 'fileset']).required(),
+  type: yup.mixed().oneOf(types).required(),
   provider: yup.mixed().oneOf(providerTypeValues).required(),
   propItems: yup.array().of(
     yup.object().shape({
@@ -287,6 +287,9 @@ const CreateCatalogDialog = props => {
     if (typeSelect === 'fileset') {
       setProviderTypes(providers.filter(p => p.value === 'hadoop'))
       setValue('provider', 'hadoop')
+    } else if (typeSelect === 'messaging') {
+      setProviderTypes(providers.filter(p => p.value === 'kafka'))
+      setValue('provider', 'kafka')
     } else {
       setProviderTypes(providers.filter(p => p.value !== 'hadoop'))
       setValue('provider', 'hive')
@@ -424,8 +427,13 @@ const CreateCatalogDialog = props => {
                       labelId='select-catalog-type'
                       disabled={type === 'update'}
                     >
-                      <MenuItem value={'relational'}>relational</MenuItem>
-                      <MenuItem value={'fileset'}>fileset</MenuItem>
+                      {types.map((item, index) => {
+                        return (
+                          <MenuItem key={item} value={item}>
+                            {item}
+                          </MenuItem>
+                        )
+                      })}
                     </Select>
                   )}
                 />

--- a/web/src/lib/utils/initial.js
+++ b/web/src/lib/utils/initial.js
@@ -3,7 +3,21 @@
  * This software is licensed under the Apache License version 2.
  */
 
+export const types = ['relational', 'fileset', 'messaging']
+
 export const providers = [
+  {
+    label: 'kafka',
+    value: 'kafka',
+    defaultProps: [
+      {
+        key: 'boostrap.servers',
+        value: '',
+        required: true,
+        description: 'The Kafka broker(s) to connect to, allowing for multiple brokers by comma-separating them'
+      }
+    ]
+  },
   {
     label: 'hadoop',
     value: 'hadoop',


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a new catalog `type` is `messaging` with the `provider` set as `kafka`.

<img width="597" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/ae3506ee-7e53-4332-8734-edcb5872dcfd">


### Why are the changes needed?

Fix: #2614

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
