### PR TITLE
[2775] feat(core): Add JDBC backend operations for topic

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/storage/kv/BinaryEntityEncoderUtil.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/kv/BinaryEntityEncoderUtil.java
@@ -10,6 +10,7 @@ import static com.datastrato.gravitino.Entity.EntityType.FILESET;
 import static com.datastrato.gravitino.Entity.EntityType.METALAKE;
 import static com.datastrato.gravitino.Entity.EntityType.SCHEMA;
 import static com.datastrato.gravitino.Entity.EntityType.TABLE;
+import static com.datastrato.gravitino.Entity.EntityType.TOPIC;
 import static com.datastrato.gravitino.storage.kv.BinaryEntityKeyEncoder.LOG;
 import static com.datastrato.gravitino.storage.kv.BinaryEntityKeyEncoder.NAMESPACE_SEPARATOR;
 import static com.datastrato.gravitino.storage.kv.BinaryEntityKeyEncoder.TYPE_AND_NAME_SEPARATOR;
@@ -146,18 +147,22 @@ public class BinaryEntityEncoderUtil {
         prefixes.add(replacePrefixTypeInfo(encode, SCHEMA.getShortName()));
         prefixes.add(replacePrefixTypeInfo(encode, TABLE.getShortName()));
         prefixes.add(replacePrefixTypeInfo(encode, FILESET.getShortName()));
+        prefixes.add(replacePrefixTypeInfo(encode, TOPIC.getShortName()));
         break;
       case CATALOG:
         prefixes.add(replacePrefixTypeInfo(encode, SCHEMA.getShortName()));
         prefixes.add(replacePrefixTypeInfo(encode, TABLE.getShortName()));
         prefixes.add(replacePrefixTypeInfo(encode, FILESET.getShortName()));
+        prefixes.add(replacePrefixTypeInfo(encode, TOPIC.getShortName()));
         break;
       case SCHEMA:
         prefixes.add(replacePrefixTypeInfo(encode, TABLE.getShortName()));
         prefixes.add(replacePrefixTypeInfo(encode, FILESET.getShortName()));
+        prefixes.add(replacePrefixTypeInfo(encode, TOPIC.getShortName()));
         break;
       case TABLE:
       case FILESET:
+      case TOPIC:
         break;
       default:
         LOG.warn("Currently unknown type: {}, please check it", type);

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/JDBCBackend.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/JDBCBackend.java
@@ -20,11 +20,13 @@ import com.datastrato.gravitino.meta.CatalogEntity;
 import com.datastrato.gravitino.meta.FilesetEntity;
 import com.datastrato.gravitino.meta.SchemaEntity;
 import com.datastrato.gravitino.meta.TableEntity;
+import com.datastrato.gravitino.meta.TopicEntity;
 import com.datastrato.gravitino.storage.relational.service.CatalogMetaService;
 import com.datastrato.gravitino.storage.relational.service.FilesetMetaService;
 import com.datastrato.gravitino.storage.relational.service.MetalakeMetaService;
 import com.datastrato.gravitino.storage.relational.service.SchemaMetaService;
 import com.datastrato.gravitino.storage.relational.service.TableMetaService;
+import com.datastrato.gravitino.storage.relational.service.TopicMetaService;
 import com.datastrato.gravitino.storage.relational.session.SqlSessionFactoryHelper;
 import java.io.IOException;
 import java.util.List;
@@ -58,6 +60,8 @@ public class JDBCBackend implements RelationalBackend {
         return (List<E>) TableMetaService.getInstance().listTablesByNamespace(namespace);
       case FILESET:
         return (List<E>) FilesetMetaService.getInstance().listFilesetsByNamespace(namespace);
+      case TOPIC:
+        return (List<E>) TopicMetaService.getInstance().listTopicsByNamespace(namespace);
       default:
         throw new UnsupportedEntityTypeException(
             "Unsupported entity type: %s for list operation", entityType);
@@ -87,8 +91,9 @@ public class JDBCBackend implements RelationalBackend {
       TableMetaService.getInstance().insertTable((TableEntity) e, overwritten);
     } else if (e instanceof FilesetEntity) {
       FilesetMetaService.getInstance().insertFileset((FilesetEntity) e, overwritten);
+    } else if (e instanceof TopicEntity) {
+      TopicMetaService.getInstance().insertTopic((TopicEntity) e, overwritten);
     } else {
-      // TODO: Add support for TopicEntity
       throw new UnsupportedEntityTypeException(
           "Unsupported entity type: %s for insert operation", e.getClass());
     }
@@ -109,6 +114,8 @@ public class JDBCBackend implements RelationalBackend {
         return (E) TableMetaService.getInstance().updateTable(ident, updater);
       case FILESET:
         return (E) FilesetMetaService.getInstance().updateFileset(ident, updater);
+      case TOPIC:
+        return (E) TopicMetaService.getInstance().updateTopic(ident, updater);
       default:
         throw new UnsupportedEntityTypeException(
             "Unsupported entity type: %s for update operation", entityType);
@@ -129,6 +136,8 @@ public class JDBCBackend implements RelationalBackend {
         return (E) TableMetaService.getInstance().getTableByIdentifier(ident);
       case FILESET:
         return (E) FilesetMetaService.getInstance().getFilesetByIdentifier(ident);
+      case TOPIC:
+        return (E) TopicMetaService.getInstance().getTopicByIdentifier(ident);
       default:
         throw new UnsupportedEntityTypeException(
             "Unsupported entity type: %s for get operation", entityType);
@@ -148,6 +157,8 @@ public class JDBCBackend implements RelationalBackend {
         return TableMetaService.getInstance().deleteTable(ident);
       case FILESET:
         return FilesetMetaService.getInstance().deleteFileset(ident);
+      case TOPIC:
+        return TopicMetaService.getInstance().deleteTopic(ident);
       default:
         throw new UnsupportedEntityTypeException(
             "Unsupported entity type: %s for delete operation", entityType);

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/mapper/TopicMetaMapper.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/mapper/TopicMetaMapper.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.storage.relational.mapper;
+
+import com.datastrato.gravitino.storage.relational.po.TopicPO;
+import java.util.List;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+public interface TopicMetaMapper {
+  String TABLE_NAME = "topic_meta";
+
+  @Insert(
+      "INSERT INTO "
+          + TABLE_NAME
+          + "(topic_id, topic_name, metalake_id, catalog_id, schema_id,"
+          + " comment, properties, audit_info, current_version, last_version,"
+          + " deleted_at)"
+          + " VALUES("
+          + " #{topicMeta.topicId},"
+          + " #{topicMeta.topicName},"
+          + " #{topicMeta.metalakeId},"
+          + " #{topicMeta.catalogId},"
+          + " #{topicMeta.schemaId},"
+          + " #{topicMeta.comment},"
+          + " #{topicMeta.properties},"
+          + " #{topicMeta.auditInfo},"
+          + " #{topicMeta.currentVersion},"
+          + " #{topicMeta.lastVersion},"
+          + " #{topicMeta.deletedAt}"
+          + " )")
+  void insertTopicMeta(@Param("topicMeta") TopicPO topicPO);
+
+  @Insert(
+      "INSERT INTO "
+          + TABLE_NAME
+          + "(topic_id, topic_name, metalake_id,  catalog_id, schema_id,"
+          + " comment, properties, audit_info,  current_version, last_version,"
+          + " deleted_at)"
+          + " VALUES("
+          + " #{topicMeta.topicId},"
+          + " #{topicMeta.topicName},"
+          + " #{topicMeta.metalakeId},"
+          + " #{topicMeta.catalogId},"
+          + " #{topicMeta.schemaId},"
+          + " #{topicMeta.comment},"
+          + " #{topicMeta.properties},"
+          + " #{topicMeta.auditInfo},"
+          + " #{topicMeta.currentVersion},"
+          + " #{topicMeta.lastVersion},"
+          + " #{topicMeta.deletedAt}"
+          + " )"
+          + " ON DUPLICATE KEY UPDATE"
+          + " topic_name = #{topicMeta.topicName},"
+          + " metalake_id = #{topicMeta.metalakeId},"
+          + " catalog_id = #{topicMeta.catalogId},"
+          + " schema_id = #{topicMeta.schemaId},"
+          + " comment = #{topicMeta.comment},"
+          + " properties = #{topicMeta.properties},"
+          + " audit_info = #{topicMeta.auditInfo},"
+          + " current_version = #{topicMeta.currentVersion},"
+          + " last_version = #{topicMeta.lastVersion},"
+          + " deleted_at = #{topicMeta.deletedAt}")
+  void insertTopicMetaOnDuplicateKeyUpdate(@Param("topicMeta") TopicPO topicPO);
+
+  @Select(
+      "SELECT topic_id as topicId, topic_name as topicName, metalake_id as metalakeId,"
+          + " catalog_id as catalogId, schema_id as schemaId,"
+          + " comment as comment, properties as properties, audit_info as auditInfo,"
+          + " current_version as currentVersion, last_version as lastVersion,"
+          + " deleted_at as deletedAt"
+          + " FROM "
+          + TABLE_NAME
+          + " WHERE schema_id = #{schemaId} AND deleted_at = 0")
+  List<TopicPO> listTopicPOsBySchemaId(@Param("schemaId") Long schemaId);
+
+  @Select(
+      "SELECT topic_id as topicId, topic_name as topicName,"
+          + " metalake_id as metalakeId, catalog_id as catalogId, schema_id as schemaId,"
+          + " comment as comment, properties as properties, audit_info as auditInfo,"
+          + " current_version as currentVersion, last_version as lastVersion,"
+          + " deleted_at as deletedAt"
+          + " FROM "
+          + TABLE_NAME
+          + " WHERE schema_id = #{schemaId} AND topic_name = #{topicName} AND deleted_at = 0")
+  TopicPO selectTopicMetaBySchemaIdAndName(
+      @Param("schemaId") Long schemaId, @Param("topicName") String topicName);
+
+  @Update(
+      "UPDATE "
+          + TABLE_NAME
+          + " SET topic_name = #{newTopicMeta.topicName},"
+          + " metalake_id = #{newTopicMeta.metalakeId},"
+          + " catalog_id = #{newTopicMeta.catalogId},"
+          + " schema_id = #{newTopicMeta.schemaId},"
+          + " comment = #{newTopicMeta.comment},"
+          + " properties = #{newTopicMeta.properties},"
+          + " audit_info = #{newTopicMeta.auditInfo},"
+          + " current_version = #{newTopicMeta.currentVersion},"
+          + " last_version = #{newTopicMeta.lastVersion},"
+          + " deleted_at = #{newTopicMeta.deletedAt}"
+          + " WHERE topic_id = #{oldTopicMeta.topicId}"
+          + " AND topic_name = #{oldTopicMeta.topicName}"
+          + " AND metalake_id = #{oldTopicMeta.metalakeId}"
+          + " AND catalog_id = #{oldTopicMeta.catalogId}"
+          + " AND schema_id = #{oldTopicMeta.schemaId}"
+          + " AND comment = #{oldTopicMeta.comment}"
+          + " AND properties = #{oldTopicMeta.properties}"
+          + " AND audit_info = #{oldTopicMeta.auditInfo}"
+          + " AND current_version = #{oldTopicMeta.currentVersion}"
+          + " AND last_version = #{oldTopicMeta.lastVersion}"
+          + " AND deleted_at = 0")
+  Integer updateTopicMeta(
+      @Param("newTopicMeta") TopicPO newTopicPO, @Param("oldTopicMeta") TopicPO oldTopicPO);
+
+  @Select(
+      "SELECT topic_id as topicId FROM "
+          + TABLE_NAME
+          + " WHERE schema_id = #{schemaId} AND topic_name = #{topicName}"
+          + " AND deleted_at = 0")
+  Long selectTopicIdBySchemaIdAndName(
+      @Param("schemaId") Long schemaId, @Param("topicName") String name);
+
+  @Update(
+      "UPDATE "
+          + TABLE_NAME
+          + " SET deleted_at = UNIX_TIMESTAMP(CURRENT_TIMESTAMP(3)) * 1000.0"
+          + " WHERE topic_id = #{topicId} AND deleted_at = 0")
+  Integer softDeleteTopicMetasByTopicId(@Param("topicId") Long topicId);
+
+  @Update(
+      "UPDATE "
+          + TABLE_NAME
+          + " SET deleted_at = UNIX_TIMESTAMP(CURRENT_TIMESTAMP(3)) * 1000.0"
+          + " WHERE catalog_id = #{catalogId} AND deleted_at = 0")
+  Integer softDeleteTopicMetasByCatalogId(@Param("catalogId") Long catalogId);
+
+  @Update(
+      "UPDATE "
+          + TABLE_NAME
+          + " SET deleted_at = UNIX_TIMESTAMP(CURRENT_TIMESTAMP(3)) * 1000.0"
+          + " WHERE metalake_id = #{metalakeId} AND deleted_at = 0")
+  Integer softDeleteTopicMetasByMetalakeId(@Param("metalakeId") Long metalakeId);
+
+  @Update(
+      "UPDATE "
+          + TABLE_NAME
+          + " SET deleted_at = UNIX_TIMESTAMP(CURRENT_TIMESTAMP(3)) * 1000.0"
+          + " WHERE schema_id = #{schemaId} AND deleted_at = 0")
+  Integer softDeleteTopicMetasBySchemaId(@Param("schemaId") Long schemaId);
+}

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/mapper/TopicMetaMapper.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/mapper/TopicMetaMapper.java
@@ -38,8 +38,8 @@ public interface TopicMetaMapper {
   @Insert(
       "INSERT INTO "
           + TABLE_NAME
-          + "(topic_id, topic_name, metalake_id,  catalog_id, schema_id,"
-          + " comment, properties, audit_info,  current_version, last_version,"
+          + "(topic_id, topic_name, metalake_id, catalog_id, schema_id,"
+          + " comment, properties, audit_info, current_version, last_version,"
           + " deleted_at)"
           + " VALUES("
           + " #{topicMeta.topicId},"

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/po/TopicPO.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/po/TopicPO.java
@@ -40,6 +40,8 @@ public class TopicPO {
         && Objects.equals(metalakeId, topicPO.metalakeId)
         && Objects.equals(catalogId, topicPO.catalogId)
         && Objects.equals(schemaId, topicPO.schemaId)
+        && Objects.equals(comment, topicPO.comment)
+        && Objects.equals(properties, topicPO.properties)
         && Objects.equals(auditInfo, topicPO.auditInfo)
         && Objects.equals(currentVersion, topicPO.currentVersion)
         && Objects.equals(lastVersion, topicPO.lastVersion)
@@ -54,6 +56,8 @@ public class TopicPO {
         metalakeId,
         catalogId,
         schemaId,
+        comment,
+        properties,
         auditInfo,
         currentVersion,
         lastVersion,

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/po/TopicPO.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/po/TopicPO.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.storage.relational.po;
+
+import com.google.common.base.Preconditions;
+import java.util.Objects;
+import lombok.Getter;
+
+@Getter
+public class TopicPO {
+  private Long topicId;
+  private String topicName;
+  private Long metalakeId;
+  private Long catalogId;
+  private Long schemaId;
+  private String comment;
+  private String properties;
+  private String auditInfo;
+  private Long currentVersion;
+  private Long lastVersion;
+  private Long deletedAt;
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof TopicPO)) {
+      return false;
+    }
+    TopicPO topicPO = (TopicPO) o;
+    return Objects.equals(topicId, topicPO.topicId)
+        && Objects.equals(topicName, topicPO.topicName)
+        && Objects.equals(metalakeId, topicPO.metalakeId)
+        && Objects.equals(catalogId, topicPO.catalogId)
+        && Objects.equals(schemaId, topicPO.schemaId)
+        && Objects.equals(auditInfo, topicPO.auditInfo)
+        && Objects.equals(currentVersion, topicPO.currentVersion)
+        && Objects.equals(lastVersion, topicPO.lastVersion)
+        && Objects.equals(deletedAt, topicPO.deletedAt);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        topicId,
+        topicName,
+        metalakeId,
+        catalogId,
+        schemaId,
+        auditInfo,
+        currentVersion,
+        lastVersion,
+        deletedAt);
+  }
+
+  public static class Builder {
+    private final TopicPO topicPO;
+
+    private Builder() {
+      topicPO = new TopicPO();
+    }
+
+    public Builder withTopicId(Long topicId) {
+      topicPO.topicId = topicId;
+      return this;
+    }
+
+    public Builder withTopicName(String topicName) {
+      topicPO.topicName = topicName;
+      return this;
+    }
+
+    public Builder withMetalakeId(Long metalakeId) {
+      topicPO.metalakeId = metalakeId;
+      return this;
+    }
+
+    public Builder withCatalogId(Long catalogId) {
+      topicPO.catalogId = catalogId;
+      return this;
+    }
+
+    public Builder withSchemaId(Long schemaId) {
+      topicPO.schemaId = schemaId;
+      return this;
+    }
+
+    public Builder withAuditInfo(String auditInfo) {
+      topicPO.auditInfo = auditInfo;
+      return this;
+    }
+
+    public Builder withCurrentVersion(Long currentVersion) {
+      topicPO.currentVersion = currentVersion;
+      return this;
+    }
+
+    public Builder withLastVersion(Long lastVersion) {
+      topicPO.lastVersion = lastVersion;
+      return this;
+    }
+
+    public Builder withDeletedAt(Long deletedAt) {
+      topicPO.deletedAt = deletedAt;
+      return this;
+    }
+
+    public Builder withComment(String comment) {
+      topicPO.comment = comment;
+      return this;
+    }
+
+    public Builder withProperties(String properties) {
+      topicPO.properties = properties;
+      return this;
+    }
+
+    private void validate() {
+      Preconditions.checkArgument(topicPO.topicId != null, "topicId cannot be null");
+      Preconditions.checkArgument(topicPO.topicName != null, "topicName cannot be null");
+      Preconditions.checkArgument(topicPO.metalakeId != null, "metalakeId cannot be null");
+      Preconditions.checkArgument(topicPO.catalogId != null, "catalogId cannot be null");
+      Preconditions.checkArgument(topicPO.schemaId != null, "schemaId cannot be null");
+      Preconditions.checkArgument(topicPO.auditInfo != null, "auditInfo cannot be null");
+      Preconditions.checkArgument(topicPO.currentVersion != null, "currentVersion cannot be null");
+      Preconditions.checkArgument(topicPO.lastVersion != null, "lastVersion cannot be null");
+      Preconditions.checkArgument(topicPO.deletedAt != null, "deletedAt cannot be null");
+    }
+
+    public TopicPO build() {
+      validate();
+      return topicPO;
+    }
+  }
+}

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/service/CatalogMetaService.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/service/CatalogMetaService.java
@@ -17,6 +17,7 @@ import com.datastrato.gravitino.storage.relational.mapper.FilesetMetaMapper;
 import com.datastrato.gravitino.storage.relational.mapper.FilesetVersionMapper;
 import com.datastrato.gravitino.storage.relational.mapper.SchemaMetaMapper;
 import com.datastrato.gravitino.storage.relational.mapper.TableMetaMapper;
+import com.datastrato.gravitino.storage.relational.mapper.TopicMetaMapper;
 import com.datastrato.gravitino.storage.relational.po.CatalogPO;
 import com.datastrato.gravitino.storage.relational.utils.ExceptionUtils;
 import com.datastrato.gravitino.storage.relational.utils.POConverters;
@@ -188,7 +189,11 @@ public class CatalogMetaService {
           () ->
               SessionUtils.doWithoutCommit(
                   FilesetVersionMapper.class,
-                  mapper -> mapper.softDeleteFilesetVersionsByCatalogId(catalogId)));
+                  mapper -> mapper.softDeleteFilesetVersionsByCatalogId(catalogId)),
+          () ->
+              SessionUtils.doWithoutCommit(
+                  TopicMetaMapper.class,
+                  mapper -> mapper.softDeleteTopicMetasByCatalogId(catalogId)));
     } else {
       List<SchemaEntity> schemaEntities =
           SchemaMetaService.getInstance()

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/service/MetalakeMetaService.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/service/MetalakeMetaService.java
@@ -19,6 +19,7 @@ import com.datastrato.gravitino.storage.relational.mapper.FilesetVersionMapper;
 import com.datastrato.gravitino.storage.relational.mapper.MetalakeMetaMapper;
 import com.datastrato.gravitino.storage.relational.mapper.SchemaMetaMapper;
 import com.datastrato.gravitino.storage.relational.mapper.TableMetaMapper;
+import com.datastrato.gravitino.storage.relational.mapper.TopicMetaMapper;
 import com.datastrato.gravitino.storage.relational.po.MetalakePO;
 import com.datastrato.gravitino.storage.relational.utils.ExceptionUtils;
 import com.datastrato.gravitino.storage.relational.utils.POConverters;
@@ -165,7 +166,11 @@ public class MetalakeMetaService {
             () ->
                 SessionUtils.doWithoutCommit(
                     FilesetVersionMapper.class,
-                    mapper -> mapper.softDeleteFilesetVersionsByMetalakeId(metalakeId)));
+                    mapper -> mapper.softDeleteFilesetVersionsByMetalakeId(metalakeId)),
+            () ->
+                SessionUtils.doWithoutCommit(
+                    TopicMetaMapper.class,
+                    mapper -> mapper.softDeleteTopicMetasByMetalakeId(metalakeId)));
       } else {
         List<CatalogEntity> catalogEntities =
             CatalogMetaService.getInstance()

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/service/SchemaMetaService.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/service/SchemaMetaService.java
@@ -17,6 +17,7 @@ import com.datastrato.gravitino.storage.relational.mapper.FilesetMetaMapper;
 import com.datastrato.gravitino.storage.relational.mapper.FilesetVersionMapper;
 import com.datastrato.gravitino.storage.relational.mapper.SchemaMetaMapper;
 import com.datastrato.gravitino.storage.relational.mapper.TableMetaMapper;
+import com.datastrato.gravitino.storage.relational.mapper.TopicMetaMapper;
 import com.datastrato.gravitino.storage.relational.po.SchemaPO;
 import com.datastrato.gravitino.storage.relational.utils.ExceptionUtils;
 import com.datastrato.gravitino.storage.relational.utils.POConverters;
@@ -179,7 +180,11 @@ public class SchemaMetaService {
             () ->
                 SessionUtils.doWithoutCommit(
                     FilesetVersionMapper.class,
-                    mapper -> mapper.softDeleteFilesetVersionsBySchemaId(schemaId)));
+                    mapper -> mapper.softDeleteFilesetVersionsBySchemaId(schemaId)),
+            () ->
+                SessionUtils.doWithoutCommit(
+                    TopicMetaMapper.class,
+                    mapper -> mapper.softDeleteTopicMetasBySchemaId(schemaId)));
       } else {
         List<TableEntity> tableEntities =
             TableMetaService.getInstance()

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/service/TopicMetaService.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/service/TopicMetaService.java
@@ -149,7 +149,7 @@ public class TopicMetaService {
     }
   }
 
-  public Object getTopicByIdentifier(NameIdentifier identifier) {
+  public TopicEntity getTopicByIdentifier(NameIdentifier identifier) {
     NameIdentifier.checkTopic(identifier);
 
     Long schemaId =

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/service/TopicMetaService.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/service/TopicMetaService.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.storage.relational.service;
+
+import com.datastrato.gravitino.Entity;
+import com.datastrato.gravitino.HasIdentifier;
+import com.datastrato.gravitino.NameIdentifier;
+import com.datastrato.gravitino.Namespace;
+import com.datastrato.gravitino.exceptions.NoSuchEntityException;
+import com.datastrato.gravitino.meta.TopicEntity;
+import com.datastrato.gravitino.storage.relational.mapper.TopicMetaMapper;
+import com.datastrato.gravitino.storage.relational.po.TopicPO;
+import com.datastrato.gravitino.storage.relational.utils.ExceptionUtils;
+import com.datastrato.gravitino.storage.relational.utils.POConverters;
+import com.datastrato.gravitino.storage.relational.utils.SessionUtils;
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * The service class for topic metadata. It provides the basic database operations for topic
+ * metadata.
+ */
+public class TopicMetaService {
+  private static final TopicMetaService INSTANCE = new TopicMetaService();
+
+  public static TopicMetaService getInstance() {
+    return INSTANCE;
+  }
+
+  private TopicMetaService() {}
+
+  public void insertTopic(TopicEntity topicEntity, boolean overwrite) {
+    try {
+      NameIdentifier.checkTopic(topicEntity.nameIdentifier());
+
+      TopicPO.Builder builder = TopicPO.builder();
+      fillTopicPOBuilderParentEntityId(builder, topicEntity.namespace());
+
+      SessionUtils.doWithCommit(
+          TopicMetaMapper.class,
+          mapper -> {
+            TopicPO po = POConverters.initializeTopicPOWithVersion(topicEntity, builder);
+            if (overwrite) {
+              mapper.insertTopicMetaOnDuplicateKeyUpdate(po);
+            } else {
+              mapper.insertTopicMeta(po);
+            }
+          });
+      // TODO: insert topic dataLayout version after supporting it
+    } catch (RuntimeException re) {
+      ExceptionUtils.checkSQLConstraintException(
+          re, Entity.EntityType.TOPIC, topicEntity.nameIdentifier().toString());
+      throw re;
+    }
+  }
+
+  public List<TopicEntity> listTopicsByNamespace(Namespace namespace) {
+    Namespace.checkTopic(namespace);
+
+    Long schemaId = CommonMetaService.getInstance().getParentEntityIdByNamespace(namespace);
+
+    List<TopicPO> topicPOs =
+        SessionUtils.getWithoutCommit(
+            TopicMetaMapper.class, mapper -> mapper.listTopicPOsBySchemaId(schemaId));
+
+    return POConverters.fromTopicPOs(topicPOs, namespace);
+  }
+
+  public <E extends Entity & HasIdentifier> TopicEntity updateTopic(
+      NameIdentifier ident, Function<E, E> updater) throws IOException {
+    NameIdentifier.checkTopic(ident);
+
+    String topicName = ident.name();
+
+    Long schemaId = CommonMetaService.getInstance().getParentEntityIdByNamespace(ident.namespace());
+
+    TopicPO oldTopicPO = getTopicPOBySchemaIdAndName(schemaId, topicName);
+    TopicEntity oldTopicEntity = POConverters.fromTopicPO(oldTopicPO, ident.namespace());
+    TopicEntity newEntity = (TopicEntity) updater.apply((E) oldTopicEntity);
+    Preconditions.checkArgument(
+        Objects.equals(oldTopicEntity.id(), newEntity.id()),
+        "The updated topic entity id: %s should be same with the topic entity id before: %s",
+        newEntity.id(),
+        oldTopicEntity.id());
+
+    Integer updateResult;
+    try {
+      updateResult =
+          SessionUtils.doWithCommitAndFetchResult(
+              TopicMetaMapper.class,
+              mapper ->
+                  mapper.updateTopicMeta(
+                      POConverters.updateTopicPOWithVersion(oldTopicPO, newEntity), oldTopicPO));
+    } catch (RuntimeException re) {
+      ExceptionUtils.checkSQLConstraintException(
+          re, Entity.EntityType.TOPIC, newEntity.nameIdentifier().toString());
+      throw re;
+    }
+
+    if (updateResult > 0) {
+      return newEntity;
+    } else {
+      throw new IOException("Failed to update the entity: " + ident);
+    }
+  }
+
+  private TopicPO getTopicPOBySchemaIdAndName(Long schemaId, String topicName) {
+    TopicPO topicPO =
+        SessionUtils.getWithoutCommit(
+            TopicMetaMapper.class,
+            mapper -> mapper.selectTopicMetaBySchemaIdAndName(schemaId, topicName));
+
+    if (topicPO == null) {
+      throw new NoSuchEntityException(
+          NoSuchEntityException.NO_SUCH_ENTITY_MESSAGE,
+          Entity.EntityType.TOPIC.name().toLowerCase(),
+          topicName);
+    }
+    return topicPO;
+  }
+
+  private void fillTopicPOBuilderParentEntityId(TopicPO.Builder builder, Namespace namespace) {
+    Namespace.checkTopic(namespace);
+    Long parentEntityId = null;
+    for (int level = 0; level < namespace.levels().length; level++) {
+      String name = namespace.level(level);
+      switch (level) {
+        case 0:
+          parentEntityId = MetalakeMetaService.getInstance().getMetalakeIdByName(name);
+          builder.withMetalakeId(parentEntityId);
+          continue;
+        case 1:
+          parentEntityId =
+              CatalogMetaService.getInstance()
+                  .getCatalogIdByMetalakeIdAndName(parentEntityId, name);
+          builder.withCatalogId(parentEntityId);
+          continue;
+        case 2:
+          parentEntityId =
+              SchemaMetaService.getInstance().getSchemaIdByCatalogIdAndName(parentEntityId, name);
+          builder.withSchemaId(parentEntityId);
+          break;
+      }
+    }
+  }
+
+  public Object getTopicByIdentifier(NameIdentifier identifier) {
+    NameIdentifier.checkTopic(identifier);
+
+    Long schemaId =
+        CommonMetaService.getInstance().getParentEntityIdByNamespace(identifier.namespace());
+
+    TopicPO topicPO = getTopicPOBySchemaIdAndName(schemaId, identifier.name());
+
+    return POConverters.fromTopicPO(topicPO, identifier.namespace());
+  }
+
+  public boolean deleteTopic(NameIdentifier identifier) {
+    NameIdentifier.checkTopic(identifier);
+
+    String topicName = identifier.name();
+
+    Long schemaId =
+        CommonMetaService.getInstance().getParentEntityIdByNamespace(identifier.namespace());
+
+    Long topicId = getTopicIdBySchemaIdAndName(schemaId, topicName);
+
+    SessionUtils.doWithCommit(
+        TopicMetaMapper.class, mapper -> mapper.softDeleteTopicMetasByTopicId(topicId));
+
+    return true;
+  }
+
+  private Long getTopicIdBySchemaIdAndName(Long schemaId, String topicName) {
+    Long topicId =
+        SessionUtils.getWithoutCommit(
+            TopicMetaMapper.class,
+            mapper -> mapper.selectTopicIdBySchemaIdAndName(schemaId, topicName));
+
+    if (topicId == null) {
+      throw new NoSuchEntityException(
+          NoSuchEntityException.NO_SUCH_ENTITY_MESSAGE,
+          Entity.EntityType.TOPIC.name().toLowerCase(),
+          topicName);
+    }
+    return topicId;
+  }
+}

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/session/SqlSessionFactoryHelper.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/session/SqlSessionFactoryHelper.java
@@ -13,6 +13,7 @@ import com.datastrato.gravitino.storage.relational.mapper.FilesetVersionMapper;
 import com.datastrato.gravitino.storage.relational.mapper.MetalakeMetaMapper;
 import com.datastrato.gravitino.storage.relational.mapper.SchemaMetaMapper;
 import com.datastrato.gravitino.storage.relational.mapper.TableMetaMapper;
+import com.datastrato.gravitino.storage.relational.mapper.TopicMetaMapper;
 import com.google.common.base.Preconditions;
 import java.sql.SQLException;
 import java.time.Duration;
@@ -84,6 +85,7 @@ public class SqlSessionFactoryHelper {
     configuration.addMapper(TableMetaMapper.class);
     configuration.addMapper(FilesetMetaMapper.class);
     configuration.addMapper(FilesetVersionMapper.class);
+    configuration.addMapper(TopicMetaMapper.class);
 
     // Create the SqlSessionFactory object, it is a singleton object
     if (sqlSessionFactory == null) {

--- a/core/src/test/java/com/datastrato/gravitino/storage/TestEntityStorage.java
+++ b/core/src/test/java/com/datastrato/gravitino/storage/TestEntityStorage.java
@@ -39,10 +39,12 @@ import com.datastrato.gravitino.meta.GroupEntity;
 import com.datastrato.gravitino.meta.SchemaEntity;
 import com.datastrato.gravitino.meta.SchemaVersion;
 import com.datastrato.gravitino.meta.TableEntity;
+import com.datastrato.gravitino.meta.TopicEntity;
 import com.datastrato.gravitino.meta.UserEntity;
 import com.datastrato.gravitino.storage.relational.RelationalEntityStore;
 import com.datastrato.gravitino.storage.relational.session.SqlSessionFactoryHelper;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import java.io.File;
 import java.io.IOException;
@@ -216,6 +218,12 @@ public class TestEntityStorage {
               Namespace.of("metalake", "catalog", "schema1"),
               "fileset1",
               auditInfo);
+      TopicEntity topic1 =
+          createTopicEntity(
+              RandomIdGenerator.INSTANCE.nextId(),
+              Namespace.of("metalake", "catalog", "schema1"),
+              "topic1",
+              auditInfo);
 
       // Store all entities
       store.put(metalake);
@@ -224,6 +232,7 @@ public class TestEntityStorage {
       store.put(schema1);
       store.put(table1);
       store.put(fileset1);
+      store.put(topic1);
 
       Assertions.assertDoesNotThrow(
           () ->
@@ -253,6 +262,12 @@ public class TestEntityStorage {
                   NameIdentifier.of("metalake", "catalog", "schema1", "fileset1"),
                   Entity.EntityType.FILESET,
                   FilesetEntity.class));
+      Assertions.assertDoesNotThrow(
+          () ->
+              store.get(
+                  NameIdentifier.of("metalake", "catalog", "schema1", "topic1"),
+                  Entity.EntityType.TOPIC,
+                  TopicEntity.class));
     }
 
     // It will automatically close the store we create before, then we reopen the entity store
@@ -287,6 +302,12 @@ public class TestEntityStorage {
                   NameIdentifier.of("metalake", "catalog", "schema1", "fileset1"),
                   Entity.EntityType.FILESET,
                   FilesetEntity.class));
+      Assertions.assertDoesNotThrow(
+          () ->
+              store.get(
+                  NameIdentifier.of("metalake", "catalog", "schema1", "topic1"),
+                  Entity.EntityType.TOPIC,
+                  TopicEntity.class));
       destroy(type);
     }
   }
@@ -336,6 +357,12 @@ public class TestEntityStorage {
               Namespace.of("metalake", "catalog", "schema1"),
               "fileset1",
               auditInfo);
+      TopicEntity topic1 =
+          createTopicEntity(
+              RandomIdGenerator.INSTANCE.nextId(),
+              Namespace.of("metalake", "catalog", "schema1"),
+              "topic1",
+              auditInfo);
 
       SchemaEntity schema2 =
           createSchemaEntity(
@@ -355,6 +382,12 @@ public class TestEntityStorage {
               Namespace.of("metalake", "catalog", "schema2"),
               "fileset1",
               auditInfo);
+      TopicEntity topic1InSchema2 =
+          createTopicEntity(
+              RandomIdGenerator.INSTANCE.nextId(),
+              Namespace.of("metalake", "catalog", "schema2"),
+              "topic1",
+              auditInfo);
 
       // Store all entities
       store.put(metalake);
@@ -366,14 +399,18 @@ public class TestEntityStorage {
       store.put(table1InSchema2);
       store.put(fileset1);
       store.put(fileset1InSchema2);
+      store.put(topic1);
+      store.put(topic1InSchema2);
 
       validateMetalakeChanged(store, metalake);
       validateCatalogChanged(store, catalog);
       validateSchemaChanged(store, schema1);
       validateTableChanged(store, table1);
       validateFilesetChanged(store, fileset1);
+      validateTopicChanged(store, topic1);
       validateDeletedTable(store);
       validateDeletedFileset(store);
+      validateDeletedTopic(store);
       validateAlreadyExistEntity(store, schema2);
       validateNotChangedEntity(store, schema2);
 
@@ -420,7 +457,6 @@ public class TestEntityStorage {
   @ParameterizedTest
   @MethodSource("storageProvider")
   void testEntityDelete(String type) throws IOException {
-    // TODO
     Config config = Mockito.mock(Config.class);
     init(type, config);
 
@@ -446,6 +482,9 @@ public class TestEntityStorage {
       FilesetEntity fileset1 =
           createFilesetEntity(
               1L, Namespace.of("metalake", "catalog", "schema1"), "fileset1", auditInfo);
+      TopicEntity topic1 =
+          createTopicEntity(
+              1L, Namespace.of("metalake", "catalog", "schema1"), "topic1", auditInfo);
 
       SchemaEntity schema2 =
           createSchemaEntity(2L, Namespace.of("metalake", "catalog"), "schema2", auditInfo);
@@ -455,6 +494,9 @@ public class TestEntityStorage {
       FilesetEntity fileset1InSchema2 =
           createFilesetEntity(
               2L, Namespace.of("metalake", "catalog", "schema2"), "fileset1", auditInfo);
+      TopicEntity topic1InSchema2 =
+          createTopicEntity(
+              2L, Namespace.of("metalake", "catalog", "schema2"), "topic1", auditInfo);
 
       // Store all entities
       store.put(metalake);
@@ -466,6 +508,8 @@ public class TestEntityStorage {
       store.put(table1InSchema2);
       store.put(fileset1);
       store.put(fileset1InSchema2);
+      store.put(topic1);
+      store.put(topic1InSchema2);
 
       validateAllEntityExist(
           metalake,
@@ -477,26 +521,41 @@ public class TestEntityStorage {
           table1,
           table1InSchema2,
           fileset1,
-          fileset1InSchema2);
+          fileset1InSchema2,
+          topic1,
+          topic1InSchema2);
 
       validateDeleteTable(store, schema2, table1, table1InSchema2);
 
       validateDeleteFileset(store, schema2, fileset1, fileset1InSchema2);
 
-      validateDeleteSchema(store, schema1, table1, fileset1);
+      validateDeleteTopic(store, schema2, topic1, topic1InSchema2);
+
+      validateDeleteSchema(store, schema1, table1, fileset1, topic1);
 
       validateDeleteCatalog(
-          store, catalog, table1, schema1, table1InSchema2, schema2, fileset1, fileset1InSchema2);
+          store,
+          catalog,
+          table1,
+          schema1,
+          table1InSchema2,
+          schema2,
+          fileset1,
+          fileset1InSchema2,
+          topic1,
+          topic1InSchema2);
 
       validateDeleteMetalake(store, metalake, catalogCopy);
 
       // Store all entities again
+      // metalake
       BaseMetalake metalakeNew =
           createBaseMakeLake(
               RandomIdGenerator.INSTANCE.nextId(),
               metalake.name(),
               (AuditInfo) metalake.auditInfo());
       store.put(metalakeNew);
+      // catalog
       CatalogEntity catalogNew =
           createCatalog(
               RandomIdGenerator.INSTANCE.nextId(),
@@ -511,6 +570,7 @@ public class TestEntityStorage {
               catalogCopy.name(),
               (AuditInfo) catalogCopy.auditInfo());
       store.put(catalogCopyNew);
+      // schema
       SchemaEntity schema1New =
           createSchemaEntity(
               RandomIdGenerator.INSTANCE.nextId(),
@@ -525,6 +585,7 @@ public class TestEntityStorage {
               schema2.name(),
               schema2.auditInfo());
       store.put(schema2New);
+      // table
       TableEntity table1New =
           createTableEntity(
               RandomIdGenerator.INSTANCE.nextId(),
@@ -539,6 +600,7 @@ public class TestEntityStorage {
               table1InSchema2.name(),
               table1InSchema2.auditInfo());
       store.put(table1InSchema2New);
+      // fileset
       FilesetEntity fileset1New =
           createFilesetEntity(
               RandomIdGenerator.INSTANCE.nextId(),
@@ -553,12 +615,29 @@ public class TestEntityStorage {
               fileset1InSchema2.name(),
               fileset1InSchema2.auditInfo());
       store.put(fileset1InSchema2New);
+      // topic
+      TopicEntity topic1New =
+          createTopicEntity(
+              RandomIdGenerator.INSTANCE.nextId(),
+              topic1.namespace(),
+              topic1.name(),
+              topic1.auditInfo());
+      store.put(topic1New);
+      TopicEntity topic1InSchema2New =
+          createTopicEntity(
+              RandomIdGenerator.INSTANCE.nextId(),
+              topic1InSchema2.namespace(),
+              topic1InSchema2.name(),
+              topic1InSchema2.auditInfo());
+      store.put(topic1InSchema2New);
 
       validateDeleteTableCascade(store, table1New);
 
       validateDeleteFilesetCascade(store, fileset1New);
 
-      validateDeleteSchemaCascade(store, schema1New, table1New, fileset1New);
+      validateDeleteTopicCascade(store, topic1New);
+
+      validateDeleteSchemaCascade(store, schema1New, table1New, fileset1New, topic1New);
 
       validateDeleteCatalogCascade(store, catalogNew, schema2New);
 
@@ -605,11 +684,15 @@ public class TestEntityStorage {
           createFilesetEntity(
               RandomIdGenerator.INSTANCE.nextId(), namespace, "sameName", auditInfo);
 
+      TopicEntity topicEntity1 =
+          createTopicEntity(RandomIdGenerator.INSTANCE.nextId(), namespace, "sameName", auditInfo);
+
       store.put(metalake1);
       store.put(catalog1);
       store.put(schema1);
       store.put(table1);
       store.put(filesetEntity1);
+      store.put(topicEntity1);
 
       NameIdentifier identifier = NameIdentifier.of("metalake1", "catalog1", "schema1", "sameName");
 
@@ -619,24 +702,43 @@ public class TestEntityStorage {
       FilesetEntity loadedFilesetEntity =
           store.get(identifier, Entity.EntityType.FILESET, FilesetEntity.class);
       Assertions.assertEquals(filesetEntity1.id(), loadedFilesetEntity.id());
+      TopicEntity loadedTopicEntity =
+          store.get(identifier, Entity.EntityType.TOPIC, TopicEntity.class);
+      Assertions.assertEquals(topicEntity1.id(), loadedTopicEntity.id());
 
-      // Remove anyone will not affect another
-      store.delete(identifier, Entity.EntityType.TABLE);
-      store.get(identifier, Entity.EntityType.FILESET, FilesetEntity.class);
+      // Remove table will not affect another
+      Assertions.assertTrue(store.delete(identifier, Entity.EntityType.TABLE));
+      Assertions.assertNotNull(
+          store.get(identifier, Entity.EntityType.FILESET, FilesetEntity.class));
+      Assertions.assertNotNull(store.get(identifier, Entity.EntityType.TOPIC, TopicEntity.class));
 
       // JDBC use id as the primary key, so we need to change the id of table1 if we want to store
       // it again
       table1 =
           createTableEntity(RandomIdGenerator.INSTANCE.nextId(), namespace, "sameName", auditInfo);
       store.put(table1);
-      store.delete(identifier, Entity.EntityType.FILESET);
-      store.get(identifier, Entity.EntityType.TABLE, TableEntity.class);
 
-      // Rename anyone will not affect another
+      // Remove fileset will not affect another
+      store.delete(identifier, Entity.EntityType.FILESET);
+      Assertions.assertNotNull(store.get(identifier, Entity.EntityType.TABLE, TableEntity.class));
+      Assertions.assertNotNull(store.get(identifier, Entity.EntityType.TOPIC, TopicEntity.class));
+
       filesetEntity1 =
           createFilesetEntity(
               RandomIdGenerator.INSTANCE.nextId(), namespace, "sameName", auditInfo);
       store.put(filesetEntity1);
+
+      // Remove topic will not affect another
+      store.delete(identifier, Entity.EntityType.TOPIC);
+      Assertions.assertNotNull(store.get(identifier, Entity.EntityType.TABLE, TableEntity.class));
+      Assertions.assertNotNull(
+          store.get(identifier, Entity.EntityType.FILESET, FilesetEntity.class));
+
+      topicEntity1 =
+          createTopicEntity(RandomIdGenerator.INSTANCE.nextId(), namespace, "sameName", auditInfo);
+      store.put(topicEntity1);
+
+      // Rename table will not affect another
       long table1Id = table1.id();
       store.update(
           identifier,
@@ -648,10 +750,13 @@ public class TestEntityStorage {
           NameIdentifier.of("metalake1", "catalog1", "schema1", "sameNameChanged");
       store.get(changedNameIdentifier, Entity.EntityType.TABLE, TableEntity.class);
       store.get(identifier, Entity.EntityType.FILESET, FilesetEntity.class);
+      store.get(identifier, Entity.EntityType.TOPIC, TopicEntity.class);
 
       table1 =
           createTableEntity(RandomIdGenerator.INSTANCE.nextId(), namespace, "sameName", auditInfo);
       store.put(table1);
+
+      // Rename fileset will not affect another
       long filesetId = filesetEntity1.id();
       store.update(
           identifier,
@@ -661,6 +766,24 @@ public class TestEntityStorage {
 
       store.get(identifier, Entity.EntityType.TABLE, TableEntity.class);
       store.get(changedNameIdentifier, Entity.EntityType.FILESET, FilesetEntity.class);
+      store.get(identifier, Entity.EntityType.TOPIC, TopicEntity.class);
+
+      filesetEntity1 =
+          createFilesetEntity(
+              RandomIdGenerator.INSTANCE.nextId(), namespace, "sameName", auditInfo);
+      store.put(filesetEntity1);
+
+      // Rename topic will not affect another
+      long topicId = topicEntity1.id();
+      store.update(
+          identifier,
+          TopicEntity.class,
+          Entity.EntityType.TOPIC,
+          e -> createTopicEntity(topicId, namespace, "sameNameChanged", e.auditInfo()));
+
+      store.get(identifier, Entity.EntityType.TABLE, TableEntity.class);
+      store.get(identifier, Entity.EntityType.FILESET, FilesetEntity.class);
+      store.get(changedNameIdentifier, Entity.EntityType.TOPIC, TopicEntity.class);
     }
   }
 
@@ -898,6 +1021,46 @@ public class TestEntityStorage {
                   "fileset2",
                   e.auditInfo()));
 
+      // Test topic
+      TopicEntity topic1 =
+          createTopicEntity(
+              RandomIdGenerator.INSTANCE.nextId(),
+              Namespace.of("metalake1", "catalog2", "schema2"),
+              "topic1",
+              auditInfo);
+      TopicEntity topic2 =
+          createTopicEntity(
+              RandomIdGenerator.INSTANCE.nextId(),
+              Namespace.of("metalake1", "catalog2", "schema2"),
+              "topic2",
+              auditInfo);
+
+      store.put(topic1);
+      store.put(topic2);
+
+      store.delete(
+          NameIdentifier.of("metalake1", "catalog2", "schema2", "topic1"), Entity.EntityType.TOPIC);
+      store.delete(
+          NameIdentifier.of("metalake1", "catalog2", "schema2", "topic2"), Entity.EntityType.TOPIC);
+
+      TopicEntity topic1New =
+          createTopicEntity(
+              RandomIdGenerator.INSTANCE.nextId(),
+              topic1.namespace(),
+              topic1.name(),
+              topic1.auditInfo());
+      store.put(topic1New);
+      store.update(
+          topic1New.nameIdentifier(),
+          TopicEntity.class,
+          Entity.EntityType.TOPIC,
+          e ->
+              createTopicEntity(
+                  topic1New.id(),
+                  Namespace.of("metalake1", "catalog2", "schema2"),
+                  "topic2",
+                  e.auditInfo()));
+
       destroy(type);
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
@@ -965,6 +1128,18 @@ public class TestEntityStorage {
         .build();
   }
 
+  public static TopicEntity createTopicEntity(
+      Long id, Namespace namespace, String name, AuditInfo auditInfo) {
+    return TopicEntity.builder()
+        .withId(id)
+        .withName(name)
+        .withNamespace(namespace)
+        .withComment("test comment")
+        .withProperties(ImmutableMap.of("key", "value"))
+        .withAuditInfo(auditInfo)
+        .build();
+  }
+
   private static UserEntity createUser(String metalake, String name, AuditInfo auditInfo) {
     return UserEntity.builder()
         .withId(1L)
@@ -989,6 +1164,13 @@ public class TestEntityStorage {
         .withAuditInfo(auditInfo)
         .withRoles(Lists.newArrayList())
         .build();
+  }
+
+  private void validateDeleteTopicCascade(EntityStore store, TopicEntity topic1)
+      throws IOException {
+    // Delete the topic 'metalake.catalog.schema1.topic1'
+    Assertions.assertTrue(store.delete(topic1.nameIdentifier(), Entity.EntityType.TOPIC));
+    Assertions.assertFalse(store.exists(topic1.nameIdentifier(), Entity.EntityType.TOPIC));
   }
 
   private void validateDeleteFilesetCascade(EntityStore store, FilesetEntity fileset1)
@@ -1026,6 +1208,21 @@ public class TestEntityStorage {
         schema2, store.get(schema2.nameIdentifier(), Entity.EntityType.SCHEMA, SchemaEntity.class));
   }
 
+  private void validateDeleteTopic(
+      EntityStore store, SchemaEntity schema2, TopicEntity topic1, TopicEntity topic1InSchema2)
+      throws IOException {
+    // Delete the topic 'metalake.catalog.schema2.topic1'
+    Assertions.assertTrue(store.delete(topic1InSchema2.nameIdentifier(), Entity.EntityType.TOPIC));
+    Assertions.assertFalse(store.exists(topic1InSchema2.nameIdentifier(), Entity.EntityType.TOPIC));
+
+    // Make sure topic 'metalake.catalog.schema1.topic1' still exist;
+    Assertions.assertEquals(
+        topic1, store.get(topic1.nameIdentifier(), Entity.EntityType.TOPIC, TopicEntity.class));
+    // Make sure schema 'metalake.catalog.schema2' still exist;
+    Assertions.assertEquals(
+        schema2, store.get(schema2.nameIdentifier(), Entity.EntityType.SCHEMA, SchemaEntity.class));
+  }
+
   private void validateDeleteMetalakeCascade(
       EntityStore store, BaseMetalake metalake, CatalogEntity catalog, SchemaEntity schema2)
       throws IOException {
@@ -1055,7 +1252,11 @@ public class TestEntityStorage {
   }
 
   private void validateDeleteSchemaCascade(
-      EntityStore store, SchemaEntity schema1, TableEntity table1, FilesetEntity fileset1)
+      EntityStore store,
+      SchemaEntity schema1,
+      TableEntity table1,
+      FilesetEntity fileset1,
+      TopicEntity topic1)
       throws IOException {
     TableEntity table1New =
         createTableEntity(
@@ -1071,6 +1272,13 @@ public class TestEntityStorage {
             fileset1.name(),
             fileset1.auditInfo());
     store.put(fileset1New);
+    TopicEntity topic1New =
+        createTopicEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            topic1.namespace(),
+            topic1.name(),
+            topic1.auditInfo());
+    store.put(topic1New);
 
     Assertions.assertThrowsExactly(
         NonEmptyEntityException.class,
@@ -1096,6 +1304,10 @@ public class TestEntityStorage {
     Assertions.assertThrows(
         NoSuchEntityException.class,
         () -> store.get(fileset1.nameIdentifier(), Entity.EntityType.FILESET, FilesetEntity.class));
+
+    Assertions.assertThrows(
+        NoSuchEntityException.class,
+        () -> store.get(topic1.nameIdentifier(), Entity.EntityType.TOPIC, TopicEntity.class));
   }
 
   private static void validateDeleteMetalake(
@@ -1119,7 +1331,9 @@ public class TestEntityStorage {
       TableEntity table1InSchema2,
       SchemaEntity schema2,
       FilesetEntity fileset1,
-      FilesetEntity fileset1InSchema2)
+      FilesetEntity fileset1InSchema2,
+      TopicEntity topic1,
+      TopicEntity topic1InSchema2)
       throws IOException {
     // Now try to delete all schemas under catalog;
     Assertions.assertThrowsExactly(
@@ -1127,6 +1341,7 @@ public class TestEntityStorage {
         () -> store.delete(catalog.nameIdentifier(), Entity.EntityType.CATALOG));
     store.delete(table1.nameIdentifier(), Entity.EntityType.TABLE);
     store.delete(fileset1.nameIdentifier(), Entity.EntityType.FILESET);
+    store.delete(topic1.nameIdentifier(), Entity.EntityType.TOPIC);
     try {
       Thread.sleep(1000);
     } catch (InterruptedException e) {
@@ -1136,6 +1351,7 @@ public class TestEntityStorage {
     store.delete(table1InSchema2.nameIdentifier(), Entity.EntityType.TABLE);
     Assertions.assertFalse(
         store.exists(fileset1InSchema2.nameIdentifier(), Entity.EntityType.FILESET));
+    Assertions.assertFalse(store.exists(topic1InSchema2.nameIdentifier(), Entity.EntityType.TOPIC));
     store.delete(schema2.nameIdentifier(), Entity.EntityType.SCHEMA);
 
     store.delete(catalog.nameIdentifier(), Entity.EntityType.CATALOG);
@@ -1143,7 +1359,11 @@ public class TestEntityStorage {
   }
 
   private static void validateDeleteSchema(
-      EntityStore store, SchemaEntity schema1, TableEntity table1, FilesetEntity fileset1)
+      EntityStore store,
+      SchemaEntity schema1,
+      TableEntity table1,
+      FilesetEntity fileset1,
+      TopicEntity topic1)
       throws IOException {
     // Delete the schema 'metalake.catalog.schema1' but failed, because it ha sub-entities;
     NonEmptyEntityException exception =
@@ -1151,21 +1371,25 @@ public class TestEntityStorage {
             NonEmptyEntityException.class,
             () -> store.delete(schema1.nameIdentifier(), Entity.EntityType.SCHEMA));
     Assertions.assertTrue(exception.getMessage().contains("metalake.catalog.schema1"));
-    // Make sure schema 'metalake.catalog.schema1' and table 'metalake.catalog.schema1.table1'
-    // and table 'metalake.catalog.schema1.fileset1' has not been deleted yet;
+    // Make sure schema 'metalake.catalog.schema1', table 'metalake.catalog.schema1.table1',
+    // table 'metalake.catalog.schema1.fileset1' and table 'metalake.catalog.schema1.topic1'
+    // has not been deleted yet;
     Assertions.assertTrue(store.exists(schema1.nameIdentifier(), Entity.EntityType.SCHEMA));
     Assertions.assertTrue(store.exists(table1.nameIdentifier(), Entity.EntityType.TABLE));
     Assertions.assertTrue(store.exists(fileset1.nameIdentifier(), Entity.EntityType.FILESET));
+    Assertions.assertTrue(store.exists(topic1.nameIdentifier(), Entity.EntityType.TOPIC));
 
     // Delete table1,fileset1 and schema1
     Assertions.assertTrue(store.delete(table1.nameIdentifier(), Entity.EntityType.TABLE));
     Assertions.assertTrue(store.delete(fileset1.nameIdentifier(), Entity.EntityType.FILESET));
+    Assertions.assertTrue(store.delete(topic1.nameIdentifier(), Entity.EntityType.TOPIC));
     Assertions.assertTrue(store.delete(schema1.nameIdentifier(), Entity.EntityType.SCHEMA));
     // Make sure table1, fileset1 in 'metalake.catalog.schema1' can't be access;
     Assertions.assertFalse(store.exists(table1.nameIdentifier(), Entity.EntityType.TABLE));
     Assertions.assertFalse(store.exists(fileset1.nameIdentifier(), Entity.EntityType.FILESET));
+    Assertions.assertFalse(store.exists(topic1.nameIdentifier(), Entity.EntityType.TOPIC));
     Assertions.assertFalse(store.exists(schema1.nameIdentifier(), Entity.EntityType.SCHEMA));
-    // Now we re-insert table1 and schema1, and everything should be OK
+    // Now we re-insert schema1, table1, fileset1 and topic1, and everything should be OK
     SchemaEntity schema1New =
         createSchemaEntity(
             RandomIdGenerator.INSTANCE.nextId(),
@@ -1187,6 +1411,14 @@ public class TestEntityStorage {
             fileset1.name(),
             fileset1.auditInfo());
     store.put(fileset1New);
+    TopicEntity topic1New =
+        createTopicEntity(
+            RandomIdGenerator.INSTANCE.nextId(),
+            topic1.namespace(),
+            topic1.name(),
+            topic1.auditInfo());
+    store.put(topic1New);
+
     Assertions.assertEquals(
         schema1New,
         store.get(schema1.nameIdentifier(), Entity.EntityType.SCHEMA, SchemaEntity.class));
@@ -1195,6 +1427,8 @@ public class TestEntityStorage {
     Assertions.assertEquals(
         fileset1New,
         store.get(fileset1.nameIdentifier(), Entity.EntityType.FILESET, FilesetEntity.class));
+    Assertions.assertEquals(
+        topic1New, store.get(topic1.nameIdentifier(), Entity.EntityType.TOPIC, TopicEntity.class));
   }
 
   private void validateDeleteTable(
@@ -1231,7 +1465,9 @@ public class TestEntityStorage {
       TableEntity table1,
       TableEntity table1InSchema2,
       FilesetEntity fileset1,
-      FilesetEntity fileset1Inschema2)
+      FilesetEntity fileset1InSchema2,
+      TopicEntity topic1,
+      TopicEntity topic1InSchema2)
       throws IOException {
     // Now try to get
     Assertions.assertEquals(
@@ -1256,9 +1492,14 @@ public class TestEntityStorage {
         fileset1,
         store.get(fileset1.nameIdentifier(), Entity.EntityType.FILESET, FilesetEntity.class));
     Assertions.assertEquals(
-        fileset1Inschema2,
+        fileset1InSchema2,
         store.get(
-            fileset1Inschema2.nameIdentifier(), Entity.EntityType.FILESET, FilesetEntity.class));
+            fileset1InSchema2.nameIdentifier(), Entity.EntityType.FILESET, FilesetEntity.class));
+    Assertions.assertEquals(
+        topic1, store.get(topic1.nameIdentifier(), Entity.EntityType.TOPIC, TopicEntity.class));
+    Assertions.assertEquals(
+        topic1InSchema2,
+        store.get(topic1InSchema2.nameIdentifier(), Entity.EntityType.TOPIC, TopicEntity.class));
   }
 
   private void validateDeletedFileset(EntityStore store) throws IOException {
@@ -1313,6 +1554,58 @@ public class TestEntityStorage {
             NameIdentifier.of("metalakeChanged", "catalogChanged", "schema2", "fileset1"),
             Entity.EntityType.FILESET,
             FilesetEntity.class));
+  }
+
+  private void validateDeletedTopic(EntityStore store) throws IOException {
+    store.delete(
+        NameIdentifier.of("metalakeChanged", "catalogChanged", "schema2", "topic1"),
+        Entity.EntityType.TOPIC);
+    // Update a deleted entities
+    Assertions.assertThrowsExactly(
+        NoSuchEntityException.class,
+        () ->
+            store.update(
+                NameIdentifier.of("metalakeChanged", "catalogChanged", "schema2", "topic1"),
+                TopicEntity.class,
+                Entity.EntityType.TOPIC,
+                (e) -> e));
+  }
+
+  private void validateTopicChanged(EntityStore store, TopicEntity topicEntity) throws IOException {
+    // Check topic entities
+    store.update(
+        NameIdentifier.of("metalakeChanged", "catalogChanged", "schemaChanged", "topic1"),
+        TopicEntity.class,
+        Entity.EntityType.TOPIC,
+        e -> {
+          AuditInfo auditInfo1 =
+              AuditInfo.builder().withCreator("creator6").withCreateTime(Instant.now()).build();
+          return createTopicEntity(
+              topicEntity.id(),
+              Namespace.of("metalakeChanged", "catalogChanged", "schemaChanged"),
+              "topicChanged",
+              auditInfo1);
+        });
+
+    Assertions.assertThrowsExactly(
+        NoSuchEntityException.class,
+        () ->
+            store.get(
+                NameIdentifier.of("metalakeChanged", "catalogChanged", "schema1", "topic1"),
+                Entity.EntityType.TOPIC,
+                TopicEntity.class));
+    TopicEntity updatedTopic =
+        store.get(
+            NameIdentifier.of("metalakeChanged", "catalogChanged", "schemaChanged", "topicChanged"),
+            Entity.EntityType.TOPIC,
+            TopicEntity.class);
+    Assertions.assertEquals("creator6", updatedTopic.auditInfo().creator());
+
+    Assertions.assertNotNull(
+        store.get(
+            NameIdentifier.of("metalakeChanged", "catalogChanged", "schema2", "topic1"),
+            Entity.EntityType.TOPIC,
+            TopicEntity.class));
   }
 
   private void validateNotChangedEntity(EntityStore store, SchemaEntity schema) throws IOException {

--- a/core/src/test/resources/h2/schema-h2.sql
+++ b/core/src/test/resources/h2/schema-h2.sql
@@ -106,3 +106,22 @@ CREATE TABLE IF NOT EXISTS `fileset_version_info` (
     KEY idx_fvmid (metalake_id),
     KEY idx_fvcid (catalog_id)
 ) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS `topic_meta` (
+    `topic_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'topic id',
+    `topic_name` VARCHAR(128) NOT NULL COMMENT 'topic name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `comment` VARCHAR(256) DEFAULT '' COMMENT 'topic comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'topic properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'topic audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'topic current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'topic last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'topic deleted at',
+    PRIMARY KEY (topic_id),
+    CONSTRAINT uk_cid_tn_del UNIQUE (schema_id, topic_name, deleted_at),
+    -- Aliases are used here, and indexes with the same name in H2 can only be created once.
+    KEY idx_tvmid (metalake_id),
+    KEY idx_tvcid (catalog_id)
+) ENGINE=InnoDB;

--- a/scripts/mysql/schema-0.5.0-mysql.sql
+++ b/scripts/mysql/schema-0.5.0-mysql.sql
@@ -99,3 +99,21 @@ CREATE TABLE IF NOT EXISTS `fileset_version_info` (
     KEY `idx_cid` (`catalog_id`),
     KEY `idx_sid` (`schema_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'fileset version info';
+
+CREATE TABLE IF NOT EXISTS `topic_meta` (
+    `topic_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'topic id',
+    `topic_name` VARCHAR(128) NOT NULL COMMENT 'topic name',
+    `metalake_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'metalake id',
+    `catalog_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'catalog id',
+    `schema_id` BIGINT(20) UNSIGNED NOT NULL COMMENT 'schema id',
+    `comment` VARCHAR(256) DEFAULT '' COMMENT 'topic comment',
+    `properties` MEDIUMTEXT DEFAULT NULL COMMENT 'topic properties',
+    `audit_info` MEDIUMTEXT NOT NULL COMMENT 'topic audit info',
+    `current_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'topic current version',
+    `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'topic last version',
+    `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'topic deleted at',
+    PRIMARY KEY (`topic_id`),
+    UNIQUE KEY `uk_sid_tn_del` (`schema_id`, `topic_name`, `deleted_at`),
+    KEY `idx_mid` (`metalake_id`),
+    KEY `idx_cid` (`catalog_id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'topic metadata';


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add JDBC backend operations for topic

### Why are the changes needed?

Implement support for storing messaging catalog metadata in the JDBC backend.
Fix: #2775 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

tests added
