### PR TITLE
#2479 [WIP, dont merge] improvement: Simply method dropSchema() in interface SupportsSchemas

### DIFF
--- a/api/src/main/java/com/datastrato/gravitino/rel/SupportsSchemas.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/SupportsSchemas.java
@@ -124,4 +124,18 @@ public interface SupportsSchemas {
    * @throws NonEmptySchemaException If the schema is not empty and cascade is false.
    */
   boolean dropSchema(NameIdentifier ident, boolean cascade) throws NonEmptySchemaException;
+
+  /**
+   * Drop a schema from the catalog. If cascade option is true, recursively drop all objects within
+   * the schema.
+   *
+   * <p>If the catalog implementation does not support this operation, it may throw {@link
+   * UnsupportedOperationException}.
+   *
+   * @param schemaName The name of the schema.
+   * @param cascade If true, recursively drop all objects within the schema.
+   * @return True if the schema exists and is dropped successfully, false otherwise.
+   * @throws NonEmptySchemaException If the schema is not empty and cascade is false.
+   */
+  boolean dropSchema(String schemaName, boolean cascade) throws NonEmptySchemaException;
 }

--- a/api/src/main/java/com/datastrato/gravitino/rel/SupportsSchemas.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/SupportsSchemas.java
@@ -47,7 +47,7 @@ public interface SupportsSchemas {
    * @return An array of schema identifier under the namespace.
    * @throws NoSuchCatalogException If the catalog does not exist.
    */
-  String[] listSchemas(Namespace namespace) throws NoSuchCatalogException;
+  NameIdentifier[] listSchemas(Namespace namespace) throws NoSuchCatalogException;
 
   /**
    * List schemas.

--- a/api/src/main/java/com/datastrato/gravitino/rel/SupportsSchemas.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/SupportsSchemas.java
@@ -47,7 +47,19 @@ public interface SupportsSchemas {
    * @return An array of schema identifier under the namespace.
    * @throws NoSuchCatalogException If the catalog does not exist.
    */
-  NameIdentifier[] listSchemas(Namespace namespace) throws NoSuchCatalogException;
+  String[] listSchemas(Namespace namespace) throws NoSuchCatalogException;
+
+  /**
+   * List schemas.
+   *
+   * <p>If an entity such as a table, view exists, its parent schemas must also exist and must be
+   * returned by this discovery method. For example, if table a.b.t exists, this method invoked as
+   * listSchemas(a) must return [a.b] in the result array
+   *
+   * @return An array of schema identifier under the namespace.
+   * @throws NoSuchCatalogException If the catalog does not exist.
+   */
+  NameIdentifier[] listSchemas() throws NoSuchCatalogException;
 
   /**
    * Check if a schema exists.

--- a/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogOperations.java
@@ -70,6 +70,8 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
 
   private final EntityStore store;
 
+  private CatalogInfo info;
+
   @VisibleForTesting Configuration hadoopConf;
 
   @VisibleForTesting Optional<Path> catalogStorageLocation;
@@ -85,6 +87,7 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
 
   @Override
   public void initialize(Map<String, String> config, CatalogInfo info) throws RuntimeException {
+    this.info = info;
     // Initialize Hadoop Configuration.
     this.hadoopConf = new Configuration();
     Map<String, String> bypassConfigs =
@@ -331,9 +334,9 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
     }
   }
 
-  @Override
   public NameIdentifier[] listSchemas() throws NoSuchCatalogException {
-    throw new UnsupportedOperationException("Does not support listSchemas() yet.");
+    Namespace ns = Namespace.ofSchema(info.namespace().level(0), info.name());
+    return listSchemas(ns);
   }
 
   @Override

--- a/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogOperations.java
@@ -332,6 +332,11 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
   }
 
   @Override
+  public NameIdentifier[] listSchemas() throws NoSuchCatalogException {
+    throw new UnsupportedOperationException("Does not support listSchemas() yet.");
+  }
+
+  @Override
   public Schema createSchema(NameIdentifier ident, String comment, Map<String, String> properties)
       throws NoSuchCatalogException, SchemaAlreadyExistsException {
     try {

--- a/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogOperations.java
@@ -494,6 +494,13 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
   }
 
   @Override
+  public boolean dropSchema(String schemaName, boolean cascade) throws NonEmptySchemaException {
+    NameIdentifier nameIdentifier =
+        NameIdentifier.ofSchema(info.namespace().level(0), info.name(), schemaName);
+    return dropSchema(nameIdentifier, cascade);
+  }
+
+  @Override
   public PropertiesMetadata tablePropertiesMetadata() throws UnsupportedOperationException {
     throw new UnsupportedOperationException(
         "Hadoop fileset catalog doesn't support table related operations");

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
@@ -294,7 +294,8 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
 
   @Override
   public NameIdentifier[] listSchemas() throws NoSuchCatalogException {
-    throw new UnsupportedOperationException("Does not support listSchemas() yet.");
+    Namespace ns = Namespace.ofSchema(info.namespace().level(0), info.name());
+    return listSchemas(ns);
   }
   /**
    * Creates a new schema with the provided identifier, comment, and metadata.

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
@@ -447,26 +447,31 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
    */
   @Override
   public boolean dropSchema(NameIdentifier ident, boolean cascade) throws NonEmptySchemaException {
+    return dropSchema(ident.name(), cascade);
+  }
+
+  @Override
+  public boolean dropSchema(String schemaName, boolean cascade) throws NonEmptySchemaException {
     try {
       clientPool.run(
           client -> {
-            client.dropDatabase(ident.name(), false, false, cascade);
+            client.dropDatabase(schemaName, false, false, cascade);
             return null;
           });
-      LOG.info("Dropped Hive schema (database) {}", ident.name());
+      LOG.info("Dropped Hive schema (database) {}", schemaName);
       return true;
 
     } catch (InvalidOperationException e) {
       throw new NonEmptySchemaException(
-          e, "Hive schema (database) %s is not empty. One or more tables exist.", ident.name());
+          e, "Hive schema (database) %s is not empty. One or more tables exist.", schemaName);
 
     } catch (NoSuchObjectException e) {
-      LOG.warn("Hive schema (database) {} does not exist in Hive Metastore", ident.name());
+      LOG.warn("Hive schema (database) {} does not exist in Hive Metastore", schemaName);
       return false;
 
     } catch (TException e) {
       throw new RuntimeException(
-          "Failed to drop Hive schema (database) " + ident.name() + " in Hive Metastore", e);
+          "Failed to drop Hive schema (database) " + schemaName + " in Hive Metastore", e);
 
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
@@ -292,6 +292,10 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
     }
   }
 
+  @Override
+  public NameIdentifier[] listSchemas() throws NoSuchCatalogException {
+    throw new UnsupportedOperationException("Does not support listSchemas() yet.");
+  }
   /**
    * Creates a new schema with the provided identifier, comment, and metadata.
    *

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveSchema.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveSchema.java
@@ -80,6 +80,9 @@ public class TestHiveSchema extends MiniHiveMetastoreService {
     NameIdentifier[] idents = schemas.listSchemas(ident.namespace());
     Assertions.assertTrue(Arrays.asList(idents).contains(ident));
 
+    NameIdentifier[] idents2 = schemas.listSchemas();
+    Assertions.assertArrayEquals(idents, idents2);
+
     Schema loadedSchema = schemas.loadSchema(ident);
     Assertions.assertEquals(schema.auditInfo().creator(), loadedSchema.auditInfo().creator());
     Assertions.assertNull(loadedSchema.auditInfo().createTime());

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
@@ -146,16 +146,16 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
    * @throws NoSuchCatalogException If the provided namespace is invalid or does not exist.
    */
   @Override
-  public String[] listSchemas(Namespace namespace) throws NoSuchCatalogException {
-    return databaseOperation.listDatabases().toArray(new String[0]);
+  public NameIdentifier[] listSchemas(Namespace namespace) throws NoSuchCatalogException {
+    List<String> schemaNames = databaseOperation.listDatabases();
+    return schemaNames.stream()
+        .map(db -> NameIdentifier.of(namespace, db))
+        .toArray(NameIdentifier[]::new);
   }
 
   @Override
   public NameIdentifier[] listSchemas() throws NoSuchCatalogException {
-    List<String> schemaNames = databaseOperation.listDatabases();
-    return schemaNames.stream()
-            .map(db -> NameIdentifier.of(namespace, db))
-            .toArray(NameIdentifier[]::new);
+    throw new UnsupportedOperationException("Does not support listSchemas() yet.");
   }
 
   /**

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
@@ -81,6 +81,8 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
 
   private final JdbcColumnDefaultValueConverter columnDefaultValueConverter;
 
+  private CatalogInfo info;
+
   /**
    * Constructs a new instance of JdbcCatalogOperations.
    *
@@ -114,6 +116,7 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
    */
   @Override
   public void initialize(Map<String, String> conf, CatalogInfo info) throws RuntimeException {
+    this.info = info;
     // Key format like gravitino.bypass.a.b
     Map<String, String> prefixMap = MapUtils.getPrefixMap(conf, CATALOG_BYPASS_PREFIX);
 
@@ -155,7 +158,8 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
 
   @Override
   public NameIdentifier[] listSchemas() throws NoSuchCatalogException {
-    throw new UnsupportedOperationException("Does not support listSchemas() yet.");
+    Namespace ns = Namespace.ofSchema(info.namespace().level(0), info.name());
+    return listSchemas(ns);
   }
 
   /**

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
@@ -146,11 +146,16 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
    * @throws NoSuchCatalogException If the provided namespace is invalid or does not exist.
    */
   @Override
-  public NameIdentifier[] listSchemas(Namespace namespace) throws NoSuchCatalogException {
+  public String[] listSchemas(Namespace namespace) throws NoSuchCatalogException {
+    return databaseOperation.listDatabases().toArray(new String[0]);
+  }
+
+  @Override
+  public NameIdentifier[] listSchemas() throws NoSuchCatalogException {
     List<String> schemaNames = databaseOperation.listDatabases();
     return schemaNames.stream()
-        .map(db -> NameIdentifier.of(namespace, db))
-        .toArray(NameIdentifier[]::new);
+            .map(db -> NameIdentifier.of(namespace, db))
+            .toArray(NameIdentifier[]::new);
   }
 
   /**

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
@@ -249,7 +249,12 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
    */
   @Override
   public boolean dropSchema(NameIdentifier ident, boolean cascade) throws NonEmptySchemaException {
-    databaseOperation.delete(ident.name(), cascade);
+    return dropSchema(ident.name(), cascade);
+  }
+
+  @Override
+  public boolean dropSchema(String schemaName, boolean cascade) throws NonEmptySchemaException {
+    databaseOperation.delete(schemaName, cascade);
     return true;
   }
 

--- a/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
@@ -213,7 +213,7 @@ public class CatalogMysqlIT extends AbstractIT {
     SupportsSchemas schemas = catalog.asSchemas();
     Namespace namespace = Namespace.of(metalakeName, catalogName);
     // list schema check.
-    NameIdentifier[] nameIdentifiers = schemas.listSchemas(namespace);
+    NameIdentifier[] nameIdentifiers = schemas.listSchemas();
     Set<String> schemaNames =
         Arrays.stream(nameIdentifiers).map(NameIdentifier::name).collect(Collectors.toSet());
     Assertions.assertTrue(schemaNames.contains(schemaName));
@@ -227,7 +227,7 @@ public class CatalogMysqlIT extends AbstractIT {
     String testSchemaName = GravitinoITUtils.genRandomName("test_schema_1");
     NameIdentifier schemaIdent = NameIdentifier.of(metalakeName, catalogName, testSchemaName);
     schemas.createSchema(schemaIdent, schema_comment, Collections.emptyMap());
-    nameIdentifiers = schemas.listSchemas(Namespace.of(metalakeName, catalogName));
+    nameIdentifiers = schemas.listSchemas();
     Map<String, NameIdentifier> schemaMap =
         Arrays.stream(nameIdentifiers).collect(Collectors.toMap(NameIdentifier::name, v -> v));
     Assertions.assertTrue(schemaMap.containsKey(testSchemaName));
@@ -250,7 +250,7 @@ public class CatalogMysqlIT extends AbstractIT {
     Assertions.assertThrows(
         NoSuchSchemaException.class, () -> mysqlService.loadSchema(schemaIdent));
 
-    nameIdentifiers = schemas.listSchemas(Namespace.of(metalakeName, catalogName));
+    nameIdentifiers = schemas.listSchemas();
     schemaMap =
         Arrays.stream(nameIdentifiers).collect(Collectors.toMap(NameIdentifier::name, v -> v));
     Assertions.assertFalse(schemaMap.containsKey(testSchemaName));
@@ -1171,7 +1171,7 @@ public class CatalogMysqlIT extends AbstractIT {
     }
 
     Set<String> schemaNames =
-        Arrays.stream(schemaSupport.listSchemas(Namespace.of(metalakeName, catalogName)))
+        Arrays.stream(schemaSupport.listSchemas())
             .map(NameIdentifier::name)
             .collect(Collectors.toSet());
 

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
@@ -249,7 +249,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     SupportsSchemas schemas = catalog.asSchemas();
     Namespace namespace = Namespace.of(metalakeName, catalogName);
     // list schema check.
-    NameIdentifier[] nameIdentifiers = schemas.listSchemas(namespace);
+    NameIdentifier[] nameIdentifiers = schemas.listSchemas();
     Set<String> schemaNames =
         Arrays.stream(nameIdentifiers).map(NameIdentifier::name).collect(Collectors.toSet());
     Assertions.assertTrue(schemaNames.contains(schemaName));
@@ -263,7 +263,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     String testSchemaName = GravitinoITUtils.genRandomName("test_schema_1");
     NameIdentifier schemaIdent = NameIdentifier.of(metalakeName, catalogName, testSchemaName);
     schemas.createSchema(schemaIdent, schema_comment, Collections.emptyMap());
-    nameIdentifiers = schemas.listSchemas(Namespace.of(metalakeName, catalogName));
+    nameIdentifiers = schemas.listSchemas();
     Map<String, NameIdentifier> schemaMap =
         Arrays.stream(nameIdentifiers).collect(Collectors.toMap(NameIdentifier::name, v -> v));
     Assertions.assertTrue(schemaMap.containsKey(testSchemaName));
@@ -286,7 +286,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     Assertions.assertThrows(
         NoSuchSchemaException.class, () -> postgreSqlService.loadSchema(schemaIdent));
 
-    nameIdentifiers = schemas.listSchemas(Namespace.of(metalakeName, catalogName));
+    nameIdentifiers = schemas.listSchemas();
     schemaMap =
         Arrays.stream(nameIdentifiers).collect(Collectors.toMap(NameIdentifier::name, v -> v));
     Assertions.assertFalse(schemaMap.containsKey(testSchemaName));
@@ -512,6 +512,9 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     Set<String> schemaNames =
         Arrays.stream(nameIdentifiers).map(NameIdentifier::name).collect(Collectors.toSet());
     Assertions.assertTrue(schemaNames.contains("public"));
+
+    NameIdentifier[] nameIdentifiers2 = catalog.asSchemas().listSchemas();
+    Assertions.assertArrayEquals(nameIdentifiers, nameIdentifiers2);
   }
 
   @Test
@@ -1070,7 +1073,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     }
 
     Set<String> schemaNames =
-        Arrays.stream(schemaSupport.listSchemas(Namespace.of(metalakeName, catalogName)))
+        Arrays.stream(schemaSupport.listSchemas())
             .map(NameIdentifier::name)
             .collect(Collectors.toSet());
 

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/TestMultipleJDBCLoad.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/TestMultipleJDBCLoad.java
@@ -7,7 +7,6 @@ package com.datastrato.gravitino.catalog.postgresql.integration.test;
 
 import com.datastrato.gravitino.Catalog;
 import com.datastrato.gravitino.NameIdentifier;
-import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.catalog.jdbc.config.JdbcConfig;
 import com.datastrato.gravitino.client.GravitinoMetalake;
 import com.datastrato.gravitino.integration.test.util.AbstractIT;
@@ -128,13 +127,9 @@ public class TestMultipleJDBCLoad extends AbstractIT {
             "comment",
             mysqlConf);
 
-    NameIdentifier[] nameIdentifiers =
-        mysqlCatalog.asSchemas().listSchemas(Namespace.of(metalakeName, mysqlCatalogName));
+    NameIdentifier[] nameIdentifiers = mysqlCatalog.asSchemas().listSchemas();
     Assertions.assertNotEquals(0, nameIdentifiers.length);
-    nameIdentifiers =
-        postgreSqlCatalog
-            .asSchemas()
-            .listSchemas(Namespace.of(metalakeName, postgreSqlCatalogName));
+    nameIdentifiers = postgreSqlCatalog.asSchemas().listSchemas();
     Assertions.assertEquals(1, nameIdentifiers.length);
     Assertions.assertEquals("public", nameIdentifiers[0].name());
 

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
@@ -136,6 +136,11 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
     }
   }
 
+  @Override
+  public NameIdentifier[] listSchemas() throws NoSuchCatalogException {
+    throw new UnsupportedOperationException("Does not support listSchemas() yet.");
+  }
+
   /**
    * Creates a new schema with the provided identifier, comment, and metadata.
    *

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
@@ -74,6 +74,8 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
 
   private IcebergTableOpsHelper icebergTableOpsHelper;
 
+  private CatalogInfo info;
+
   /**
    * Initializes the Iceberg catalog operations with the provided configuration.
    *
@@ -83,6 +85,7 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
    */
   @Override
   public void initialize(Map<String, String> conf, CatalogInfo info) throws RuntimeException {
+    this.info = info;
     // Key format like gravitino.bypass.a.b
     Map<String, String> prefixMap = MapUtils.getPrefixMap(conf, CATALOG_BYPASS_PREFIX);
 
@@ -138,7 +141,8 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
 
   @Override
   public NameIdentifier[] listSchemas() throws NoSuchCatalogException {
-    throw new UnsupportedOperationException("Does not support listSchemas() yet.");
+    Namespace ns = Namespace.ofSchema(info.namespace().level(0), info.name());
+    return listSchemas(ns);
   }
 
   /**

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
@@ -298,16 +298,21 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
    */
   @Override
   public boolean dropSchema(NameIdentifier ident, boolean cascade) throws NonEmptySchemaException {
+    return dropSchema(ident.name(), cascade);
+  }
+
+  @Override
+  public boolean dropSchema(String schemaName, boolean cascade) throws NonEmptySchemaException {
     Preconditions.checkArgument(!cascade, "Iceberg does not support cascading delete operations.");
     try {
-      icebergTableOps.dropNamespace(IcebergTableOpsHelper.getIcebergNamespace(ident.name()));
-      LOG.info("Dropped Iceberg schema (database) {}", ident.name());
+      icebergTableOps.dropNamespace(IcebergTableOpsHelper.getIcebergNamespace(schemaName));
+      LOG.info("Dropped Iceberg schema (database) {}", schemaName);
       return true;
     } catch (NamespaceNotEmptyException e) {
       throw new NonEmptySchemaException(
-          e, "Iceberg schema (database) %s is not empty. One or more tables exist.", ident.name());
+          e, "Iceberg schema (database) %s is not empty. One or more tables exist.", schemaName);
     } catch (NoSuchNamespaceException e) {
-      LOG.warn("Iceberg schema (database) {} does not exist", ident.name());
+      LOG.warn("Iceberg schema (database) {} does not exist", schemaName);
       return false;
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergSchema.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergSchema.java
@@ -49,7 +49,7 @@ public class TestIcebergSchema {
     Assertions.assertTrue(icebergCatalog.asSchemas().schemaExists(ident));
 
     Set<String> names =
-        Arrays.stream(icebergCatalog.asSchemas().listSchemas(ident.namespace()))
+        Arrays.stream(icebergCatalog.asSchemas().listSchemas())
             .map(NameIdentifier::name)
             .collect(Collectors.toSet());
     Assertions.assertTrue(names.contains(ident.name()));

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergIT.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergIT.java
@@ -242,9 +242,8 @@ public class CatalogIcebergIT extends AbstractIT {
   @Test
   void testOperationIcebergSchema() {
     SupportsSchemas schemas = catalog.asSchemas();
-    Namespace namespace = Namespace.of(metalakeName, catalogName);
     // list schema check.
-    NameIdentifier[] nameIdentifiers = schemas.listSchemas(namespace);
+    NameIdentifier[] nameIdentifiers = schemas.listSchemas();
     Set<String> schemaNames =
         Arrays.stream(nameIdentifiers).map(NameIdentifier::name).collect(Collectors.toSet());
     Assertions.assertTrue(schemaNames.contains(schemaName));
@@ -259,7 +258,7 @@ public class CatalogIcebergIT extends AbstractIT {
     String testSchemaName = GravitinoITUtils.genRandomName("test_schema_1");
     NameIdentifier schemaIdent = NameIdentifier.of(metalakeName, catalogName, testSchemaName);
     schemas.createSchema(schemaIdent, schema_comment, Collections.emptyMap());
-    nameIdentifiers = schemas.listSchemas(Namespace.of(metalakeName, catalogName));
+    nameIdentifiers = schemas.listSchemas();
     Map<String, NameIdentifier> schemaMap =
         Arrays.stream(nameIdentifiers).collect(Collectors.toMap(NameIdentifier::name, v -> v));
     Assertions.assertTrue(schemaMap.containsKey(testSchemaName));
@@ -296,7 +295,7 @@ public class CatalogIcebergIT extends AbstractIT {
           hiveCatalog.loadNamespaceMetadata(icebergNamespace);
         });
 
-    nameIdentifiers = schemas.listSchemas(Namespace.of(metalakeName, catalogName));
+    nameIdentifiers = schemas.listSchemas();
     schemaMap =
         Arrays.stream(nameIdentifiers).collect(Collectors.toMap(NameIdentifier::name, v -> v));
     Assertions.assertFalse(schemaMap.containsKey(testSchemaName));

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/TestMultipleJDBCLoad.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/TestMultipleJDBCLoad.java
@@ -10,7 +10,6 @@ import static com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergCatalogP
 
 import com.datastrato.gravitino.Catalog;
 import com.datastrato.gravitino.NameIdentifier;
-import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergConfig;
 import com.datastrato.gravitino.client.GravitinoMetalake;
 import com.datastrato.gravitino.integration.test.util.AbstractIT;
@@ -35,7 +34,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 
 @Tag("gravitino-docker-it")
 public class TestMultipleJDBCLoad extends AbstractIT {
-  private static String TEST_DB_NAME = RandomNameUtils.genRandomName("ct_db");
+  private static final String TEST_DB_NAME = RandomNameUtils.genRandomName("ct_db");
 
   private static MySQLContainer mySQLContainer;
   private static PostgreSQLContainer postgreSQLContainer;
@@ -124,13 +123,9 @@ public class TestMultipleJDBCLoad extends AbstractIT {
             "comment",
             icebergMysqlConf);
 
-    NameIdentifier[] nameIdentifiers =
-        mysqlCatalog.asSchemas().listSchemas(Namespace.of(metalakeName, mysqlCatalogName));
+    NameIdentifier[] nameIdentifiers = mysqlCatalog.asSchemas().listSchemas();
     Assertions.assertEquals(0, nameIdentifiers.length);
-    nameIdentifiers =
-        postgreSqlCatalog
-            .asSchemas()
-            .listSchemas(Namespace.of(metalakeName, postgreSqlCatalogName));
+    nameIdentifiers = postgreSqlCatalog.asSchemas().listSchemas();
     Assertions.assertEquals(0, nameIdentifiers.length);
 
     String schemaName = RandomNameUtils.genRandomName("it_schema");

--- a/catalogs/catalog-messaging-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
+++ b/catalogs/catalog-messaging-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
@@ -341,6 +341,11 @@ public class KafkaCatalogOperations implements CatalogOperations, SupportsSchema
   }
 
   @Override
+  public NameIdentifier[] listSchemas() throws NoSuchCatalogException {
+    throw new UnsupportedOperationException("Does not support listSchemas() yet.");
+  }
+
+  @Override
   public Schema createSchema(NameIdentifier ident, String comment, Map<String, String> properties)
       throws NoSuchCatalogException, SchemaAlreadyExistsException {
     // It appears that the "default" schema suffices, so there is no need to support creating schema

--- a/catalogs/catalog-messaging-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
+++ b/catalogs/catalog-messaging-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
@@ -342,7 +342,8 @@ public class KafkaCatalogOperations implements CatalogOperations, SupportsSchema
 
   @Override
   public NameIdentifier[] listSchemas() throws NoSuchCatalogException {
-    throw new UnsupportedOperationException("Does not support listSchemas() yet.");
+    Namespace ns = Namespace.ofSchema(info.namespace().level(0), info.name());
+    return listSchemas(ns);
   }
 
   @Override

--- a/catalogs/catalog-messaging-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
+++ b/catalogs/catalog-messaging-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
@@ -388,7 +388,12 @@ public class KafkaCatalogOperations implements CatalogOperations, SupportsSchema
 
   @Override
   public boolean dropSchema(NameIdentifier ident, boolean cascade) throws NonEmptySchemaException {
-    if (ident.equals(defaultSchemaIdent)) {
+    return dropSchema(ident.name(), cascade);
+  }
+
+  @Override
+  public boolean dropSchema(String schemaName, boolean cascade) throws NonEmptySchemaException {
+    if (schemaName.equals(defaultSchemaIdent.name())) {
       throw new IllegalArgumentException("Cannot drop the default schema");
     }
     // TODO: Implement dropping schema after adding support for schema creation

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/BaseSchemaCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/BaseSchemaCatalog.java
@@ -21,6 +21,7 @@ import com.datastrato.gravitino.exceptions.SchemaAlreadyExistsException;
 import com.datastrato.gravitino.rel.Schema;
 import com.datastrato.gravitino.rel.SchemaChange;
 import com.datastrato.gravitino.rel.SupportsSchemas;
+import com.datastrato.gravitino.rel.types.Type;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Arrays;
 import java.util.Collections;
@@ -40,8 +41,11 @@ abstract class BaseSchemaCatalog extends CatalogDTO implements SupportsSchemas {
 
   /** The REST client to send the requests. */
   protected final RESTClient restClient;
+  /** The namespace of current catalog, which is the metalake name. */
+  protected final Namespace namespace;
 
   BaseSchemaCatalog(
+      Namespace namespace,
       String name,
       Type type,
       String provider,
@@ -51,6 +55,8 @@ abstract class BaseSchemaCatalog extends CatalogDTO implements SupportsSchemas {
       RESTClient restClient) {
     super(name, type, provider, comment, properties, auditDTO);
     this.restClient = restClient;
+    Namespace.checkCatalog(namespace);
+    this.namespace = namespace;
   }
 
   @Override
@@ -82,7 +88,7 @@ abstract class BaseSchemaCatalog extends CatalogDTO implements SupportsSchemas {
 
   @Override
   public NameIdentifier[] listSchemas() throws NoSuchCatalogException {
-    return listSchemas(Namespace.ofSchema());
+    return listSchemas(Namespace.ofSchema(namespace.level(0), name()));
   }
 
   /**

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/BaseSchemaCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/BaseSchemaCatalog.java
@@ -186,11 +186,16 @@ abstract class BaseSchemaCatalog extends CatalogDTO implements SupportsSchemas {
   @Override
   public boolean dropSchema(NameIdentifier ident, boolean cascade) throws NonEmptySchemaException {
     NameIdentifier.checkSchema(ident);
+    return dropSchema(ident.name(), cascade);
+  }
 
+  @Override
+  public boolean dropSchema(String schemaName, boolean cascade) throws NonEmptySchemaException {
+    Namespace ns = Namespace.ofSchema(namespace.level(0), name());
     try {
       DropResponse resp =
           restClient.delete(
-              formatSchemaRequestPath(ident.namespace()) + "/" + ident.name(),
+              formatSchemaRequestPath(ns) + "/" + schemaName,
               Collections.singletonMap("cascade", String.valueOf(cascade)),
               DropResponse.class,
               Collections.emptyMap(),
@@ -201,7 +206,7 @@ abstract class BaseSchemaCatalog extends CatalogDTO implements SupportsSchemas {
     } catch (NonEmptySchemaException e) {
       throw e;
     } catch (Exception e) {
-      LOG.warn("Failed to drop schema {}", ident, e);
+      LOG.warn("Failed to drop schema {}", schemaName, e);
       return false;
     }
   }

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/BaseSchemaCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/BaseSchemaCatalog.java
@@ -80,6 +80,11 @@ abstract class BaseSchemaCatalog extends CatalogDTO implements SupportsSchemas {
     return resp.identifiers();
   }
 
+  @Override
+  public NameIdentifier[] listSchemas() throws NoSuchCatalogException {
+    return listSchemas(Namespace.ofSchema());
+  }
+
   /**
    * Create a new schema with specified identifier, comment and metadata.
    *

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/DTOConverters.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/DTOConverters.java
@@ -7,6 +7,7 @@ package com.datastrato.gravitino.client;
 import com.datastrato.gravitino.Catalog;
 import com.datastrato.gravitino.CatalogChange;
 import com.datastrato.gravitino.MetalakeChange;
+import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.dto.AuditDTO;
 import com.datastrato.gravitino.dto.CatalogDTO;
 import com.datastrato.gravitino.dto.MetalakeDTO;
@@ -59,10 +60,12 @@ class DTOConverters {
   }
 
   @SuppressWarnings("unchecked")
-  static Catalog toCatalog(CatalogDTO catalog, RESTClient client) {
+  static Catalog toCatalog(String metalake, CatalogDTO catalog, RESTClient client) {
+    Namespace namespace = Namespace.ofCatalog(metalake);
     switch (catalog.type()) {
       case RELATIONAL:
         return RelationalCatalog.builder()
+            .withNamespace(namespace)
             .withName(catalog.name())
             .withType(catalog.type())
             .withProvider(catalog.provider())
@@ -74,6 +77,7 @@ class DTOConverters {
 
       case FILESET:
         return FilesetCatalog.builder()
+            .withNamespace(namespace)
             .withName(catalog.name())
             .withType(catalog.type())
             .withProvider(catalog.provider())
@@ -85,6 +89,7 @@ class DTOConverters {
 
       case MESSAGING:
         return MessagingCatalog.builder()
+            .withNamespace(namespace)
             .withName(catalog.name())
             .withType(catalog.type())
             .withProvider(catalog.provider())

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/FilesetCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/FilesetCatalog.java
@@ -37,6 +37,7 @@ public class FilesetCatalog extends BaseSchemaCatalog
     implements com.datastrato.gravitino.file.FilesetCatalog {
 
   FilesetCatalog(
+      Namespace namespace,
       String name,
       Type type,
       String provider,
@@ -44,7 +45,7 @@ public class FilesetCatalog extends BaseSchemaCatalog
       Map<String, String> properties,
       AuditDTO auditDTO,
       RESTClient restClient) {
-    super(name, type, provider, comment, properties, auditDTO, restClient);
+    super(namespace, name, type, provider, comment, properties, auditDTO, restClient);
   }
 
   @Override
@@ -225,8 +226,15 @@ public class FilesetCatalog extends BaseSchemaCatalog
   static class Builder extends CatalogDTO.Builder<Builder> {
     /** The REST client to send the requests. */
     private RESTClient restClient;
+    /** The namespace of the catalog */
+    private Namespace namespace;
 
     private Builder() {}
+
+    Builder withNamespace(Namespace namespace) {
+      this.namespace = namespace;
+      return this;
+    }
 
     Builder withRestClient(RESTClient restClient) {
       this.restClient = restClient;
@@ -235,13 +243,15 @@ public class FilesetCatalog extends BaseSchemaCatalog
 
     @Override
     public FilesetCatalog build() {
+      Namespace.checkCatalog(namespace);
       Preconditions.checkArgument(restClient != null, "restClient must be set");
       Preconditions.checkArgument(StringUtils.isNotBlank(name), "name must not be blank");
       Preconditions.checkArgument(type != null, "type must not be null");
       Preconditions.checkArgument(StringUtils.isNotBlank(provider), "provider must not be blank");
       Preconditions.checkArgument(audit != null, "audit must not be null");
 
-      return new FilesetCatalog(name, type, provider, comment, properties, audit, restClient);
+      return new FilesetCatalog(
+          namespace, name, type, provider, comment, properties, audit, restClient);
     }
   }
 }

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoMetalake.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoMetalake.java
@@ -99,7 +99,7 @@ public class GravitinoMetalake extends MetalakeDTO implements SupportsCatalogs {
             ErrorHandlers.catalogErrorHandler());
 
     return Arrays.stream(resp.getCatalogs())
-        .map(c -> DTOConverters.toCatalog(c, restClient))
+        .map(c -> DTOConverters.toCatalog(this.name(), c, restClient))
         .toArray(Catalog[]::new);
   }
 
@@ -122,7 +122,7 @@ public class GravitinoMetalake extends MetalakeDTO implements SupportsCatalogs {
             ErrorHandlers.catalogErrorHandler());
     resp.validate();
 
-    return DTOConverters.toCatalog(resp.getCatalog(), restClient);
+    return DTOConverters.toCatalog(this.name(), resp.getCatalog(), restClient);
   }
 
   /**
@@ -160,7 +160,7 @@ public class GravitinoMetalake extends MetalakeDTO implements SupportsCatalogs {
             ErrorHandlers.catalogErrorHandler());
     resp.validate();
 
-    return DTOConverters.toCatalog(resp.getCatalog(), restClient);
+    return DTOConverters.toCatalog(this.name(), resp.getCatalog(), restClient);
   }
 
   /**
@@ -193,7 +193,7 @@ public class GravitinoMetalake extends MetalakeDTO implements SupportsCatalogs {
             ErrorHandlers.catalogErrorHandler());
     resp.validate();
 
-    return DTOConverters.toCatalog(resp.getCatalog(), restClient);
+    return DTOConverters.toCatalog(this.name(), resp.getCatalog(), restClient);
   }
 
   /**

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/MessagingCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/MessagingCatalog.java
@@ -38,6 +38,7 @@ import org.apache.commons.lang3.StringUtils;
 public class MessagingCatalog extends BaseSchemaCatalog implements TopicCatalog {
 
   MessagingCatalog(
+      Namespace namespace,
       String name,
       Type type,
       String provider,
@@ -45,7 +46,7 @@ public class MessagingCatalog extends BaseSchemaCatalog implements TopicCatalog 
       Map<String, String> properties,
       AuditDTO auditDTO,
       RESTClient restClient) {
-    super(name, type, provider, comment, properties, auditDTO, restClient);
+    super(namespace, name, type, provider, comment, properties, auditDTO, restClient);
   }
 
   /** @return A new builder for {@link MessagingCatalog}. */
@@ -205,7 +206,15 @@ public class MessagingCatalog extends BaseSchemaCatalog implements TopicCatalog 
     /** The REST client to send the requests. */
     private RESTClient restClient;
 
+    /** The namespace of the catalog */
+    private Namespace namespace;
+
     private Builder() {}
+
+    Builder withNamespace(Namespace namespace) {
+      this.namespace = namespace;
+      return this;
+    }
 
     Builder withRestClient(RESTClient restClient) {
       this.restClient = restClient;
@@ -214,13 +223,15 @@ public class MessagingCatalog extends BaseSchemaCatalog implements TopicCatalog 
 
     @Override
     public MessagingCatalog build() {
+      Namespace.checkCatalog(namespace);
       Preconditions.checkArgument(StringUtils.isNotBlank(name), "name must not be blank");
       Preconditions.checkArgument(type != null, "type must not be null");
       Preconditions.checkArgument(StringUtils.isNotBlank(provider), "provider must not be blank");
       Preconditions.checkArgument(audit != null, "audit must not be null");
       Preconditions.checkArgument(restClient != null, "restClient must be set");
 
-      return new MessagingCatalog(name, type, provider, comment, properties, audit, restClient);
+      return new MessagingCatalog(
+          namespace, name, type, provider, comment, properties, audit, restClient);
     }
   }
 }

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/RelationalCatalog.java
@@ -50,6 +50,7 @@ public class RelationalCatalog extends BaseSchemaCatalog implements TableCatalog
   private static final Logger LOG = LoggerFactory.getLogger(RelationalCatalog.class);
 
   RelationalCatalog(
+      Namespace namespace,
       String name,
       Type type,
       String provider,
@@ -57,7 +58,7 @@ public class RelationalCatalog extends BaseSchemaCatalog implements TableCatalog
       Map<String, String> properties,
       AuditDTO auditDTO,
       RESTClient restClient) {
-    super(name, type, provider, comment, properties, auditDTO, restClient);
+    super(namespace, name, type, provider, comment, properties, auditDTO, restClient);
   }
 
   @Override
@@ -272,6 +273,8 @@ public class RelationalCatalog extends BaseSchemaCatalog implements TableCatalog
   static class Builder extends CatalogDTO.Builder<Builder> {
     /** The REST client to send the requests. */
     private RESTClient restClient;
+    /** The namespace of the catalog */
+    private Namespace namespace;
 
     protected Builder() {}
 
@@ -280,15 +283,22 @@ public class RelationalCatalog extends BaseSchemaCatalog implements TableCatalog
       return this;
     }
 
+    Builder withNamespace(Namespace namespace) {
+      this.namespace = namespace;
+      return this;
+    }
+
     @Override
     public RelationalCatalog build() {
+      Namespace.checkCatalog(namespace);
       Preconditions.checkArgument(restClient != null, "restClient must be set");
       Preconditions.checkArgument(StringUtils.isNotBlank(name), "name must not be blank");
       Preconditions.checkArgument(type != null, "type must not be null");
       Preconditions.checkArgument(StringUtils.isNotBlank(provider), "provider must not be blank");
       Preconditions.checkArgument(audit != null, "audit must not be null");
 
-      return new RelationalCatalog(name, type, provider, comment, properties, audit, restClient);
+      return new RelationalCatalog(
+          namespace, name, type, provider, comment, properties, audit, restClient);
     }
   }
 }

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalCatalog.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalCatalog.java
@@ -137,7 +137,7 @@ public class TestRelationalCatalog extends TestBase {
 
     EntityListResponse resp = new EntityListResponse(new NameIdentifier[] {schema1, schema2});
     buildMockResource(Method.GET, schemaPath, null, resp, SC_OK);
-    NameIdentifier[] schemas = catalog.asSchemas().listSchemas(schemaNs);
+    NameIdentifier[] schemas = catalog.asSchemas().listSchemas();
 
     Assertions.assertEquals(2, schemas.length);
     Assertions.assertEquals(schema1, schemas[0]);
@@ -146,7 +146,7 @@ public class TestRelationalCatalog extends TestBase {
     // Test return empty schema list
     EntityListResponse emptyResp = new EntityListResponse(new NameIdentifier[] {});
     buildMockResource(Method.GET, schemaPath, null, emptyResp, SC_OK);
-    NameIdentifier[] emptySchemas = catalog.asSchemas().listSchemas(schemaNs);
+    NameIdentifier[] emptySchemas = catalog.asSchemas().listSchemas();
     Assertions.assertEquals(0, emptySchemas.length);
 
     // Test throw NoSuchCatalogException
@@ -155,21 +155,20 @@ public class TestRelationalCatalog extends TestBase {
     buildMockResource(Method.GET, schemaPath, null, errorResp, SC_NOT_FOUND);
     SupportsSchemas supportSchemas = catalog.asSchemas();
     Throwable ex =
-        Assertions.assertThrows(
-            NoSuchCatalogException.class, () -> supportSchemas.listSchemas(schemaNs));
+        Assertions.assertThrows(NoSuchCatalogException.class, () -> supportSchemas.listSchemas());
     Assertions.assertTrue(ex.getMessage().contains("catalog not found"));
 
     // Test throw RuntimeException
     ErrorResponse errorResp1 = ErrorResponse.internalError("internal error");
     buildMockResource(Method.GET, schemaPath, null, errorResp1, SC_INTERNAL_SERVER_ERROR);
     Throwable ex1 =
-        Assertions.assertThrows(RuntimeException.class, () -> supportSchemas.listSchemas(schemaNs));
+        Assertions.assertThrows(RuntimeException.class, () -> supportSchemas.listSchemas());
     Assertions.assertTrue(ex1.getMessage().contains("internal error"));
 
     // Test throw unparsed system error
     buildMockResource(Method.GET, schemaPath, null, "unparsed error", SC_BAD_REQUEST);
     Throwable ex2 =
-        Assertions.assertThrows(RESTException.class, () -> supportSchemas.listSchemas(schemaNs));
+        Assertions.assertThrows(RESTException.class, () -> supportSchemas.listSchemas());
     Assertions.assertTrue(ex2.getMessage().contains("unparsed error"));
   }
 

--- a/core/src/main/java/com/datastrato/gravitino/catalog/SchemaOperationDispatcher.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/SchemaOperationDispatcher.java
@@ -20,7 +20,6 @@ import com.datastrato.gravitino.meta.AuditInfo;
 import com.datastrato.gravitino.meta.SchemaEntity;
 import com.datastrato.gravitino.rel.Schema;
 import com.datastrato.gravitino.rel.SchemaChange;
-import com.datastrato.gravitino.rel.SupportsSchemas;
 import com.datastrato.gravitino.storage.IdGenerator;
 import com.datastrato.gravitino.utils.PrincipalUtils;
 import java.time.Instant;
@@ -28,7 +27,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SchemaOperationDispatcher extends OperationDispatcher implements SupportsSchemas {
+public class SchemaOperationDispatcher extends OperationDispatcher {
 
   private static final Logger LOG = LoggerFactory.getLogger(SchemaOperationDispatcher.class);
 
@@ -52,7 +51,6 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Su
    *     namespace.
    * @throws NoSuchCatalogException If the catalog namespace does not exist.
    */
-  @Override
   public NameIdentifier[] listSchemas(Namespace namespace) throws NoSuchCatalogException {
     return doWithCatalog(
         getCatalogIdentifier(NameIdentifier.of(namespace.levels())),
@@ -71,7 +69,6 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Su
    *     exist.
    * @throws SchemaAlreadyExistsException If a schema with the same identifier already exists.
    */
-  @Override
   public Schema createSchema(NameIdentifier ident, String comment, Map<String, String> properties)
       throws NoSuchCatalogException, SchemaAlreadyExistsException {
     NameIdentifier catalogIdent = getCatalogIdentifier(ident);
@@ -155,7 +152,6 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Su
    * @return The loaded Schema object.
    * @throws NoSuchSchemaException If the schema does not exist.
    */
-  @Override
   public Schema loadSchema(NameIdentifier ident) throws NoSuchSchemaException {
     NameIdentifier catalogIdentifier = getCatalogIdentifier(ident);
     Schema schema =
@@ -209,7 +205,6 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Su
    * @throws NoSuchSchemaException If the schema corresponding to the provided identifier does not
    *     exist.
    */
-  @Override
   public Schema alterSchema(NameIdentifier ident, SchemaChange... changes)
       throws NoSuchSchemaException {
     validateAlterProperties(ident, HasPropertyMetadata::schemaPropertiesMetadata, changes);
@@ -294,7 +289,6 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Su
    * @return True if the schema was successfully dropped, false otherwise.
    * @throws NonEmptySchemaException If the schema contains tables and cascade is set to false.
    */
-  @Override
   public boolean dropSchema(NameIdentifier ident, boolean cascade) throws NonEmptySchemaException {
     boolean dropped =
         doWithCatalog(

--- a/core/src/test/java/com/datastrato/gravitino/TestCatalogOperations.java
+++ b/core/src/test/java/com/datastrato/gravitino/TestCatalogOperations.java
@@ -218,6 +218,11 @@ public class TestCatalogOperations
   }
 
   @Override
+  public NameIdentifier[] listSchemas() throws NoSuchCatalogException {
+    return schemas.keySet().toArray(new NameIdentifier[0]);
+  }
+
+  @Override
   public Schema createSchema(NameIdentifier ident, String comment, Map<String, String> properties)
       throws NoSuchCatalogException, SchemaAlreadyExistsException {
     AuditInfo auditInfo =

--- a/core/src/test/java/com/datastrato/gravitino/TestCatalogOperations.java
+++ b/core/src/test/java/com/datastrato/gravitino/TestCatalogOperations.java
@@ -44,6 +44,8 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class TestCatalogOperations
     implements CatalogOperations, TableCatalog, FilesetCatalog, TopicCatalog, SupportsSchemas {
@@ -307,6 +309,26 @@ public class TestCatalogOperations
     if (cascade) {
       tables.keySet().stream()
           .filter(table -> table.namespace().toString().equals(ident.toString()))
+          .forEach(tables::remove);
+    }
+
+    return true;
+  }
+
+  @Override
+  public boolean dropSchema(String schemaName, boolean cascade) throws NonEmptySchemaException {
+    Set<String> allSchemas =
+        schemas.keySet().stream().map(NameIdentifier::name).collect(Collectors.toSet());
+
+    if (!allSchemas.contains(schemaName)) {
+      return false;
+    }
+
+    schemas.keySet().stream().filter(key -> key.name().equals(schemaName)).forEach(schemas::remove);
+
+    if (cascade) {
+      tables.keySet().stream()
+          .filter(table -> table.namespace().level(2).equals(schemaName))
           .forEach(tables::remove);
     }
 

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoQueryITBase.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoQueryITBase.java
@@ -189,7 +189,7 @@ public class TrinoQueryITBase {
     }
     Catalog catalog = metalake.loadCatalog(NameIdentifier.of(metalakeName, catalogName));
     SupportsSchemas schemas = catalog.asSchemas();
-    Arrays.stream(schemas.listSchemas(Namespace.ofSchema(metalakeName, catalogName)))
+    Arrays.stream(schemas.listSchemas())
         .filter(schema -> !schema.name().equals("default"))
         .forEach(
             schema -> {


### PR DESCRIPTION
### What changes were proposed in this pull request?

The method in SupportsSchemas is not that user-friendly. Provide a new "dropSchema" method which takes the schemaName as parameter instead of an NameIdentifier. See more in https://github.com/datastrato/gravitino/issues/2479

### Why are the changes needed?

Simplify the interface, making it easier to use

Fix: #2479

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

The UT and IT covers this change.
