### PR TITLE
[#2388] feat(spark-connector): filter non relational catalogs before register to spark catalog manager

### DIFF
--- a/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/catalog/GravitinoCatalogManager.java
+++ b/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/catalog/GravitinoCatalogManager.java
@@ -73,15 +73,15 @@ public class GravitinoCatalogManager {
     return metalakeName;
   }
 
-  public Set<String> listCatalogs() {
-    NameIdentifier[] catalogNames = metalake.listCatalogs(Namespace.ofCatalog(metalake.name()));
-    LOG.info(
-        "Load metalake {}'s catalogs. catalogs: {}.",
-        metalake.name(),
-        Arrays.toString(catalogNames));
-    return Arrays.stream(catalogNames)
-        .map(identifier -> identifier.name())
-        .collect(Collectors.toSet());
+  public void loadRelationalCatalogs() {
+    Catalog[] catalogs = metalake.listCatalogsInfo(Namespace.ofCatalog(metalake.name()));
+    Arrays.stream(catalogs)
+        .filter(catalog -> Type.RELATIONAL.equals(catalog.type()))
+        .forEach(catalog -> gravitinoCatalogs.put(catalog.name(), catalog));
+  }
+
+  public Set<String> getCatalogNames() {
+    return gravitinoCatalogs.asMap().keySet().stream().collect(Collectors.toSet());
   }
 
   private Catalog loadCatalog(String catalogName) {

--- a/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/catalog/GravitinoCatalogManager.java
+++ b/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/catalog/GravitinoCatalogManager.java
@@ -76,7 +76,7 @@ public class GravitinoCatalogManager {
   public void loadRelationalCatalogs() {
     Catalog[] catalogs = metalake.listCatalogsInfo(Namespace.ofCatalog(metalake.name()));
     Arrays.stream(catalogs)
-        .filter(catalog -> Type.RELATIONAL.equals(catalog.type()))
+        .filter(catalog -> Catalog.Type.RELATIONAL.equals(catalog.type()))
         .forEach(catalog -> gravitinoCatalogs.put(catalog.name(), catalog));
   }
 

--- a/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/plugin/GravitinoDriverPlugin.java
+++ b/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/plugin/GravitinoDriverPlugin.java
@@ -44,8 +44,9 @@ public class GravitinoDriverPlugin implements DriverPlugin {
             "%s:%s, should not be empty", GravitinoSparkConfig.GRAVITINO_METALAKE, metalake));
 
     catalogManager = GravitinoCatalogManager.create(gravitinoUri, metalake);
-    Set<String> catalogs = catalogManager.listCatalogs();
-    registerGravitinoCatalogs(conf, catalogs);
+    catalogManager.loadRelationalCatalogs();
+    Set<String> catalogNames = catalogManager.getCatalogNames();
+    registerGravitinoCatalogs(conf, catalogNames);
     registerSqlExtensions();
     return Collections.emptyMap();
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
filter non relational catalogs before register to spark catalog manager

### Why are the changes needed?
Fix: #2388 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
existing test
