### PR TITLE
[#2621] feat(spark-connector) support hive table location properties

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkCommonIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkCommonIT.java
@@ -37,8 +37,6 @@ import org.slf4j.LoggerFactory;
 public abstract class SparkCommonIT extends SparkEnvIT {
   private static final Logger LOG = LoggerFactory.getLogger(SparkCommonIT.class);
 
-  private static String LOCATION = "/user/hive/external_db";
-
   // To generate test data for write&read table.
   protected static final Map<DataType, String> typeConstant =
       ImmutableMap.of(
@@ -673,14 +671,14 @@ public abstract class SparkCommonIT extends SparkEnvIT {
   }
 
   protected void checkTableLocation(Path dir) {
-    Assertions.assertTrue(dir.toString().equals(hdfs.getUri() + LOCATION));
+    Assertions.assertTrue(dir.toString().equals(hdfs.getUri() + "/user/hive/external_db"));
   }
 
-  protected void deleteDirIfExists() {
+  protected void deleteDirIfExists(String path) {
     try {
-      Path location = new Path(LOCATION);
-      if (hdfs.exists(location)) {
-        hdfs.delete(new Path(LOCATION), true);
+      Path dir = new Path(path);
+      if (hdfs.exists(dir)) {
+        hdfs.delete(dir, true);
       }
     } catch (IOException e) {
       throw new RuntimeException(e);
@@ -763,22 +761,17 @@ public abstract class SparkCommonIT extends SparkEnvIT {
   }
 
   protected String getCreateSimpleTableString(String tableName) {
-    return getCreateSimpleTableString(tableName, false, false);
+    return getCreateSimpleTableString(tableName, false);
   }
 
-  protected String getCreateSimpleTableString(
-      String tableName, boolean isExternal, boolean hasLocation) {
+  protected String getCreateSimpleTableString(String tableName, boolean isExternal) {
     String external = "";
-    String location = "";
     if (isExternal) {
       external = "EXTERNAL";
     }
-    if (hasLocation) {
-      location = "LOCATION '" + LOCATION + "'";
-    }
     return String.format(
-        "CREATE %s TABLE %s (id INT COMMENT 'id comment', name STRING COMMENT '', age INT) %s",
-        external, tableName, location);
+        "CREATE %s TABLE %s (id INT COMMENT 'id comment', name STRING COMMENT '', age INT)",
+        external, tableName);
   }
 
   protected List<SparkColumnInfo> getSimpleTableColumn() {

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkCommonIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkCommonIT.java
@@ -670,10 +670,6 @@ public abstract class SparkCommonIT extends SparkEnvIT {
     }
   }
 
-  protected void checkTableLocation(Path dir) {
-    Assertions.assertTrue(dir.toString().equals(hdfs.getUri() + "/user/hive/external_db"));
-  }
-
   protected void deleteDirIfExists(String path) {
     try {
       Path dir = new Path(path);

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/hive/SparkHiveCatalogIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/hive/SparkHiveCatalogIT.java
@@ -210,7 +210,7 @@ public class SparkHiveCatalogIT extends SparkCommonIT {
   void testHiveFormatWithExternalTable() {
     String tableName = "test_hive_format_with_external_table";
     dropTableIfExists(tableName);
-    String createTableSql = getCreateSimpleTableString(tableName, true);
+    String createTableSql = getCreateSimpleTableString(tableName, true, false);
     sql(createTableSql);
     SparkTableInfo tableInfo = getTableInfo(tableName);
 
@@ -225,6 +225,27 @@ public class SparkHiveCatalogIT extends SparkCommonIT {
     dropTableIfExists(tableName);
     Path tableLocation = new Path(tableInfo.getTableLocation());
     checkDataFileExists(tableLocation);
+  }
+
+  @Test
+  void testHiveFormatWithLocationTable() {
+    String tableName = "test_hive_format_with_location_table";
+    Boolean[] isExternals = {Boolean.TRUE, Boolean.FALSE};
+
+    Arrays.stream(isExternals)
+        .forEach(
+            isExternal -> {
+              dropTableIfExists(tableName);
+              deleteDirIfExists();
+              String createTableSql = getCreateSimpleTableString(tableName, isExternal, true);
+              sql(createTableSql);
+
+              SparkTableInfo tableInfo = getTableInfo(tableName);
+              Path tableLocation = new Path(tableInfo.getTableLocation());
+              checkTableReadWrite(tableInfo);
+              checkTableLocation(tableLocation);
+              checkDataFileExists(tableLocation);
+            });
   }
 
   @Test

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/hive/SparkHiveCatalogIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/hive/SparkHiveCatalogIT.java
@@ -210,7 +210,7 @@ public class SparkHiveCatalogIT extends SparkCommonIT {
   void testHiveFormatWithExternalTable() {
     String tableName = "test_hive_format_with_external_table";
     dropTableIfExists(tableName);
-    String createTableSql = getCreateSimpleTableString(tableName, true, false);
+    String createTableSql = getCreateSimpleTableString(tableName, true);
     sql(createTableSql);
     SparkTableInfo tableInfo = getTableInfo(tableName);
 
@@ -236,15 +236,15 @@ public class SparkHiveCatalogIT extends SparkCommonIT {
         .forEach(
             isExternal -> {
               dropTableIfExists(tableName);
-              deleteDirIfExists();
-              String createTableSql = getCreateSimpleTableString(tableName, isExternal, true);
+              deleteDirIfExists("/user/hive/external_db");
+              String createTableSql = getCreateSimpleTableString(tableName, isExternal);
+              createTableSql = createTableSql + "LOCATION '/user/hive/external_db'";
               sql(createTableSql);
 
               SparkTableInfo tableInfo = getTableInfo(tableName);
-              Path tableLocation = new Path(tableInfo.getTableLocation());
               checkTableReadWrite(tableInfo);
+              Path tableLocation = new Path(tableInfo.getTableLocation());
               checkTableLocation(tableLocation);
-              checkDataFileExists(tableLocation);
             });
   }
 

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/hive/SparkHiveCatalogIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/hive/SparkHiveCatalogIT.java
@@ -230,21 +230,21 @@ public class SparkHiveCatalogIT extends SparkCommonIT {
   @Test
   void testHiveFormatWithLocationTable() {
     String tableName = "test_hive_format_with_location_table";
+    String location = "/user/hive/external_db";
     Boolean[] isExternals = {Boolean.TRUE, Boolean.FALSE};
 
     Arrays.stream(isExternals)
         .forEach(
             isExternal -> {
               dropTableIfExists(tableName);
-              deleteDirIfExists("/user/hive/external_db");
+              deleteDirIfExists(location);
               String createTableSql = getCreateSimpleTableString(tableName, isExternal);
-              createTableSql = createTableSql + "LOCATION '/user/hive/external_db'";
+              createTableSql = createTableSql + "LOCATION '" + location + "'";
               sql(createTableSql);
 
               SparkTableInfo tableInfo = getTableInfo(tableName);
               checkTableReadWrite(tableInfo);
-              Path tableLocation = new Path(tableInfo.getTableLocation());
-              checkTableLocation(tableLocation);
+              Assertions.assertTrue(tableInfo.getTableLocation().equals(hdfs.getUri() + location));
             });
   }
 

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/spark/SparkUtilIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/spark/SparkUtilIT.java
@@ -118,10 +118,6 @@ public abstract class SparkUtilIT extends AbstractIT {
     sql("DROP TABLE IF EXISTS " + tableName);
   }
 
-  protected void dropTable(String tableName) {
-    sql("DROP TABLE " + tableName);
-  }
-
   protected boolean tableExists(String tableName) {
     try {
       SparkTableInfo tableInfo = getTableInfo(tableName);

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/spark/SparkUtilIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/spark/SparkUtilIT.java
@@ -118,6 +118,10 @@ public abstract class SparkUtilIT extends AbstractIT {
     sql("DROP TABLE IF EXISTS " + tableName);
   }
 
+  protected void dropTable(String tableName) {
+    sql("DROP TABLE " + tableName);
+  }
+
   protected boolean tableExists(String tableName) {
     try {
       SparkTableInfo tableInfo = getTableInfo(tableName);

--- a/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/hive/HivePropertiesConstants.java
+++ b/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/hive/HivePropertiesConstants.java
@@ -31,12 +31,14 @@ public class HivePropertiesConstants {
   public static final String GRAVITINO_HIVE_FORMAT_CSV = StorageFormat.CSV.toString();
   public static final String GRAVITINO_HIVE_EXTERNAL_TABLE = EXTERNAL_TABLE.name();
   public static final String GRAVITINO_HIVE_TABLE_TYPE = "table-type";
+  public static final String GRAVITINO_HIVE_LOCATION = "location";
 
   public static final String SPARK_HIVE_STORED_AS = "hive.stored-as";
   public static final String SPARK_HIVE_INPUT_FORMAT = "input-format";
   public static final String SPARK_HIVE_OUTPUT_FORMAT = "output-format";
   public static final String SPARK_HIVE_SERDE_LIB = "serde-lib";
   public static final String SPARK_HIVE_EXTERNAL = "external";
+  public static final String SPARK_HIVE_LOCATION = "location";
 
   @VisibleForTesting
   public static final String TEXT_INPUT_FORMAT_CLASS =

--- a/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/hive/HivePropertiesConstants.java
+++ b/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/hive/HivePropertiesConstants.java
@@ -10,6 +10,7 @@ import static com.datastrato.gravitino.catalog.hive.HiveTablePropertiesMetadata.
 import com.datastrato.gravitino.catalog.hive.HiveTablePropertiesMetadata;
 import com.datastrato.gravitino.catalog.hive.HiveTablePropertiesMetadata.StorageFormat;
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
 
 public class HivePropertiesConstants {
   public static final String GRAVITINO_HIVE_FORMAT = HiveTablePropertiesMetadata.FORMAT;
@@ -30,15 +31,15 @@ public class HivePropertiesConstants {
   public static final String GRAVITINO_HIVE_FORMAT_JSON = StorageFormat.JSON.toString();
   public static final String GRAVITINO_HIVE_FORMAT_CSV = StorageFormat.CSV.toString();
   public static final String GRAVITINO_HIVE_EXTERNAL_TABLE = EXTERNAL_TABLE.name();
-  public static final String GRAVITINO_HIVE_TABLE_TYPE = "table-type";
-  public static final String GRAVITINO_HIVE_LOCATION = "location";
+  public static final String GRAVITINO_HIVE_TABLE_TYPE = HiveTablePropertiesMetadata.TABLE_TYPE;
+  public static final String GRAVITINO_HIVE_TABLE_LOCATION = HiveTablePropertiesMetadata.LOCATION;
 
   public static final String SPARK_HIVE_STORED_AS = "hive.stored-as";
   public static final String SPARK_HIVE_INPUT_FORMAT = "input-format";
   public static final String SPARK_HIVE_OUTPUT_FORMAT = "output-format";
   public static final String SPARK_HIVE_SERDE_LIB = "serde-lib";
   public static final String SPARK_HIVE_EXTERNAL = "external";
-  public static final String SPARK_HIVE_LOCATION = "location";
+  public static final String SPARK_HIVE_LOCATION = TableCatalog.PROP_LOCATION;
 
   @VisibleForTesting
   public static final String TEXT_INPUT_FORMAT_CLASS =

--- a/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/hive/HivePropertiesConverter.java
+++ b/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/hive/HivePropertiesConverter.java
@@ -64,6 +64,7 @@ public class HivePropertiesConverter implements PropertiesConverter {
     String isExternal =
         Optional.ofNullable(gravitinoTableProperties.get(TableCatalog.PROP_EXTERNAL))
             .orElse("false");
+    String location = gravitinoTableProperties.get(TableCatalog.PROP_LOCATION);
 
     if (fileFormat != null) {
       String gravitinoFormat = fileFormatMap.get(fileFormat.toLowerCase(Locale.ROOT));
@@ -80,6 +81,11 @@ public class HivePropertiesConverter implements PropertiesConverter {
           HivePropertiesConstants.GRAVITINO_HIVE_TABLE_TYPE,
           HiveTablePropertiesMetadata.TableType.EXTERNAL_TABLE.name());
     }
+
+    if (location != null) {
+      gravitinoTableProperties.put(HivePropertiesConstants.GRAVITINO_HIVE_TABLE_LOCATION, location);
+    }
+
     sparkToGravitinoPropertyMap.forEach(
         (sparkProperty, gravitinoProperty) -> {
           if (gravitinoTableProperties.containsKey(sparkProperty)) {
@@ -96,9 +102,16 @@ public class HivePropertiesConverter implements PropertiesConverter {
     Map<String, String> sparkTableProperties = toOptionProperties(properties);
     String hiveTableType =
         sparkTableProperties.get(HivePropertiesConstants.GRAVITINO_HIVE_TABLE_TYPE);
+    String location =
+        sparkTableProperties.get(HivePropertiesConstants.GRAVITINO_HIVE_TABLE_LOCATION);
+
     if (HivePropertiesConstants.GRAVITINO_HIVE_EXTERNAL_TABLE.equalsIgnoreCase(hiveTableType)) {
       sparkTableProperties.remove(HivePropertiesConstants.GRAVITINO_HIVE_TABLE_TYPE);
       sparkTableProperties.put(HivePropertiesConstants.SPARK_HIVE_EXTERNAL, "true");
+    }
+
+    if (location != null) {
+      sparkTableProperties.put(HivePropertiesConstants.SPARK_HIVE_LOCATION, location);
     }
 
     return sparkTableProperties;

--- a/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/hive/HivePropertiesConverter.java
+++ b/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/hive/HivePropertiesConverter.java
@@ -38,7 +38,14 @@ public class HivePropertiesConverter implements PropertiesConverter {
           "hive.input-format",
           HivePropertiesConstants.GRAVITINO_HIVE_INPUT_FORMAT,
           "hive.serde",
-          HivePropertiesConstants.GRAVITINO_HIVE_SERDE_LIB);
+          HivePropertiesConstants.GRAVITINO_HIVE_SERDE_LIB,
+          HivePropertiesConstants.SPARK_HIVE_LOCATION,
+          HivePropertiesConstants.GRAVITINO_HIVE_TABLE_LOCATION);
+
+  static final Map<String, String> gravitinoToSparkPropertyMap =
+      ImmutableMap.of(
+          HivePropertiesConstants.GRAVITINO_HIVE_TABLE_LOCATION,
+          HivePropertiesConstants.SPARK_HIVE_LOCATION);
 
   /**
    * CREATE TABLE xxx STORED AS PARQUET will save "hive.stored-as" = "PARQUET" in property.
@@ -64,7 +71,6 @@ public class HivePropertiesConverter implements PropertiesConverter {
     String isExternal =
         Optional.ofNullable(gravitinoTableProperties.get(TableCatalog.PROP_EXTERNAL))
             .orElse("false");
-    String location = gravitinoTableProperties.get(TableCatalog.PROP_LOCATION);
 
     if (fileFormat != null) {
       String gravitinoFormat = fileFormatMap.get(fileFormat.toLowerCase(Locale.ROOT));
@@ -80,10 +86,6 @@ public class HivePropertiesConverter implements PropertiesConverter {
       gravitinoTableProperties.put(
           HivePropertiesConstants.GRAVITINO_HIVE_TABLE_TYPE,
           HiveTablePropertiesMetadata.TableType.EXTERNAL_TABLE.name());
-    }
-
-    if (location != null) {
-      gravitinoTableProperties.put(HivePropertiesConstants.GRAVITINO_HIVE_TABLE_LOCATION, location);
     }
 
     sparkToGravitinoPropertyMap.forEach(
@@ -102,17 +104,19 @@ public class HivePropertiesConverter implements PropertiesConverter {
     Map<String, String> sparkTableProperties = toOptionProperties(properties);
     String hiveTableType =
         sparkTableProperties.get(HivePropertiesConstants.GRAVITINO_HIVE_TABLE_TYPE);
-    String location =
-        sparkTableProperties.get(HivePropertiesConstants.GRAVITINO_HIVE_TABLE_LOCATION);
 
     if (HivePropertiesConstants.GRAVITINO_HIVE_EXTERNAL_TABLE.equalsIgnoreCase(hiveTableType)) {
       sparkTableProperties.remove(HivePropertiesConstants.GRAVITINO_HIVE_TABLE_TYPE);
       sparkTableProperties.put(HivePropertiesConstants.SPARK_HIVE_EXTERNAL, "true");
     }
 
-    if (location != null) {
-      sparkTableProperties.put(HivePropertiesConstants.SPARK_HIVE_LOCATION, location);
-    }
+    gravitinoToSparkPropertyMap.forEach(
+        (gravitinoProperty, sparkProperty) -> {
+          if (sparkTableProperties.containsKey(gravitinoProperty)) {
+            String value = sparkTableProperties.remove(gravitinoProperty);
+            sparkTableProperties.put(sparkProperty, value);
+          }
+        });
 
     return sparkTableProperties;
   }

--- a/spark-connector/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/hive/TestHivePropertiesConverter.java
+++ b/spark-connector/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/hive/TestHivePropertiesConverter.java
@@ -102,13 +102,13 @@ public class TestHivePropertiesConverter {
         hivePropertiesConverter.toGravitinoTableProperties(
             ImmutableMap.of(HivePropertiesConstants.SPARK_HIVE_LOCATION, "/user/hive/external_db"));
     Assertions.assertEquals(
-        hiveProperties.get(HivePropertiesConstants.GRAVITINO_HIVE_LOCATION),
+        hiveProperties.get(HivePropertiesConstants.GRAVITINO_HIVE_TABLE_LOCATION),
         "/user/hive/external_db");
 
     hiveProperties =
         hivePropertiesConverter.toSparkTableProperties(
             ImmutableMap.of(
-                HivePropertiesConstants.GRAVITINO_HIVE_LOCATION, "/user/hive/external_db"));
+                HivePropertiesConstants.GRAVITINO_HIVE_TABLE_LOCATION, "/user/hive/external_db"));
     Assertions.assertEquals(
         ImmutableMap.of(HivePropertiesConstants.SPARK_HIVE_LOCATION, "/user/hive/external_db"),
         hiveProperties);

--- a/spark-connector/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/hive/TestHivePropertiesConverter.java
+++ b/spark-connector/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/hive/TestHivePropertiesConverter.java
@@ -98,20 +98,19 @@ public class TestHivePropertiesConverter {
 
   @Test
   void testLocation() {
+    String location = "/user/hive/external_db";
+
     Map<String, String> hiveProperties =
         hivePropertiesConverter.toGravitinoTableProperties(
-            ImmutableMap.of(HivePropertiesConstants.SPARK_HIVE_LOCATION, "/user/hive/external_db"));
+            ImmutableMap.of(HivePropertiesConstants.SPARK_HIVE_LOCATION, location));
     Assertions.assertEquals(
-        hiveProperties.get(HivePropertiesConstants.GRAVITINO_HIVE_TABLE_LOCATION),
-        "/user/hive/external_db");
+        hiveProperties.get(HivePropertiesConstants.GRAVITINO_HIVE_TABLE_LOCATION), location);
 
     hiveProperties =
         hivePropertiesConverter.toSparkTableProperties(
-            ImmutableMap.of(
-                HivePropertiesConstants.GRAVITINO_HIVE_TABLE_LOCATION, "/user/hive/external_db"));
+            ImmutableMap.of(HivePropertiesConstants.GRAVITINO_HIVE_TABLE_LOCATION, location));
     Assertions.assertEquals(
-        ImmutableMap.of(HivePropertiesConstants.SPARK_HIVE_LOCATION, "/user/hive/external_db"),
-        hiveProperties);
+        ImmutableMap.of(HivePropertiesConstants.SPARK_HIVE_LOCATION, location), hiveProperties);
   }
 
   @Test

--- a/spark-connector/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/hive/TestHivePropertiesConverter.java
+++ b/spark-connector/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/hive/TestHivePropertiesConverter.java
@@ -97,6 +97,24 @@ public class TestHivePropertiesConverter {
   }
 
   @Test
+  void testLocation() {
+    Map<String, String> hiveProperties =
+        hivePropertiesConverter.toGravitinoTableProperties(
+            ImmutableMap.of(HivePropertiesConstants.SPARK_HIVE_LOCATION, "/user/hive/external_db"));
+    Assertions.assertEquals(
+        hiveProperties.get(HivePropertiesConstants.GRAVITINO_HIVE_LOCATION),
+        "/user/hive/external_db");
+
+    hiveProperties =
+        hivePropertiesConverter.toSparkTableProperties(
+            ImmutableMap.of(
+                HivePropertiesConstants.GRAVITINO_HIVE_LOCATION, "/user/hive/external_db"));
+    Assertions.assertEquals(
+        ImmutableMap.of(HivePropertiesConstants.SPARK_HIVE_LOCATION, "/user/hive/external_db"),
+        hiveProperties);
+  }
+
+  @Test
   void testOptionProperties() {
     Map<String, String> properties =
         HivePropertiesConverter.fromOptionProperties(


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

supports location properties, transform from Spark location to Gravitino location
`CREATE TABLE xx LOCATION xxx`

### Why are the changes needed?

Fix: #2621 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

IT
