### PR TITLE
[#2788] fix(ci):  Fix CI issue after Github CI image is upgraded

### DIFF
--- a/.github/workflows/backend-integration-test.yml
+++ b/.github/workflows/backend-integration-test.yml
@@ -97,7 +97,7 @@ jobs:
           name: integrate test reports
           path: |
             build/reports
-            integration-test/build/integration-test.log
+            integration-test/build/integration-test-integration-test.log
             distribution/package/logs/gravitino-server.out
             distribution/package/logs/gravitino-server.log
             catalogs/**/*.log

--- a/integration-test/trino-it/launch.sh
+++ b/integration-test/trino-it/launch.sh
@@ -8,16 +8,16 @@ cd "$(dirname "$0")"
 
 playground_dir="$(dirname "${BASH_SOURCE-$0}")"
 playground_dir="$(cd "${playground_dir}">/dev/null; pwd)"
-isExist=`which docker-compose`
+isExist=`which docker`
 if [ ! $isExist ]
 then
-  echo "ERROR: No docker service environment found, please install docker-compose first."
+  echo "ERROR: No docker service environment found, please install docker first."
   exit
 fi
 
 cd ${playground_dir}
 
-docker-compose up -d
+docker compose up -d
 
 if [ -n "$GRAVITINO_LOG_PATH" ]; then
     LOG_PATH=$GRAVITINO_LOG_PATH
@@ -25,15 +25,15 @@ else
     LOG_PATH=../build/integration-test.log
 fi
 
-echo "The docker-compose log is: $LOG_PATH"
+echo "The docker compose log is: $LOG_PATH"
 
-nohup docker-compose logs -f  -t >> $LOG_PATH &
+nohup docker compose logs -f  -t >> $LOG_PATH &
 
 max_attempts=600
 
 for ((i = 0; i < max_attempts; i++)); do
-    docker-compose exec -T trino trino --execute "SELECT 1" >/dev/null 2>&1 && {
-        echo "All docker-compose service is now available."
+    docker compose exec -T trino trino --execute "SELECT 1" >/dev/null 2>&1 && {
+        echo "All docker compose service is now available."
         exit 0
     }
     sleep 1

--- a/integration-test/trino-it/shutdown.sh
+++ b/integration-test/trino-it/shutdown.sh
@@ -5,4 +5,4 @@
 #
 cd "$(dirname "$0")"
 
-docker-compose down
+docker compose down


### PR DESCRIPTION

### What changes were proposed in this pull request?

Change `docker-compose` to `docker compose`

### Why are the changes needed?

Github CI image updates its base image to upgrade docker compose from v1 to v2, in which the command `docker-compose` is no longer supported, instead user should use `docker compose`.

Fix: #2788

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Test locally and CI.
