### PR TITLE
[#2750]improve(doc): Split the metadata managing doc into several ones

### DIFF
--- a/docs/apache-hive-catalog.md
+++ b/docs/apache-hive-catalog.md
@@ -42,7 +42,7 @@ The Hive catalog supports creating, updating, and deleting databases and tables 
 
 ### Catalog operations
 
-Refer to [Manage Metadata Using Gravitino](./manage-metadata-using-gravitino.md#catalog-operations) for more details.
+Refer to [Manage Relational Metadata Using Gravitino](./manage-relational-metadata-using-gravitino.md#catalog-operations) for more details.
 
 ## Schema
 
@@ -61,7 +61,7 @@ The following table lists predefined schema properties for the Hive database. Ad
 
 ### Schema operations
 
-see [Manage Metadata Using Gravitino](./manage-metadata-using-gravitino.md#schema-operations).
+see [Manage Relational Metadata Using Gravitino](./manage-relational-metadata-using-gravitino.md#schema-operations).
 
 ## Table
 
@@ -117,7 +117,7 @@ The following table lists the data types mapped from the Hive catalog to Graviti
 | `uniontype`                 | `uniontype`         | 0.2.0         |
 
 :::info
-Since 0.5.0, the data types other than listed above are mapped to Gravitino **[Unparsed Type](./manage-metadata-using-gravitino.md#unparsed-type)** that represents an unresolvable data type from the Hive catalog.
+Since 0.5.0, the data types other than listed above are mapped to Gravitino **[Unparsed Type](./manage-relational-metadata-using-gravitino.md#unparsed-type)** that represents an unresolvable data type from the Hive catalog.
 :::
 
 ### Table properties
@@ -151,11 +151,11 @@ Hive automatically adds and manages some reserved properties. Users aren't allow
 
 ### Table operations
 
-Refer to [Manage Metadata Using Gravitino](./manage-metadata-using-gravitino.md#table-operations) for more details.
+Refer to [Manage Relational Metadata Using Gravitino](./manage-relational-metadata-using-gravitino.md#table-operations) for more details.
 
 #### Alter operations
 
-Gravitino has already defined a unified set of [metadata operation interfaces](./manage-metadata-using-gravitino.md#alter-a-table), and almost all [Hive Alter operations](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-AlterTable/Partition/Column) have corresponding table update requests which enable you to change the struct of an existing table.
+Gravitino has already defined a unified set of [metadata operation interfaces](./manage-relational-metadata-using-gravitino.md#alter-a-table), and almost all [Hive Alter operations](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-AlterTable/Partition/Column) have corresponding table update requests which enable you to change the struct of an existing table.
 The following table lists the mapping relationship between Hive Alter operations and Gravitino table update requests.
 
 ##### Alter table

--- a/docs/expression.md
+++ b/docs/expression.md
@@ -9,7 +9,7 @@ license: Copyright 2024 Datastrato Pvt Ltd. This software is licensed under the 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-This page introduces the expression system of Gravitino. Expressions are vital component of metadata definition, through expressions, you can define [default values](./manage-metadata-using-gravitino.md#table-column-default-value) for columns, function arguments for [function partitioning](./table-partitioning-bucketing-sort-order-indexes.md#table-partitioning), [bucketing](./table-partitioning-bucketing-sort-order-indexes.md#table-bucketing), and sort term of [sort ordering](./table-partitioning-bucketing-sort-order-indexes.md#sort-ordering) in tables.
+This page introduces the expression system of Gravitino. Expressions are vital component of metadata definition, through expressions, you can define [default values](./manage-relational-metadata-using-gravitino.md#table-column-default-value) for columns, function arguments for [function partitioning](./table-partitioning-bucketing-sort-order-indexes.md#table-partitioning), [bucketing](./table-partitioning-bucketing-sort-order-indexes.md#table-bucketing), and sort term of [sort ordering](./table-partitioning-bucketing-sort-order-indexes.md#sort-ordering) in tables.
 Gravitino expression system divides expressions into three basic parts: field reference, literal, and function. Function expressions can contain field references, literals, and other function expressions.
 
 ## Field reference

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,11 @@ To get started with Gravitino, see [Getting started](./getting-started.md) for t
 
 Gravitino provides two SDKs to manage metadata from different catalogs in a unified way: the
 REST API and the Java SDK. You can use either to manage metadata. See
-[Manage metadata using Gravitino](./manage-metadata-using-gravitino.md) for details.
+
+* [Manage metalake using Gravitino](./manage-metalake-using-gravitino.md) to learn how to manage
+  metalakes.
+* [Manage relational metadata using Gravitino](./manage-relational-metadata-using-gravitino.md)
+  to learn how to manage relational metadata.
 
 Also, you can find the complete REST API definition in
 [Gravitino Open API](./api/rest/gravitino-rest-api), and the
@@ -57,6 +61,8 @@ Java SDK definition in [Gravitino Javadoc](pathname:///docs/0.4.0/api/java/index
 Gravitino provides a web UI to manage the metadata. Visit the web UI in the browser via `http://<ip-address>:8090`. See [Gravitino web UI](./webui.md) for details.
 
 Gravitino currently supports the following catalogs:
+
+**Relational catalogs:**
 
 * [**Iceberg catalog**](./lakehouse-iceberg-catalog.md)
 * [**Hive catalog**](./apache-hive-catalog.md)

--- a/docs/jdbc-mysql-catalog.md
+++ b/docs/jdbc-mysql-catalog.md
@@ -28,7 +28,7 @@ Gravitino saves some system information in schema and table comment, like `(From
 - Supports metadata management of MySQL (5.7, 8.0).
 - Supports DDL operation for MySQL databases and tables.
 - Supports table index.
-- Supports [column default value](./manage-metadata-using-gravitino.md#table-column-default-value) and [auto-increment](./manage-metadata-using-gravitino.md#table-column-auto-increment).
+- Supports [column default value](./manage-relational-metadata-using-gravitino.md#table-column-default-value) and [auto-increment](./manage-relational-metadata-using-gravitino.md#table-column-auto-increment).
 - Supports managing MySQL table features though table properties, like using `engine` to set MySQL storage engine.
 
 ### Catalog properties
@@ -54,7 +54,7 @@ You must download the corresponding JDBC driver to the `catalogs/jdbc-mysql/libs
 
 ### Catalog operations
 
-Refer to [Manage Metadata Using Gravitino](./manage-metadata-using-gravitino.md#catalog-operations) for more details.
+Refer to [Manage Relational Metadata Using Gravitino](./manage-relational-metadata-using-gravitino.md#catalog-operations) for more details.
 
 ## Schema
 
@@ -71,7 +71,7 @@ Refer to [Manage Metadata Using Gravitino](./manage-metadata-using-gravitino.md#
 
 ### Schema operations
 
-Refer to [Manage Metadata Using Gravitino](./manage-metadata-using-gravitino.md#schema-operations) for more details.
+Refer to [Manage Relational Metadata Using Gravitino](./manage-relational-metadata-using-gravitino.md#schema-operations) for more details.
 
 ## Table
 
@@ -80,7 +80,7 @@ Refer to [Manage Metadata Using Gravitino](./manage-metadata-using-gravitino.md#
 - Gravitino's table concept corresponds to the MySQL table.
 - Supports DDL operation for MySQL tables.
 - Supports index.
-- Supports [column default value](./manage-metadata-using-gravitino.md#table-column-default-value) and [auto-increment](./manage-metadata-using-gravitino.md#table-column-auto-increment)..
+- Supports [column default value](./manage-relational-metadata-using-gravitino.md#table-column-default-value) and [auto-increment](./manage-relational-metadata-using-gravitino.md#table-column-auto-increment)..
 - Supports managing MySQL table features though table properties, like using `engine` to set MySQL storage engine.
 
 #### Table column types
@@ -104,7 +104,7 @@ Refer to [Manage Metadata Using Gravitino](./manage-metadata-using-gravitino.md#
 
 :::info
 MySQL doesn't support Gravitino `Boolean` `Fixed` `Struct` `List` `Map` `Timestamp_tz` `IntervalDay` `IntervalYear` `Union` `UUID` type.
-Meanwhile, the data types other than listed above are mapped to Gravitino **[Unparsed Type](./manage-metadata-using-gravitino.md#unparsed-type)** that represents an unresolvable data type since 0.5.0.
+Meanwhile, the data types other than listed above are mapped to Gravitino **[Unparsed Type](./manage-relational-metadata-using-gravitino.md#unparsed-type)** that represents an unresolvable data type since 0.5.0.
 :::
 
 #### Table column auto-increment
@@ -215,7 +215,7 @@ Index[] indexes = new Index[] {
 
 ### Table operations
 
-Refer to [Manage Metadata Using Gravitino](./manage-metadata-using-gravitino.md#table-operations) for more details.
+Refer to [Manage Relational Metadata Using Gravitino](./manage-relational-metadata-using-gravitino.md#table-operations) for more details.
 
 #### Alter table operations
 

--- a/docs/jdbc-postgresql-catalog.md
+++ b/docs/jdbc-postgresql-catalog.md
@@ -28,7 +28,7 @@ Gravitino saves some system information in schema and table comment, like `(From
 - Supports metadata management of PostgreSQL (12.x, 13.x, 14.x, 15.x, 16.x).
 - Supports DDL operation for PostgreSQL schemas and tables.
 - Supports table index.
-- Supports [column default value](./manage-metadata-using-gravitino.md#table-column-default-value). and [auto-increment](./manage-metadata-using-gravitino.md#table-column-auto-increment). 
+- Supports [column default value](./manage-relational-metadata-using-gravitino.md#table-column-default-value). and [auto-increment](./manage-relational-metadata-using-gravitino.md#table-column-auto-increment).
 
 ### Catalog properties
 
@@ -57,7 +57,7 @@ In PostgreSQL, the database corresponds to the Gravitino catalog, and the schema
 
 ### Catalog operations
 
-Please refer to [Manage Metadata Using Gravitino](./manage-metadata-using-gravitino.md#catalog-operations) for more details.
+Please refer to [Manage Relational Metadata Using Gravitino](./manage-relational-metadata-using-gravitino.md#catalog-operations) for more details.
 
 ## Schema
 
@@ -74,7 +74,7 @@ Please refer to [Manage Metadata Using Gravitino](./manage-metadata-using-gravit
 
 ### Schema operations
 
-Please refer to [Manage Metadata Using Gravitino](./manage-metadata-using-gravitino.md#schema-operations) for more details.
+Please refer to [Manage Relational Metadata Using Gravitino](./manage-relational-metadata-using-gravitino.md#schema-operations) for more details.
 
 ## Table
 
@@ -83,7 +83,7 @@ Please refer to [Manage Metadata Using Gravitino](./manage-metadata-using-gravit
 - The Gravitino table corresponds to the PostgreSQL table.
 - Supports DDL operation for PostgreSQL tables.
 - Supports index.
-- Support [column default value](./manage-metadata-using-gravitino.md#table-column-default-value) and [auto-increment](./manage-metadata-using-gravitino.md#table-column-auto-increment).
+- Support [column default value](./manage-relational-metadata-using-gravitino.md#table-column-default-value) and [auto-increment](./manage-relational-metadata-using-gravitino.md#table-column-auto-increment).
 - Doesn't support table property settings.
 
 #### Table column types
@@ -108,7 +108,7 @@ Please refer to [Manage Metadata Using Gravitino](./manage-metadata-using-gravit
 
 :::info
 PostgreSQL doesn't support Gravitino `Fixed` `Struct` `List` `Map` `IntervalDay` `IntervalYear` `Union` `UUID` type.
-Meanwhile, the data types other than listed above are mapped to Gravitino **[Unparsed Type](./manage-metadata-using-gravitino.md#unparsed-type)** that represents an unresolvable data type since 0.5.0.
+Meanwhile, the data types other than listed above are mapped to Gravitino **[Unparsed Type](./manage-relational-metadata-using-gravitino.md#unparsed-type)** that represents an unresolvable data type since 0.5.0.
 :::
 
 #### Table column auto-increment
@@ -158,7 +158,7 @@ Index[] indexes = new Index[] {
 
 ### Table operations
 
-Please refer to [Manage Metadata Using Gravitino](./manage-metadata-using-gravitino.md#table-operations) for more details.
+Please refer to [Manage Relational Metadata Using Gravitino](./manage-relational-metadata-using-gravitino.md#table-operations) for more details.
 
 #### Alter table operations
 

--- a/docs/lakehouse-iceberg-catalog.md
+++ b/docs/lakehouse-iceberg-catalog.md
@@ -58,7 +58,7 @@ You must download the corresponding JDBC driver to the `catalogs/lakehouse-icebe
 
 ### Catalog operations
 
-Please refer to [Manage Metadata Using Gravitino](./manage-metadata-using-gravitino.md#catalog-operations) for more details.
+Please refer to [Manage Relational Metadata Using Gravitino](./manage-relational-metadata-using-gravitino.md#catalog-operations) for more details.
 
 ## Schema 
 
@@ -72,7 +72,7 @@ You could put properties except `comment`.
 
 ### Schema operations
 
-Please refer to [Manage Metadata Using Gravitino](./manage-metadata-using-gravitino.md#schema-operations) for more details.
+Please refer to [Manage Relational Metadata Using Gravitino](./manage-relational-metadata-using-gravitino.md#schema-operations) for more details.
 
 ## Table 
 
@@ -215,7 +215,7 @@ Apache Iceberg doesn't support Gravitino `EvenDistribution` type.
 
 :::info
 Apache Iceberg doesn't support Gravitino `Varchar` `Fixedchar` `Byte` `Short` `Union` type.
-Meanwhile, the data types other than listed above are mapped to Gravitino **[Unparsed Type](./manage-metadata-using-gravitino.md#unparsed-type)** that represents an unresolvable data type since 0.5.0.
+Meanwhile, the data types other than listed above are mapped to Gravitino **[Unparsed Type](./manage-relational-metadata-using-gravitino.md#unparsed-type)** that represents an unresolvable data type since 0.5.0.
 :::
 
 ### Table properties
@@ -241,7 +241,7 @@ The Gravitino server doesn't allow passing the following reserved fields.
 
 ### Table operations
 
-Please refer to [Manage Metadata Using Gravitino](./manage-metadata-using-gravitino.md#table-operations) for more details.
+Please refer to [Manage Relational Metadata Using Gravitino](./manage-relational-metadata-using-gravitino.md#table-operations) for more details.
 
 #### Alter table operations
 

--- a/docs/manage-metalake-using-gravitino.md
+++ b/docs/manage-metalake-using-gravitino.md
@@ -1,0 +1,182 @@
+---
+title: "Manage metalake using Gravitino"
+slug: /manage-metalake-using-gravitino
+date: 2023-12-10
+keyword: Gravitino metalake manage
+license: Copyright 2023 Datastrato Pvt Ltd. This software is licensed under the Apache License version 2.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+This page introduces how to manage metalake by Gravitino. Metalake is a tenant-like concept in
+Gravitino, all the catalogs, users and roles are under a metalake. Typically, a metalake is
+mapping to a organization or a company.
+
+Through Gravitino, you can create, edit, and delete metalake. This page includes the following
+contents:
+
+Assuming Gravitino has just started, and the host and port is [http://localhost:8090](http://localhost:8090).
+
+## Metalake operations
+
+### Create a metalake
+
+You can create a metalake by sending a `POST` request to the `/api/metalakes` endpoint or just use the Gravitino Java client.
+The following is an example of creating a metalake:
+
+<Tabs>
+<TabItem value="shell" label="Shell">
+
+```shell
+curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
+-H "Content-Type: application/json" -d '{"name":"metalake","comment":"comment","properties":{}}' \
+http://localhost:8090/api/metalakes
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+GravitinoClient gravitinoClient = GravitinoClient
+    .builder("http://127.0.0.1:8090")
+    .build();
+GravitinoMetaLake newMetalake = gravitinoClient.createMetalake(
+    NameIdentifier.of("metalake"),
+    "This is a new metalake",
+    new HashMap<>());
+  // ...
+```
+
+</TabItem>
+</Tabs>
+
+### Load a metalake
+
+You can create a metalake by sending a `GET` request to the `/api/metalakes/{metalake_name}` endpoint or just use the Gravitino Java client. The following is an example of loading a metalake:
+
+<Tabs>
+<TabItem value="shell" label="Shell">
+
+```shell
+curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
+-H "Content-Type: application/json"  http://localhost:8090/api/metalakes/metalake
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+// ...
+GravitinoMetaLake loaded = gravitinoClient.loadMetalake(
+    NameIdentifier.of("metalake"));
+// ...
+```
+
+</TabItem>
+</Tabs>
+
+### Alter a metalake
+
+You can modify a metalake by sending a `PUT` request to the `/api/metalakes/{metalake_name}` endpoint or just use the Gravitino Java client. The following is an example of altering a metalake:
+
+<Tabs>
+<TabItem value="shell" label="Shell">
+
+```shell
+curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
+-H "Content-Type: application/json" -d '{
+  "updates": [
+    {
+      "@type": "rename",
+      "newName": "metalake"
+    },
+    {
+      "@type": "setProperty",
+      "property": "key2",
+      "value": "value2"
+    }
+  ]
+}' http://localhost:8090/api/metalakes/new_metalake
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+// ...
+GravitinoMetaLake renamed = gravitinoClient.alterMetalake(
+    NameIdentifier.of("new_metalake"),
+    MetalakeChange.rename("new_metalake_renamed")
+);
+// ...
+```
+
+</TabItem>
+</Tabs>
+
+
+Currently, Gravitino supports the following changes to a metalake:
+
+| Supported modification | JSON                                                         | Java                                            |
+|------------------------|--------------------------------------------------------------|-------------------------------------------------|
+| Rename metalake        | `{"@type":"rename","newName":"metalake_renamed"}`            | `MetalakeChange.rename("metalake_renamed")`     |
+| Update comment         | `{"@type":"updateComment","newComment":"new_comment"}`       | `MetalakeChange.updateComment("new_comment")`   |
+| Set a property         | `{"@type":"setProperty","property":"key1","value":"value1"}` | `MetalakeChange.setProperty("key1", "value1")`  |
+| Remove a property      | `{"@type":"removeProperty","property":"key1"}`               | `MetalakeChange.removeProperty("key1")`         |
+
+
+### Drop a metalake
+
+You can remove a metalake by sending a `DELETE` request to the `/api/metalakes/{metalake_name}` endpoint or just use the Gravitino Java client. The following is an example of dropping a metalake:
+
+<Tabs>
+<TabItem value="shell" label="Shell">
+
+```shell
+curl -X DELETE -H "Accept: application/vnd.gravitino.v1+json" \
+-H "Content-Type: application/json" http://localhost:8090/api/metalakes/metalake
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+// ...
+boolean success = gravitinoClient.dropMetalake(
+    NameIdentifier.of("metalake")
+);
+// ...
+```
+
+</TabItem>
+</Tabs>
+
+:::note
+Current Gravitino doesn't support dropping a metalake in cascade mode, which means all the 
+catalogs, schemas and tables under the metalake need to be removed before dropping the metalake.
+:::
+
+### List all metalakes
+
+You can list metalakes by sending a `GET` request to the `/api/metalakes` endpoint or just use the Gravitino Java client. The following is an example of listing all metalake names:
+
+<Tabs>
+<TabItem value="shell" label="Shell">
+
+```shell
+curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
+-H "Content-Type: application/json"  http://localhost:8090/api/metalakes
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+// ...
+GravitinoMetaLake[] allMetalakes = gravitinoClient.listMetalakes();
+// ...
+```
+
+</TabItem>
+</Tabs>

--- a/docs/manage-relational-metadata-using-gravitino.md
+++ b/docs/manage-relational-metadata-using-gravitino.md
@@ -1,198 +1,42 @@
 ---
-title: "Manage metadata using Gravitino"
-slug: /manage-metadata-using-gravitino
+title: "Manage relational metadata using Gravitino"
+slug: /manage-relational-metadata-using-gravitino
 date: 2023-12-10
-keyword: Gravitino metadata manage
+keyword: Gravitino relational metadata manage
 license: Copyright 2023 Datastrato Pvt Ltd. This software is licensed under the Apache License version 2.
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-This page introduces how to manage metadata by Gravitino. Through Gravitino, you can create, edit, and delete metadata
-like metalakes, catalogs, schemas, and tables. This page includes the following contents:
+This page introduces how to manage relational metadata by Gravitino, relational metadata refers
+to relational catalog, schema, table and partitions. Through Gravitino, you can create, edit, and
+delete relational metadata via unified REST APIs or Java client.
 
-In this document, Gravitino uses Apache Hive catalog as an example to show how to manage metadata by Gravitino. Other catalogs are similar to Hive catalog,
-but they may have some differences, especially in catalog property, table property, and column type. For more details, please refer to the related doc.
+In this document, Gravitino uses Apache Hive catalog as an example to show how to manage
+relational metadata by Gravitino. Other relational catalogs are similar to Hive catalog,
+but they may have some differences, especially in catalog property, table property, and column type.
+For more details, please refer to the related doc.
 
 - [**Apache Hive**](./apache-hive-catalog.md)
 - [**MySQL**](./jdbc-mysql-catalog.md)
 - [**PostgreSQL**](./jdbc-postgresql-catalog.md)
 - [**Apache Iceberg**](./lakehouse-iceberg-catalog.md)
 
+Assuming:
 
-Assuming Gravitino has just started, and the host and port is [http://localhost:8090](http://localhost:8090).
-
-## Metalake operations
-
-### Create a metalake
-
-You can create a metalake by sending a `POST` request to the `/api/metalakes` endpoint or just use the Gravitino Java client.
-The following is an example of creating a metalake:
-
-<Tabs>
-<TabItem value="shell" label="Shell">
-
-```shell
-curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" -d '{"name":"metalake","comment":"comment","properties":{}}' \
-http://localhost:8090/api/metalakes
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-GravitinoClient gravitinoClient = GravitinoClient
-    .builder("http://127.0.0.1:8090")
-    .build();
-GravitinoMetaLake newMetalake = gravitinoClient.createMetalake(
-    NameIdentifier.of("metalake"),
-    "This is a new metalake",
-    new HashMap<>());
-  // ...
-```
-
-</TabItem>
-</Tabs>
-
-### Load a metalake
-
-You can create a metalake by sending a `GET` request to the `/api/metalakes/{metalake_name}` endpoint or just use the Gravitino Java client. The following is an example of loading a metalake:
-
-<Tabs>
-<TabItem value="shell" label="Shell">
-
-```shell
-curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json"  http://localhost:8090/api/metalakes/metalake
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-// ...
-GravitinoMetaLake loaded = gravitinoClient.loadMetalake(
-    NameIdentifier.of("metalake"));
-// ...
-```
-
-</TabItem>
-</Tabs>
-
-### Alter a metalake
-
-You can modify a metalake by sending a `PUT` request to the `/api/metalakes/{metalake_name}` endpoint or just use the Gravitino Java client. The following is an example of altering a metalake:
-
-<Tabs>
-<TabItem value="shell" label="Shell">
-
-```shell
-curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" -d '{
-  "updates": [
-    {
-      "@type": "rename",
-      "newName": "metalake"
-    },
-    {
-      "@type": "setProperty",
-      "property": "key2",
-      "value": "value2"
-    }
-  ]
-}' http://localhost:8090/api/metalakes/new_metalake
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-// ...
-GravitinoMetaLake renamed = gravitinoClient.alterMetalake(
-    NameIdentifier.of("new_metalake"),
-    MetalakeChange.rename("new_metalake_renamed")
-);
-// ...
-```
-
-</TabItem>
-</Tabs>
-
-
-Currently, Gravitino supports the following changes to a metalake:
-
-| Supported modification | JSON                                                         | Java                                            |
-|------------------------|--------------------------------------------------------------|-------------------------------------------------|
-| Rename metalake        | `{"@type":"rename","newName":"metalake_renamed"}`            | `MetalakeChange.rename("metalake_renamed")`     |
-| Update comment         | `{"@type":"updateComment","newComment":"new_comment"}`       | `MetalakeChange.updateComment("new_comment")`   |
-| Set a property         | `{"@type":"setProperty","property":"key1","value":"value1"}` | `MetalakeChange.setProperty("key1", "value1")`  |
-| Remove a property      | `{"@type":"removeProperty","property":"key1"}`               | `MetalakeChange.removeProperty("key1")`         |
-
-
-### Drop a metalake
-
-You can remove a metalake by sending a `DELETE` request to the `/api/metalakes/{metalake_name}` endpoint or just use the Gravitino Java client. The following is an example of dropping a metalake:
-
-<Tabs>
-<TabItem value="shell" label="Shell">
-
-```shell
-curl -X DELETE -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json" http://localhost:8090/api/metalakes/metalake
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-// ...
-boolean success = gravitinoClient.dropMetalake(
-    NameIdentifier.of("metalake")
-);
-// ...
-```
-
-</TabItem>
-</Tabs>
-
-:::note
-Dropping a metalake only removes metadata about the metalake and catalogs, schemas, tables under the metalake in Gravitino, It doesn't remove the real schema and table data in Apache Hive.
-:::
-
-### List all metalakes
-
-You can list metalakes by sending a `GET` request to the `/api/metalakes` endpoint or just use the Gravitino Java client. The following is an example of listing all metalake names:
-
-<Tabs>
-<TabItem value="shell" label="Shell">
-
-```shell
-curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
--H "Content-Type: application/json"  http://localhost:8090/api/metalakes
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-// ...
-GravitinoMetaLake[] allMetalakes = gravitinoClient.listMetalakes();
-// ...
-```
-
-</TabItem>
-</Tabs>
+ - Gravitino has just started, and the host and port is [http://localhost:8090](http://localhost:8090).
+ - Metalake has been created.
 
 ## Catalog operations
 
 ### Create a catalog
 
 :::tip
-Users should create a metalake before creating a catalog.
+The code below is an example of creating a Hive catalog. For other relational catalogs, the code is
+similar, but the catalog type, provider, and properties may be different. For more details, please refer to the related doc.
 
-The code below is an example of creating a Hive catalog. For other catalogs, the code is similar, but the catalog type, provider, and properties may be different. For more details, please refer to the related doc.
+For relational catalog, you must specify the catalog `type` as `RELATIONAL` when creating a catalog.
 :::
 
 You can create a catalog by sending a `POST` request to the `/api/metalakes/{metalake_name}/catalogs` endpoint or just use the Gravitino Java client. The following is an example of creating a catalog:

--- a/docs/trino-connector/development.md
+++ b/docs/trino-connector/development.md
@@ -13,7 +13,7 @@ This document is to guide users through the development of the Gravitino connect
 Before you start developing the Gravitino trino connector, you need to have the following prerequisites:
 
 1. You need to start the Gravitino server locally, for more information, please refer to the [start Gravitino server](../how-to-install.md)
-2. Create a catalog in the Gravitino server, for more information, please refer to the [Gravitino metadata management](../manage-metadata-using-gravitino.md). Assuming we have just created a MySQL catalog using the following command:
+2. Create a catalog in the Gravitino server, for more information, please refer to the [Gravitino metadata management](../manage-relational-metadata-using-gravitino.md). Assuming we have just created a MySQL catalog using the following command:
 
 ```curl
 curl -X POST -H "Content-Type: application/json" -d '{"name":"test","comment":"comment","properties":{}}' http://localhost:8090/api/metalakes

--- a/docs/trino-connector/installation.md
+++ b/docs/trino-connector/installation.md
@@ -113,7 +113,7 @@ system
 
 You can see the `gravitino` catalog in the result set. This signifies the successful installation of the Gravitino connector.
 
-Assuming you have created a catalog named `test.jdbc-mysql` in the Gravitino server, or please refer to [Create a Catalog](../manage-metadata-using-gravitino.md#create-a-catalog). Then you can use the Trino CLI to connect to the Trino container and run a query like this.
+Assuming you have created a catalog named `test.jdbc-mysql` in the Gravitino server, or please refer to [Create a Catalog](../manage-relational-metadata-using-gravitino.md#create-a-catalog). Then you can use the Trino CLI to connect to the Trino container and run a query like this.
 
 ```text
 docker exec -it trino-gravitino trino

--- a/docs/trino-connector/supported-catalog.md
+++ b/docs/trino-connector/supported-catalog.md
@@ -120,7 +120,7 @@ call gravitino.system.alter_catalog(
 ```
 
 if you need more information about catalog, please refer to:
-[Create a Catalog](../manage-metadata-using-gravitino.md#create-a-catalog).
+[Create a Catalog](../manage-relational-metadata-using-gravitino.md#create-a-catalog).
 
 ## Data type mapping between Trino and Gravitino
 
@@ -147,4 +147,4 @@ Hive does not support `TIME` data type.
 | MapType        | MAP        |
 | StructType     | ROW        |
 
-For more about Trino data types, please refer to [Trino data types](https://trino.io/docs/current/language/types.html) and Gravitino data types, please refer to [Gravitino data types](../manage-metadata-using-gravitino.md#gravitino-table-column-type).
+For more about Trino data types, please refer to [Trino data types](https://trino.io/docs/current/language/types.html) and Gravitino data types, please refer to [Gravitino data types](../manage-relational-metadata-using-gravitino.md#gravitino-table-column-type).

--- a/docs/trino-connector/trino-connector.md
+++ b/docs/trino-connector/trino-connector.md
@@ -22,7 +22,7 @@ The loading of Gravitino's catalogs into Trino follows the naming convention:
 ```
 
 Regarding `metalake` and `catalog`, 
-you can refer to [Create a Metalake](../manage-metadata-using-gravitino.md#create-a-metalake), [Create a Catalog](../manage-metadata-using-gravitino.md#create-a-catalog).
+you can refer to [Create a Metalake](../manage-relational-metadata-using-gravitino.md#create-a-metalake), [Create a Catalog](../manage-relational-metadata-using-gravitino.md#create-a-catalog).
 
 Usage in queries is as follows:
 

--- a/docs/webui.md
+++ b/docs/webui.md
@@ -16,10 +16,6 @@ This document primarily outlines how users can manage metadata within Gravitino 
 
 Currently, you can integrate [OAuth settings](security.md) to view, add, modify, and delete metalakes, create catalogs, and view catalogs, schemas, and tables, among other functions.
 
-:::caution
-More features are under development. For the details, please refer to the [Manage metadata using Gravitino](manage-metadata-using-gravitino.md) document.
-:::
-
 [Build](how-to-build.md#quick-start) and [deploy](getting-started.md#getting-started-locally) the Gravitino Web UI and open it in a browser at `http://<gravitino-host>:<gravitino-port>`, by default is [http://localhost:8090](http://localhost:8090).
 
 ## Initial page


### PR DESCRIPTION
### What changes were proposed in this pull request?

Split the "manage-metadata-using-gravitino.md" into several ones.

### Why are the changes needed?

As we added more catalog types, it is not feasible to list all the APIs in one doc, so here propose to split the docs.

Fix: #2750 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Just docs.
