### PR TITLE
[#2754] improvement(web): list metalakes sort by created time as default

### DIFF
--- a/web/src/lib/store/metalakes/index.js
+++ b/web/src/lib/store/metalakes/index.js
@@ -38,7 +38,7 @@ export const fetchMetalakes = createAsyncThunk('appMetalakes/fetchMetalakes', as
 
   const { metalakes } = res
 
-  metalakes.sort((a, b) => new Date(a.audit.createtime) - new Date(b.audit.createtime))
+  metalakes.sort((a, b) => new Date(b.audit.createTime) - new Date(a.audit.createTime))
 
   return { metalakes }
 })

--- a/web/src/lib/store/metalakes/index.js
+++ b/web/src/lib/store/metalakes/index.js
@@ -38,6 +38,8 @@ export const fetchMetalakes = createAsyncThunk('appMetalakes/fetchMetalakes', as
 
   const { metalakes } = res
 
+  metalakes.sort((a, b) => a.audit.createtime - b.audit.createtime)
+
   return { metalakes }
 })
 

--- a/web/src/lib/store/metalakes/index.js
+++ b/web/src/lib/store/metalakes/index.js
@@ -38,7 +38,7 @@ export const fetchMetalakes = createAsyncThunk('appMetalakes/fetchMetalakes', as
 
   const { metalakes } = res
 
-  metalakes.sort((a, b) => a.audit.createtime - b.audit.createtime)
+  metalakes.sort((a, b) => new Date(a.audit.createtime) - new Date(b.audit.createtime))
 
   return { metalakes }
 })


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

When listing metalakes they get sorted by their createdTime value

### Why are the changes needed?


Its requested in the issue
Fix: #2754  (issue)

### Does this PR introduce _any_ user-facing change?

metalakes will be shown in ASC order


### How was this patch tested?

N/A

