### PR TITLE
improve(filesystem-hadoop): support path without scheme for gvfs api

### DIFF
--- a/clients/filesystem-hadoop3/src/main/java/com/datastrato/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
+++ b/clients/filesystem-hadoop3/src/main/java/com/datastrato/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
@@ -52,7 +52,7 @@ public class GravitinoVirtualFileSystem extends FileSystem {
   private Cache<NameIdentifier, Pair<Fileset, FileSystem>> filesetCache;
   private ScheduledThreadPoolExecutor scheduler;
 
-  // The pattern is used to match gvfs path. The scheme prefix (gvfs://) is optional.
+  // The pattern is used to match gvfs path. The scheme prefix (gvfs://fileset) is optional.
   // The following path can be match:
   //     gvfs://fileset/fileset_catalog/fileset_schema/fileset1/file.txt
   //     /fileset_catalog/fileset_schema/fileset1/sub_dir/

--- a/clients/filesystem-hadoop3/src/main/java/com/datastrato/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
+++ b/clients/filesystem-hadoop3/src/main/java/com/datastrato/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
@@ -297,7 +297,7 @@ public class GravitinoVirtualFileSystem extends FileSystem {
     Preconditions.checkArgument(
         matcher.matches() && matcher.groupCount() == 3,
         "URI %s doesn't contains valid identifier",
-        virtualUri);
+        virtualPath);
 
     return NameIdentifier.ofFileset(
         metalakeName, matcher.group(1), matcher.group(2), matcher.group(3));

--- a/clients/filesystem-hadoop3/src/main/java/com/datastrato/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
+++ b/clients/filesystem-hadoop3/src/main/java/com/datastrato/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
@@ -278,7 +278,7 @@ public class GravitinoVirtualFileSystem extends FileSystem {
       FileStatus fileStatus, String actualPrefix, String virtualPrefix) {
     String filePath = fileStatus.getPath().toString();
     Preconditions.checkArgument(
-        !filePath.startsWith(actualPrefix),
+        filePath.startsWith(actualPrefix),
         "Path %s doesn't start with prefix \"%s\".",
         filePath,
         actualPrefix);

--- a/clients/filesystem-hadoop3/src/main/java/com/datastrato/gravitino/filesystem/hadoop/GravitinoVirtualFileSystemConfiguration.java
+++ b/clients/filesystem-hadoop3/src/main/java/com/datastrato/gravitino/filesystem/hadoop/GravitinoVirtualFileSystemConfiguration.java
@@ -6,7 +6,7 @@ package com.datastrato.gravitino.filesystem.hadoop;
 
 /** Configuration class for Gravitino Virtual File System. */
 class GravitinoVirtualFileSystemConfiguration {
-  public static final String GVFS_FILESET_PREFIX = "gvfs://fileset/";
+  public static final String GVFS_FILESET_PREFIX = "gvfs://fileset";
   public static final String GVFS_SCHEME = "gvfs";
 
   /** The configuration key for the Gravitino server URI. */

--- a/clients/filesystem-hadoop3/src/test/java/com/datastrato/gravitino/filesystem/hadoop/FileSystemTestUtils.java
+++ b/clients/filesystem-hadoop3/src/test/java/com/datastrato/gravitino/filesystem/hadoop/FileSystemTestUtils.java
@@ -16,7 +16,7 @@ import org.apache.hadoop.util.Progressable;
 
 public class FileSystemTestUtils {
   private static final String LOCAL_FS_PREFIX =
-      "file:/tmp/gravitino_test_fs_" + UUID.randomUUID().toString().replace("-", "") + "/";
+      "file:/tmp/gravitino_test_fs_" + UUID.randomUUID().toString().replace("-", "");
 
   private static final int BUFFER_SIZE = 3;
   private static final short REPLICATION = 1;
@@ -30,15 +30,16 @@ public class FileSystemTestUtils {
     return LOCAL_FS_PREFIX;
   }
 
-  public static Path createFilesetPath(String filesetCatalog, String schema, String fileset) {
-    return new Path(
-        GravitinoVirtualFileSystemConfiguration.GVFS_FILESET_PREFIX
-            + "/"
-            + filesetCatalog
-            + "/"
-            + schema
-            + "/"
-            + fileset);
+  public static Path createFilesetPath(
+      String filesetCatalog, String schema, String fileset, boolean withScheme) {
+    String filesetPath =
+        String.format(
+            "%s/%s/%s/%s",
+            withScheme ? GravitinoVirtualFileSystemConfiguration.GVFS_FILESET_PREFIX : "",
+            filesetCatalog,
+            schema,
+            fileset);
+    return new Path(filesetPath);
   }
 
   public static Path createLocalRootDir(String filesetCatalog) {
@@ -46,7 +47,7 @@ public class FileSystemTestUtils {
   }
 
   public static Path createLocalDirPrefix(String filesetCatalog, String schema, String fileset) {
-    return new Path(LOCAL_FS_PREFIX + filesetCatalog + "/" + schema + "/" + fileset);
+    return new Path(LOCAL_FS_PREFIX + "/" + filesetCatalog + "/" + schema + "/" + fileset);
   }
 
   public static void create(Path path, FileSystem fileSystem) throws IOException {

--- a/clients/filesystem-hadoop3/src/test/java/com/datastrato/gravitino/filesystem/hadoop/FileSystemTestUtils.java
+++ b/clients/filesystem-hadoop3/src/test/java/com/datastrato/gravitino/filesystem/hadoop/FileSystemTestUtils.java
@@ -43,11 +43,11 @@ public class FileSystemTestUtils {
   }
 
   public static Path createLocalRootDir(String filesetCatalog) {
-    return new Path(LOCAL_FS_PREFIX + filesetCatalog);
+    return new Path(String.format("%s/%s", LOCAL_FS_PREFIX, filesetCatalog));
   }
 
   public static Path createLocalDirPrefix(String filesetCatalog, String schema, String fileset) {
-    return new Path(LOCAL_FS_PREFIX + "/" + filesetCatalog + "/" + schema + "/" + fileset);
+    return new Path(String.format("%s/%s/%s/%s", LOCAL_FS_PREFIX, filesetCatalog, schema, fileset));
   }
 
   public static void create(Path path, FileSystem fileSystem) throws IOException {

--- a/clients/filesystem-hadoop3/src/test/java/com/datastrato/gravitino/filesystem/hadoop/TestGvfsBase.java
+++ b/clients/filesystem-hadoop3/src/test/java/com/datastrato/gravitino/filesystem/hadoop/TestGvfsBase.java
@@ -14,6 +14,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.file.Fileset;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -493,6 +495,69 @@ public class TestGvfsBase extends GravitinoMockServerBase {
               .replaceFirst(
                   GravitinoVirtualFileSystemConfiguration.GVFS_FILESET_PREFIX,
                   FileSystemTestUtils.localRootPrefix()));
+    }
+  }
+
+  @Test
+  public void testExtractIdentifier() throws IOException, URISyntaxException {
+    try (GravitinoVirtualFileSystem fs =
+        (GravitinoVirtualFileSystem) managedFilesetPath.getFileSystem(conf)) {
+      NameIdentifier identifier =
+          fs.extractIdentifier(new URI("gvfs://fileset/catalog1/schema1/fileset1"));
+      assertEquals(
+          NameIdentifier.ofFileset(metalakeName, "catalog1", "schema1", "fileset1"), identifier);
+
+      NameIdentifier identifier2 =
+          fs.extractIdentifier(new URI("gvfs://fileset/catalog1/schema1/fileset1/"));
+      assertEquals(
+          NameIdentifier.ofFileset(metalakeName, "catalog1", "schema1", "fileset1"), identifier2);
+
+      NameIdentifier identifier3 =
+          fs.extractIdentifier(new URI("gvfs://fileset/catalog1/schema1/fileset1/files"));
+      assertEquals(
+          NameIdentifier.ofFileset(metalakeName, "catalog1", "schema1", "fileset1"), identifier3);
+
+      NameIdentifier identifier4 =
+          fs.extractIdentifier(new URI("gvfs://fileset/catalog1/schema1/fileset1/dir/dir"));
+      assertEquals(
+          NameIdentifier.ofFileset(metalakeName, "catalog1", "schema1", "fileset1"), identifier4);
+
+      NameIdentifier identifier5 =
+          fs.extractIdentifier(new URI("gvfs://fileset/catalog1/schema1/fileset1/dir/dir/"));
+      assertEquals(
+          NameIdentifier.ofFileset(metalakeName, "catalog1", "schema1", "fileset1"), identifier5);
+
+      NameIdentifier identifier6 = fs.extractIdentifier(new URI("/catalog1/schema1/fileset1"));
+      assertEquals(
+          NameIdentifier.ofFileset(metalakeName, "catalog1", "schema1", "fileset1"), identifier6);
+
+      NameIdentifier identifier7 = fs.extractIdentifier(new URI("/catalog1/schema1/fileset1/"));
+      assertEquals(
+          NameIdentifier.ofFileset(metalakeName, "catalog1", "schema1", "fileset1"), identifier7);
+
+      NameIdentifier identifier8 = fs.extractIdentifier(new URI("/catalog1/schema1/fileset1/dir"));
+      assertEquals(
+          NameIdentifier.ofFileset(metalakeName, "catalog1", "schema1", "fileset1"), identifier8);
+
+      NameIdentifier identifier9 =
+          fs.extractIdentifier(new URI("/catalog1/schema1/fileset1/dir/dir/"));
+      assertEquals(
+          NameIdentifier.ofFileset(metalakeName, "catalog1", "schema1", "fileset1"), identifier9);
+
+      NameIdentifier identifier10 =
+          fs.extractIdentifier(new URI("/catalog1/schema1/fileset1/dir/dir"));
+      assertEquals(
+          NameIdentifier.ofFileset(metalakeName, "catalog1", "schema1", "fileset1"), identifier10);
+
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> fs.extractIdentifier(new URI("gvfs://fileset/catalog1/")));
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> fs.extractIdentifier(new URI("hdfs://fileset/catalog1/schema1/fileset1")));
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> fs.extractIdentifier(new URI("/catalog1/schema1/")));
     }
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

It will use the path without scheme in tensorflow. This MR will support the path without gvfs scheme.
https://github.com/tensorflow/io/blob/master/tensorflow_io/core/filesystems/hdfs/hadoop_filesystem.cc#L618
https://github.com/tensorflow/io/blob/master/tensorflow_io/core/filesystems/hdfs/hadoop_filesystem.cc#L116

### Why are the changes needed?

-  support path without Scheme for Hadoop API
- #2860

### Does this PR introduce _any_ user-facing change?

- no

### How was this patch tested?

- UTs pass