### PR TITLE
[MINOR] Disable doris module since it is not ready for shipping

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -701,7 +701,8 @@ tasks {
     dependsOn(
       ":catalogs:catalog-hive:copyLibAndConfig",
       ":catalogs:catalog-lakehouse-iceberg:copyLibAndConfig",
-      ":catalogs:catalog-jdbc-doris:copyLibAndConfig",
+      // TODO. Enable packaging the catalog-jdbc-doris module when it is ready for shipping
+      // ":catalogs:catalog-jdbc-doris:copyLibAndConfig",
       ":catalogs:catalog-jdbc-mysql:copyLibAndConfig",
       ":catalogs:catalog-jdbc-postgresql:copyLibAndConfig",
       ":catalogs:catalog-hadoop:copyLibAndConfig",


### PR DESCRIPTION
### What changes were proposed in this pull request?

Don't package the Doris module into released package, since it is not ready for shipping. We could enable this when it is functional-ready.

### Why are the changes needed?

To avoid ship with incomplete feature.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No.
