### PR TITLE
[#2761] fix(docs): update docs after separating the Gravitino java client to two clients

### DIFF
--- a/docs/manage-metalake-using-gravitino.md
+++ b/docs/manage-metalake-using-gravitino.md
@@ -22,7 +22,7 @@ Assuming Gravitino has just started, and the host and port is [http://localhost:
 
 ### Create a metalake
 
-You can create a metalake by sending a `POST` request to the `/api/metalakes` endpoint or just use the Gravitino Java client.
+You can create a metalake by sending a `POST` request to the `/api/metalakes` endpoint or just use the Gravitino Admin Java client.
 The following is an example of creating a metalake:
 
 <Tabs>
@@ -41,6 +41,7 @@ http://localhost:8090/api/metalakes
 GravitinoAdminClient gravitinoAdminClient = GravitinoAdminClient
     .builder("http://127.0.0.1:8090")
     .build();
+
 GravitinoMetaLake newMetalake = gravitinoAdminClient.createMetalake(
     NameIdentifier.of("metalake"),
     "This is a new metalake",

--- a/docs/manage-metalake-using-gravitino.md
+++ b/docs/manage-metalake-using-gravitino.md
@@ -38,10 +38,10 @@ http://localhost:8090/api/metalakes
 <TabItem value="java" label="Java">
 
 ```java
-GravitinoClient gravitinoClient = GravitinoClient
+GravitinoAdminClient gravitinoAdminClient = GravitinoAdminClient
     .builder("http://127.0.0.1:8090")
     .build();
-GravitinoMetaLake newMetalake = gravitinoClient.createMetalake(
+GravitinoMetaLake newMetalake = gravitinoAdminClient.createMetalake(
     NameIdentifier.of("metalake"),
     "This is a new metalake",
     new HashMap<>());
@@ -68,7 +68,7 @@ curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
 
 ```java
 // ...
-GravitinoMetaLake loaded = gravitinoClient.loadMetalake(
+GravitinoMetaLake loaded = gravitinoAdminClient.loadMetalake(
     NameIdentifier.of("metalake"));
 // ...
 ```
@@ -105,7 +105,7 @@ curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
 
 ```java
 // ...
-GravitinoMetaLake renamed = gravitinoClient.alterMetalake(
+GravitinoMetaLake renamed = gravitinoAdminClient.alterMetalake(
     NameIdentifier.of("new_metalake"),
     MetalakeChange.rename("new_metalake_renamed")
 );
@@ -143,7 +143,7 @@ curl -X DELETE -H "Accept: application/vnd.gravitino.v1+json" \
 
 ```java
 // ...
-boolean success = gravitinoClient.dropMetalake(
+boolean success = gravitinoAdminClient.dropMetalake(
     NameIdentifier.of("metalake")
 );
 // ...
@@ -174,7 +174,7 @@ curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
 
 ```java
 // ...
-GravitinoMetaLake[] allMetalakes = gravitinoClient.listMetalakes();
+GravitinoMetaLake[] allMetalakes = gravitinoAdminClient.listMetalakes();
 // ...
 ```
 

--- a/docs/manage-relational-metadata-using-gravitino.md
+++ b/docs/manage-relational-metadata-using-gravitino.md
@@ -61,20 +61,19 @@ curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
 <TabItem value="java" label="Java">
 
 ```java
-GravitinoClient gravitinoClient = GravitinoClient
-    .builder("http://127.0.0.1:8090")
-    .build();
 
 // Assuming you have just created a metalake named `metalake`
-GravitinoMetaLake gravitinoMetaLake =
-    gravitinoClient.loadMetalake(NameIdentifier.of("metalake"));
+GravitinoClient gravitinoClient = GravitinoClient
+    .builder("http://127.0.0.1:8090")
+    .withMetalake("metalake")
+    .build();
 
 Map<String, String> hiveProperties = ImmutableMap.<String, String>builder()
         // You should replace the following with your own hive metastore uris that Gravitino can access
         .put("metastore.uris", "thrift://localhost:9083")
         .build();
 
-Catalog catalog = gravitinoMetaLake.createCatalog(
+Catalog catalog = gravitinoClient.createCatalog(
     NameIdentifier.of("metalake", "catalog"),
     Type.RELATIONAL,
     "hive", // provider, We support hive, jdbc-mysql, jdbc-postgresql, lakehouse-iceberg, etc.
@@ -113,10 +112,11 @@ curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
 ```java
 // ...
 // Assuming you have just created a metalake named `metalake`
-GravitinoMetaLake gravitinoMetaLake =
-    gravitinoClient.loadMetalake(NameIdentifier.of("metalake"));
-
-Catalog catalog = gravitinoMetaLake.loadCatalog(NameIdentifier.of("metalake", "catalog"));
+GravitinoClient gravitinoClient = GravitinoClient
+        .builder("http://127.0.0.1:8090")
+        .withMetalake("metalake")
+        .build();
+Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "catalog"));
 // ...
 ```
 
@@ -153,10 +153,11 @@ curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
 ```java
 // ...
 // Assuming you have just created a metalake named `metalake`
-GravitinoMetaLake gravitinoMetaLake =
-    gravitinoClient.loadMetalake(NameIdentifier.of("metalake"));
-
-Catalog catalog = gravitinoMetaLake.alterCatalog(NameIdentifier.of("metalake", "catalog"),
+GravitinoClient gravitinoClient = GravitinoClient
+        .builder("http://127.0.0.1:8090")
+        .withMetalake("metalake")
+        .build();
+Catalog catalog = gravitinoClient.alterCatalog(NameIdentifier.of("metalake", "catalog"),
     CatalogChange.rename("alter_catalog"), CatalogChange.updateComment("new comment"));
 // ...
 ```
@@ -192,11 +193,13 @@ http://localhost:8090/api/metalakes/metalake/catalogs/catalog
 ```java
 // ...
 // Assuming you have just created a metalake named `metalake`
-GravitinoMetaLake gravitinoMetaLake =
-    gravitinoClient.loadMetalake(NameIdentifier.of("metalake"));
-gravitinoMetaLake.dropCatalog(NameIdentifier.of("metalake", "catalog"));
+GravitinoClient gravitinoClient = GravitinoClient
+        .builder("http://127.0.0.1:8090")
+        .withMetalake("metalake")
+        .build();
+gravitinoClient.dropCatalog(NameIdentifier.of("metalake", "catalog"));
 // ...
-  // ...
+
 ```
 
 </TabItem>
@@ -226,10 +229,12 @@ http://localhost:8090/api/metalakes/metalake/catalogs
 ```java
 // ...
 // Assuming you have just created a metalake named `metalake`
-GravitinoMetaLake gravitinoMetaLake =
-    gravitinoClient.loadMetalake(NameIdentifier.of("metalake"));
+GravitinoClient gravitinoClient = GravitinoClient
+        .builder("http://127.0.0.1:8090")
+        .withMetalake("metalake")
+        .build();
 
-NameIdentifier[] catalogsIdents = gravitinoMetaLake.listCatalogs(Namespace.ofCatalog("metalake"));
+NameIdentifier[] catalogsIdents = gravitinoClient.listCatalogs(Namespace.ofCatalog("metalake"));
 // ...
 ```
 
@@ -255,8 +260,10 @@ http://localhost:8090/api/metalakes/metalake/catalogs?details=true
 ```java
 // ...
 // Assuming you have just created a metalake named `metalake`
-GravitinoMetaLake gravitinoMetaLake =
-    gravitinoClient.loadMetalake(NameIdentifier.of("metalake"));
+GravitinoClient gravitinoClient = GravitinoClient
+        .builder("http://127.0.0.1:8090")
+        .withMetalake("metalake")
+        .build();
 
 Catalog[] catalogsInfos = gravitinoMetaLake.listCatalogsInfo(Namespace.ofCatalog("metalake"));
 // ...
@@ -294,16 +301,14 @@ curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
 <TabItem value="java" label="Java">
 
 ```java
-GravitinoClient gravitinoClient = GravitinoClient
-    .builder("http://127.0.0.1:8090")
-    .build();
-
 // Assuming you have just created a metalake named `metalake`
-GravitinoMetaLake gravitinoMetaLake =
-    gravitinoClient.loadMetalake(NameIdentifier.of("metalake"));
+GravitinoClient gravitinoClient = GravitinoClient
+        .builder("http://127.0.0.1:8090")
+        .withMetalake("metalake")
+        .build();
 
 // Assuming you have just created a Hive catalog named `catalog`
-Catalog catalog = gravitinoMetaLake.loadCatalog(NameIdentifier.of("metalake", "catalog"));
+Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "catalog"));
 
 SupportsSchemas supportsSchemas = catalog.asSchemas();
 
@@ -348,7 +353,7 @@ http://localhost:8090/api/metalakes/metalake/catalogs/catalog/schemas/schema
 ```java
 // ...
 // Assuming you have just created a Hive catalog named `hive_catalog`
-Catalog catalog = gravitinoMetaLake.loadCatalog(NameIdentifier.of("metalake", "catalog"));
+Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "catalog"));
 SupportsSchemas supportsSchemas = catalog.asSchemas();
 Schema schema = supportsSchemas.loadSchema(NameIdentifier.of("metalake", "catalog", "schema"));
 // ...
@@ -386,7 +391,7 @@ curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
 ```java
 // ...
 // Assuming you have just created a Hive catalog named `hive_catalog`
-Catalog catalog = gravitinoMetaLake.loadCatalog(NameIdentifier.of("metalake", "hive_catalog"));
+Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "hive_catalog"));
 
 SupportsSchemas supportsSchemas = catalog.asSchemas();
 
@@ -425,7 +430,7 @@ http://localhost:8090/api/metalakes/metalake/catalogs/catalog/schemas/schema?cas
 ```java
 // ...
 // Assuming you have just created a Hive catalog named `hive_catalog`
-Catalog catalog = gravitinoMetaLake.loadCatalog(NameIdentifier.of("metalake", "catalog"));
+Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "catalog"));
 
 SupportsSchemas supportsSchemas = catalog.asSchemas();
 // cascade can be true or false
@@ -458,7 +463,7 @@ curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
 ```java
 // ...
 // Assuming you have just created a Hive catalog named `hive_catalog`
-Catalog catalog = gravitinoMetaLake.loadCatalog(NameIdentifier.of("metalake", "catalog"));
+Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "catalog"));
 
 SupportsSchemas supportsSchemas = catalog.asSchemas();
 NameIdentifier[] schemas = supportsSchemas.listSchemas(Namespace.ofSchema("metalake", "catalog"));
@@ -609,16 +614,14 @@ curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
 <TabItem value="java" label="Java">
 
 ```java
-GravitinoClient gravitinoClient = GravitinoClient
-    .builder("http://127.0.0.1:8090")
-    .build();
-
 // Assuming you have just created a metalake named `metalake`
-GravitinoMetaLake gravitinoMetaLake =
-    gravitinoClient.loadMetalake(NameIdentifier.of("metalake"));
+GravitinoClient gravitinoClient = GravitinoClient
+        .builder("http://127.0.0.1:8090")
+        .withMetalake("metalake")
+        .build();
 
 // Assuming you have just created a Hive catalog named `hive_catalog`
-Catalog catalog = gravitinoMetaLake.loadCatalog(NameIdentifier.of("metalake", "catalog"));
+Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "catalog"));
 
 TableCatalog tableCatalog = catalog.asTableCatalog();
 
@@ -795,7 +798,7 @@ http://localhost:8090/api/metalakes/metalake/catalogs/catalog/schemas/schema/tab
 ```java
 // ...
 // Assuming you have just created a Hive catalog named `catalog`
-Catalog catalog = gravitinoMetaLake.loadCatalog(NameIdentifier.of("metalake", "catalog"));
+Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "catalog"));
 
 TableCatalog tableCatalog = catalog.asTableCatalog();
 tableCatalog.loadTable(NameIdentifier.of("metalake", "hive_catalog", "schema", "table"));
@@ -839,7 +842,7 @@ curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
 ```java
 // ...
 // Assuming you have just created a Hive catalog named `catalog`
-Catalog catalog = gravitinoMetaLake.loadCatalog(NameIdentifier.of("metalake", "catalog"));
+Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "catalog"));
 
 TableCatalog tableCatalog = catalog.asTableCatalog();
 
@@ -888,7 +891,7 @@ http://localhost:8090/api/metalakes/metalake/catalogs/catalog/schemas/schema/tab
 ```java
 // ...
 // Assuming you have just created a Hive catalog named `hive_catalog`
-Catalog catalog = gravitinoMetaLake.loadCatalog(NameIdentifier.of("metalake", "catalog"));
+Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "catalog"));
 
 TableCatalog tableCatalog = catalog.asTableCatalog();
 
@@ -929,7 +932,7 @@ http://localhost:8090/api/metalakes/metalake/catalogs/catalog/schemas/schema/tab
 ```java
 // ...
 // Assuming you have just created a Hive catalog named `hive_catalog`
-Catalog catalog = gravitinoMetaLake.loadCatalog(NameIdentifier.of("metalake", "catalog"));
+Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "catalog"));
 
 TableCatalog tableCatalog = catalog.asTableCatalog();
 NameIdentifier[] identifiers =

--- a/docs/manage-relational-metadata-using-gravitino.md
+++ b/docs/manage-relational-metadata-using-gravitino.md
@@ -111,11 +111,7 @@ curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
 
 ```java
 // ...
-// Assuming you have just created a metalake named `metalake`
-GravitinoClient gravitinoClient = GravitinoClient
-        .builder("http://127.0.0.1:8090")
-        .withMetalake("metalake")
-        .build();
+// Assuming you have created a metalake named `metalake` and a catalog named `catalog`
 Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "catalog"));
 // ...
 ```
@@ -152,11 +148,7 @@ curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
 
 ```java
 // ...
-// Assuming you have just created a metalake named `metalake`
-GravitinoClient gravitinoClient = GravitinoClient
-        .builder("http://127.0.0.1:8090")
-        .withMetalake("metalake")
-        .build();
+// Assuming you have created a metalake named `metalake` and a catalog named `catalog`
 Catalog catalog = gravitinoClient.alterCatalog(NameIdentifier.of("metalake", "catalog"),
     CatalogChange.rename("alter_catalog"), CatalogChange.updateComment("new comment"));
 // ...
@@ -192,11 +184,7 @@ http://localhost:8090/api/metalakes/metalake/catalogs/catalog
 
 ```java
 // ...
-// Assuming you have just created a metalake named `metalake`
-GravitinoClient gravitinoClient = GravitinoClient
-        .builder("http://127.0.0.1:8090")
-        .withMetalake("metalake")
-        .build();
+// Assuming you have created a metalake named `metalake` and a catalog named `catalog`
 gravitinoClient.dropCatalog(NameIdentifier.of("metalake", "catalog"));
 // ...
 
@@ -229,11 +217,6 @@ http://localhost:8090/api/metalakes/metalake/catalogs
 ```java
 // ...
 // Assuming you have just created a metalake named `metalake`
-GravitinoClient gravitinoClient = GravitinoClient
-        .builder("http://127.0.0.1:8090")
-        .withMetalake("metalake")
-        .build();
-
 NameIdentifier[] catalogsIdents = gravitinoClient.listCatalogs(Namespace.ofCatalog("metalake"));
 // ...
 ```
@@ -260,11 +243,6 @@ http://localhost:8090/api/metalakes/metalake/catalogs?details=true
 ```java
 // ...
 // Assuming you have just created a metalake named `metalake`
-GravitinoClient gravitinoClient = GravitinoClient
-        .builder("http://127.0.0.1:8090")
-        .withMetalake("metalake")
-        .build();
-
 Catalog[] catalogsInfos = gravitinoMetaLake.listCatalogsInfo(Namespace.ofCatalog("metalake"));
 // ...
 ```
@@ -301,21 +279,15 @@ curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
 <TabItem value="java" label="Java">
 
 ```java
-// Assuming you have just created a metalake named `metalake`
-GravitinoClient gravitinoClient = GravitinoClient
-        .builder("http://127.0.0.1:8090")
-        .withMetalake("metalake")
-        .build();
-
-// Assuming you have just created a Hive catalog named `catalog`
-Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "catalog"));
+// Assuming you have just created a Hive catalog named `hive_catalog`
+Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "hive_catalog"));
 
 SupportsSchemas supportsSchemas = catalog.asSchemas();
 
 Map<String, String> schemaProperties = ImmutableMap.<String, String>builder()
     .build();
 Schema schema = supportsSchemas.createSchema(
-    NameIdentifier.of("metalake", "catalog", "schema"),
+    NameIdentifier.of("metalake", "hive_catalog", "schema"),
     "This is a schema",
     schemaProperties
 );
@@ -353,9 +325,9 @@ http://localhost:8090/api/metalakes/metalake/catalogs/catalog/schemas/schema
 ```java
 // ...
 // Assuming you have just created a Hive catalog named `hive_catalog`
-Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "catalog"));
+Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "hive_catalog"));
 SupportsSchemas supportsSchemas = catalog.asSchemas();
-Schema schema = supportsSchemas.loadSchema(NameIdentifier.of("metalake", "catalog", "schema"));
+Schema schema = supportsSchemas.loadSchema(NameIdentifier.of("metalake", "hive_catalog", "schema"));
 // ...
 ```
 
@@ -430,11 +402,11 @@ http://localhost:8090/api/metalakes/metalake/catalogs/catalog/schemas/schema?cas
 ```java
 // ...
 // Assuming you have just created a Hive catalog named `hive_catalog`
-Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "catalog"));
+Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "hive_catalog"));
 
 SupportsSchemas supportsSchemas = catalog.asSchemas();
 // cascade can be true or false
-supportsSchemas.dropSchema(NameIdentifier.of("metalake", "catalog", "schema"), true);
+supportsSchemas.dropSchema(NameIdentifier.of("metalake", "hive_catalog", "schema"), true);
 ```
 
 </TabItem>
@@ -463,10 +435,10 @@ curl -X GET -H "Accept: application/vnd.gravitino.v1+json" \
 ```java
 // ...
 // Assuming you have just created a Hive catalog named `hive_catalog`
-Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "catalog"));
+Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "hive_catalog"));
 
 SupportsSchemas supportsSchemas = catalog.asSchemas();
-NameIdentifier[] schemas = supportsSchemas.listSchemas(Namespace.ofSchema("metalake", "catalog"));
+NameIdentifier[] schemas = supportsSchemas.listSchemas(Namespace.ofSchema("metalake", "hive_catalog"));
 ```
 
 </TabItem>
@@ -614,14 +586,8 @@ curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
 <TabItem value="java" label="Java">
 
 ```java
-// Assuming you have just created a metalake named `metalake`
-GravitinoClient gravitinoClient = GravitinoClient
-        .builder("http://127.0.0.1:8090")
-        .withMetalake("metalake")
-        .build();
-
 // Assuming you have just created a Hive catalog named `hive_catalog`
-Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "catalog"));
+Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "hive_catalog"));
 
 TableCatalog tableCatalog = catalog.asTableCatalog();
 
@@ -633,7 +599,7 @@ Map<String, String> tablePropertiesMap = ImmutableMap.<String, String>builder()
         .build();
 
 tableCatalog.createTable(
-  NameIdentifier.of("metalake", "catalog", "schema", "example_table"),
+  NameIdentifier.of("metalake", "hive_catalog", "schema", "example_table"),
   new Column[] {
     Column.of("id", Types.IntegerType.get(), "id column comment", false, true, Literals.integerLiteral(-1)),
     Column.of("name", Types.VarCharType.of(500), "name column comment", true, false, Literals.NULL),
@@ -797,8 +763,8 @@ http://localhost:8090/api/metalakes/metalake/catalogs/catalog/schemas/schema/tab
 
 ```java
 // ...
-// Assuming you have just created a Hive catalog named `catalog`
-Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "catalog"));
+// Assuming you have just created a Hive catalog named `hive_catalog`
+Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "hive_catalog"));
 
 TableCatalog tableCatalog = catalog.asTableCatalog();
 tableCatalog.loadTable(NameIdentifier.of("metalake", "hive_catalog", "schema", "table"));
@@ -841,12 +807,12 @@ curl -X PUT -H "Accept: application/vnd.gravitino.v1+json" \
 
 ```java
 // ...
-// Assuming you have just created a Hive catalog named `catalog`
-Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "catalog"));
+// Assuming you have just created a Hive catalog named `hive_catalog`
+Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "hive_catalog"));
 
 TableCatalog tableCatalog = catalog.asTableCatalog();
 
-Table t = tableCatalog.alterTable(NameIdentifier.of("metalake", "catalog", "schema", "table"),
+Table t = tableCatalog.alterTable(NameIdentifier.of("metalake", "hive_catalog", "schema", "table"),
     TableChange.rename("table_renamed"), TableChange.updateComment("xxx"));
 // ...
 ```
@@ -891,15 +857,15 @@ http://localhost:8090/api/metalakes/metalake/catalogs/catalog/schemas/schema/tab
 ```java
 // ...
 // Assuming you have just created a Hive catalog named `hive_catalog`
-Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "catalog"));
+Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "hive_catalog"));
 
 TableCatalog tableCatalog = catalog.asTableCatalog();
 
 // Drop a table
-tableCatalog.dropTable(NameIdentifier.of("metalake", "catalog", "schema", "table"));
+tableCatalog.dropTable(NameIdentifier.of("metalake", "hive_catalog", "schema", "table"));
 
 // Purge a table
-tableCatalog.purgeTable(NameIdentifier.of("metalake", "catalog", "schema", "table"));
+tableCatalog.purgeTable(NameIdentifier.of("metalake", "hive_catalog", "schema", "table"));
 // ...
 ```
 
@@ -932,11 +898,11 @@ http://localhost:8090/api/metalakes/metalake/catalogs/catalog/schemas/schema/tab
 ```java
 // ...
 // Assuming you have just created a Hive catalog named `hive_catalog`
-Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "catalog"));
+Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "hive_catalog"));
 
 TableCatalog tableCatalog = catalog.asTableCatalog();
 NameIdentifier[] identifiers =
-    tableCatalog.listTables(Namespace.ofTable("metalake", "catalog", "schema"));
+    tableCatalog.listTables(Namespace.ofTable("metalake", "hive_catalog", "schema"));
 // ...
 ```
 

--- a/docs/manage-table-partition-using-gravitino.md
+++ b/docs/manage-table-partition-using-gravitino.md
@@ -249,12 +249,12 @@ curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
 ```java
 GravitinoClient gravitinoClient = GravitinoClient
     .builder("http://127.0.0.1:8090")
+    .withMetalake("metalake")
     .build();
 
 // Assume that you have a partitioned table named "metalake.catalog.schema.table".
 Partition addedPartition = 
     gravitinoClient
-        .loadMetalake(NameIdentifier.of("metalake"))
         .loadCatalog(NameIdentifier.of("metalake", "catalog"))
         .asTableCatalog()
         .loadTable(NameIdentifier.of("metalake", "catalog", "schema", "table"))
@@ -294,12 +294,12 @@ If the partition name contains special characters, you should use [URL encoding]
 ```java
 GravitinoClient gravitinoClient = GravitinoClient
     .builder("http://127.0.0.1:8090")
+    .withMetalake("metalake")
     .build();
 
 // Assume that you have a partitioned table named "metalake.catalog.schema.table".
 Partition Partition = 
     gravitinoClient
-        .loadMetalake(NameIdentifier.of("metalake"))
         .loadCatalog(NameIdentifier.of("metalake", "catalog"))
         .asTableCatalog()
         .loadTable(NameIdentifier.of("metalake", "catalog", "schema", "table"))
@@ -330,12 +330,12 @@ http://localhost:8090/api/metalakes/metalake/catalogs/catalog/schemas/schema/tab
 ```java
 GravitinoClient gravitinoClient = GravitinoClient
     .builder("http://127.0.0.1:8090")
+    .withMetalake("metalake")
     .build();
 
 // Assume that you have a partitioned table named "metalake.catalog.schema.table".
 String[] partitionNames = 
     gravitinoClient
-        .loadMetalake(NameIdentifier.of("metalake"))
         .loadCatalog(NameIdentifier.of("metalake", "catalog"))
         .asTableCatalog()
         .loadTable(NameIdentifier.of("metalake", "catalog", "schema", "table"))
@@ -367,7 +367,6 @@ http://localhost:8090/api/metalakes/metalake/catalogs/catalog/schemas/schema/tab
 // Assume that you have a partitioned table named "metalake.catalog.schema.table".
 Partition[] partitions =
         gravitinoClient
-            .loadMetalake(NameIdentifier.of("metalake"))
             .loadCatalog(NameIdentifier.of("metalake", "catalog"))
             .asTableCatalog()
             .loadTable(NameIdentifier.of("metalake", "catalog", "schema", "table"))

--- a/docs/security.md
+++ b/docs/security.md
@@ -71,7 +71,6 @@ KerberosTokenProvider provider = KerberosTokenProvider.builder()
 
 // Use ticketCache to create KerberosTokenProvider
 KerberosTokenProvider provider = KerberosTokenProvider.builder()
-        .withMetalake("metalake")
         .withClientPrincipal(clientPrincipal)
         .build();        
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -22,6 +22,7 @@ For the client side, users can enable `simple` mode by the following code:
 
 ```java
 GravitinoClient client = GravitinoClient.builder(uri)
+    .withMetalake("metalake")
     .withSimpleAuth()
     .build();
 ```
@@ -47,6 +48,7 @@ DefaultOAuth2TokenProvider authDataProvider = DefaultOAuth2TokenProvider.builder
     .build();
 
 GravitinoClient client = GravitinoClient.builder(uri)
+    .withMetalake("metalake")
     .withOAuth(authDataProvider)
     .build();
 ```
@@ -69,10 +71,12 @@ KerberosTokenProvider provider = KerberosTokenProvider.builder()
 
 // Use ticketCache to create KerberosTokenProvider
 KerberosTokenProvider provider = KerberosTokenProvider.builder()
+        .withMetalake("metalake")
         .withClientPrincipal(clientPrincipal)
         .build();        
 
 GravitinoClient client = GravitinoClient.builder(uri)
+    .withMetalake("metalake")
     .withKerberosAuth(provider)
     .build();
 ```
@@ -278,7 +282,7 @@ import com.datastrato.gravitino.client.GravitinoVersion;
 public class Main {
     public static void main(String[] args) {
         String uri = "https://localhost:8433";
-        GravitinoClient client = GravitinoClient.builder(uri).build();
+        GravitinoClient client = GravitinoClient.builder(uri).withMetalake("metalake").build();
         GravitinoVersion gravitinoVersion = client.getVersion();
         System.out.println(gravitinoVersion);
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

After separating the Gravitino java client to two clients, the documents should be updated as well.

### Why are the changes needed?

The Gravitino java client was separated to two: GravitinoClient and GravitinoAdminClient. So the document need be corrected.

Fix: #2761

### Does this PR introduce _any_ user-facing change?
No; Just the mark down documents.

### How was this patch tested?

Manual review.
