### PR TITLE
refactor(core): use capability of column default value

### DIFF
--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogCapability.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogCapability.java
@@ -16,4 +16,13 @@ public class HiveCatalogCapability implements Capability {
         "The NOT NULL constraint for column is only supported since Hive 3.0, "
             + "but the current Gravitino Hive catalog only supports Hive 2.x.");
   }
+
+  @Override
+  public CapabilityResult columnDefaultValue() {
+    // The DEFAULT constraint for column is supported since Hive3.0, see
+    // https://issues.apache.org/jira/browse/HIVE-18726
+    return CapabilityResult.unsupported(
+        "The DEFAULT constraint for column is only supported since Hive 3.0, "
+            + "but the current Gravitino Hive catalog only supports Hive 2.x.");
+  }
 }

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveTable.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveTable.java
@@ -25,13 +25,11 @@ import com.datastrato.gravitino.rel.TableChange;
 import com.datastrato.gravitino.rel.expressions.NamedReference;
 import com.datastrato.gravitino.rel.expressions.distributions.Distribution;
 import com.datastrato.gravitino.rel.expressions.distributions.Distributions;
-import com.datastrato.gravitino.rel.expressions.literals.Literals;
 import com.datastrato.gravitino.rel.expressions.sorts.NullOrdering;
 import com.datastrato.gravitino.rel.expressions.sorts.SortDirection;
 import com.datastrato.gravitino.rel.expressions.sorts.SortOrder;
 import com.datastrato.gravitino.rel.expressions.sorts.SortOrders;
 import com.datastrato.gravitino.rel.expressions.transforms.Transform;
-import com.datastrato.gravitino.rel.expressions.transforms.Transforms;
 import com.datastrato.gravitino.rel.types.Types;
 import com.google.common.collect.Maps;
 import java.time.Instant;
@@ -201,34 +199,6 @@ public class TestHiveTable extends MiniHiveMetastoreService {
                     distribution,
                     sortOrders));
     Assertions.assertTrue(exception.getMessage().contains("Table already exists"));
-
-    HiveColumn withDefault =
-        HiveColumn.builder()
-            .withName("col_3")
-            .withType(Types.ByteType.get())
-            .withComment(HIVE_COMMENT)
-            .withNullable(true)
-            .withDefaultValue(Literals.NULL)
-            .build();
-    exception =
-        Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                tableCatalog.createTable(
-                    tableIdentifier,
-                    new Column[] {withDefault},
-                    HIVE_COMMENT,
-                    properties,
-                    Transforms.EMPTY_TRANSFORM,
-                    distribution,
-                    sortOrders));
-    Assertions.assertTrue(
-        exception
-            .getMessage()
-            .contains(
-                "The DEFAULT constraint for column is only supported since Hive 3.0, "
-                    + "but the current Gravitino Hive catalog only supports Hive 2.x"),
-        "The exception message is: " + exception.getMessage());
   }
 
   @Test
@@ -446,32 +416,6 @@ public class TestHiveTable extends MiniHiveMetastoreService {
             IllegalArgumentException.class,
             () -> tableCatalog.alterTable(tableIdentifier, tableChange6));
     Assertions.assertTrue(exception.getMessage().contains("Cannot add column with duplicate name"));
-
-    TableChange tableChange8 =
-        TableChange.addColumn(
-            new String[] {"col_3"}, Types.ByteType.get(), "comment", Literals.NULL);
-    exception =
-        Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () -> tableCatalog.alterTable(tableIdentifier, tableChange8));
-    Assertions.assertTrue(
-        exception
-            .getMessage()
-            .contains(
-                "The DEFAULT constraint for column is only supported since Hive 3.0, "
-                    + "but the current Gravitino Hive catalog only supports Hive 2.x"),
-        "The exception message is: " + exception.getMessage());
-
-    TableChange tableChange9 =
-        TableChange.updateColumnDefaultValue(
-            new String[] {"col_1"}, Literals.of("0", Types.ByteType.get()));
-    exception =
-        Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () -> tableCatalog.alterTable(tableIdentifier, tableChange9));
-
-    Assertions.assertEquals(
-        "Hive does not support altering column default value", exception.getMessage());
 
     // test alter
     tableCatalog.alterTable(

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
@@ -507,6 +507,30 @@ public class CatalogHiveIT extends AbstractIT {
             .contains(
                 "The NOT NULL constraint for column is only supported since Hive 3.0, "
                     + "but the current Gravitino Hive catalog only supports Hive 2.x"));
+
+    // test column default value
+    Column withDefault =
+        Column.of(
+            "default_column", Types.StringType.get(), "default column", true, false, Literals.NULL);
+    exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                catalog
+                    .asTableCatalog()
+                    .createTable(
+                        nameIdentifier,
+                        new Column[] {withDefault},
+                        TABLE_COMMENT,
+                        properties,
+                        Transforms.EMPTY_TRANSFORM));
+    Assertions.assertTrue(
+        exception
+            .getMessage()
+            .contains(
+                "The DEFAULT constraint for column is only supported since Hive 3.0, "
+                    + "but the current Gravitino Hive catalog only supports Hive 2.x"),
+        "The exception message is: " + exception.getMessage());
   }
 
   @Test
@@ -1133,6 +1157,20 @@ public class CatalogHiveIT extends AbstractIT {
             .contains(
                 "The NOT NULL constraint for column is only supported since Hive 3.0,"
                     + " but the current Gravitino Hive catalog only supports Hive 2.x. Illegal column: hive_col_name1"));
+
+    // test update column default value exception
+    TableChange updateDefaultValue =
+        TableChange.updateColumnDefaultValue(new String[] {HIVE_COL_NAME1}, Literals.NULL);
+    exception =
+        assertThrows(
+            IllegalArgumentException.class, () -> tableCatalog.alterTable(id, updateDefaultValue));
+    Assertions.assertTrue(
+        exception
+            .getMessage()
+            .contains(
+                "The DEFAULT constraint for column is only supported since Hive 3.0, "
+                    + "but the current Gravitino Hive catalog only supports Hive 2.x"),
+        "The exception message is: " + exception.getMessage());
 
     // test updateColumnPosition exception
     Column col1 = Column.of("name", Types.StringType.get(), "comment");

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalog.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalog.java
@@ -6,6 +6,7 @@ package com.datastrato.gravitino.catalog.lakehouse.iceberg;
 
 import com.datastrato.gravitino.connector.BaseCatalog;
 import com.datastrato.gravitino.connector.CatalogOperations;
+import com.datastrato.gravitino.connector.capability.Capability;
 import com.datastrato.gravitino.rel.SupportsSchemas;
 import com.datastrato.gravitino.rel.TableCatalog;
 import java.util.Map;
@@ -29,6 +30,11 @@ public class IcebergCatalog extends BaseCatalog<IcebergCatalog> {
   protected CatalogOperations newOps(Map<String, String> config) {
     IcebergCatalogOperations ops = new IcebergCatalogOperations();
     return ops;
+  }
+
+  @Override
+  public Capability newCapability() {
+    return new IcebergCatalogCapability();
   }
 
   /** @return The Iceberg catalog operations as {@link IcebergCatalogOperations}. */

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogCapability.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogCapability.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.catalog.lakehouse.iceberg;
+
+import com.datastrato.gravitino.connector.capability.Capability;
+import com.datastrato.gravitino.connector.capability.CapabilityResult;
+
+public class IcebergCatalogCapability implements Capability {
+  @Override
+  public CapabilityResult columnDefaultValue() {
+    // Iceberg column default value is WIP, see
+    // https://github.com/apache/iceberg/pull/4525
+    return CapabilityResult.unsupported("Iceberg does not support column default value.");
+  }
+}

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
@@ -481,16 +481,13 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
       IcebergColumn[] icebergColumns =
           Arrays.stream(columns)
               .map(
-                  column -> {
-                    IcebergTableOpsHelper.validateColumnDefaultValue(
-                        column.name(), column.defaultValue());
-                    return IcebergColumn.builder()
-                        .withName(column.name())
-                        .withType(column.dataType())
-                        .withComment(column.comment())
-                        .withNullable(column.nullable())
-                        .build();
-                  })
+                  column ->
+                      IcebergColumn.builder()
+                          .withName(column.name())
+                          .withType(column.dataType())
+                          .withComment(column.comment())
+                          .withNullable(column.nullable())
+                          .build())
               .toArray(IcebergColumn[]::new);
 
       IcebergTable createdTable =

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/ops/IcebergTableOpsHelper.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/ops/IcebergTableOpsHelper.java
@@ -7,7 +7,6 @@ package com.datastrato.gravitino.catalog.lakehouse.iceberg.ops;
 
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.catalog.lakehouse.iceberg.converter.ConvertUtil;
-import com.datastrato.gravitino.rel.Column;
 import com.datastrato.gravitino.rel.TableChange;
 import com.datastrato.gravitino.rel.TableChange.AddColumn;
 import com.datastrato.gravitino.rel.TableChange.After;
@@ -22,7 +21,6 @@ import com.datastrato.gravitino.rel.TableChange.UpdateColumnComment;
 import com.datastrato.gravitino.rel.TableChange.UpdateColumnPosition;
 import com.datastrato.gravitino.rel.TableChange.UpdateColumnType;
 import com.datastrato.gravitino.rel.TableChange.UpdateComment;
-import com.datastrato.gravitino.rel.expressions.Expression;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -193,9 +191,6 @@ public class IcebergTableOpsHelper {
       parentStruct = icebergTableSchema.asStruct();
     }
 
-    validateColumnDefaultValue(
-        String.join(".", addColumn.fieldName()), addColumn.getDefaultValue());
-
     if (addColumn.isAutoIncrement()) {
       throw new IllegalArgumentException("Iceberg doesn't support auto increment column");
     }
@@ -259,22 +254,12 @@ public class IcebergTableOpsHelper {
             icebergUpdateSchema, (TableChange.UpdateColumnNullability) change);
       } else if (change instanceof TableChange.UpdateColumnAutoIncrement) {
         throw new IllegalArgumentException("Iceberg doesn't support auto increment column");
-      } else if (change instanceof TableChange.UpdateColumnDefaultValue) {
-        throw new IllegalArgumentException("Iceberg doesn't support update column default value");
       } else {
         throw new NotSupportedException(
             "Iceberg doesn't support " + change.getClass().getSimpleName() + " for now");
       }
     }
     icebergUpdateSchema.commit();
-  }
-
-  public static void validateColumnDefaultValue(String fieldName, Expression defaultValue) {
-    // Iceberg column default value is WIP, see
-    // https://github.com/apache/iceberg/pull/4525
-    Preconditions.checkArgument(
-        defaultValue.equals(Column.DEFAULT_VALUE_NOT_SET),
-        "Iceberg does not support column default value. Illegal column: " + fieldName);
   }
 
   public IcebergTableChange buildIcebergTableChanges(

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergTable.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergTable.java
@@ -4,7 +4,6 @@
  */
 package com.datastrato.gravitino.catalog.lakehouse.iceberg;
 
-import static com.datastrato.gravitino.rel.expressions.transforms.Transforms.EMPTY_TRANSFORM;
 import static com.datastrato.gravitino.rel.expressions.transforms.Transforms.bucket;
 import static com.datastrato.gravitino.rel.expressions.transforms.Transforms.day;
 import static com.datastrato.gravitino.rel.expressions.transforms.Transforms.identity;
@@ -25,7 +24,6 @@ import com.datastrato.gravitino.rel.TableChange;
 import com.datastrato.gravitino.rel.expressions.NamedReference;
 import com.datastrato.gravitino.rel.expressions.distributions.Distribution;
 import com.datastrato.gravitino.rel.expressions.distributions.Distributions;
-import com.datastrato.gravitino.rel.expressions.literals.Literals;
 import com.datastrato.gravitino.rel.expressions.sorts.NullOrdering;
 import com.datastrato.gravitino.rel.expressions.sorts.SortDirection;
 import com.datastrato.gravitino.rel.expressions.sorts.SortOrder;
@@ -216,31 +214,6 @@ public class TestIcebergTable {
                     Distributions.NONE,
                     sortOrders));
     Assertions.assertTrue(exception.getMessage().contains("Table already exists"));
-
-    IcebergColumn withDefaultValue =
-        IcebergColumn.builder()
-            .withName("col")
-            .withType(Types.DateType.get())
-            .withComment(ICEBERG_COMMENT)
-            .withNullable(false)
-            .withDefaultValue(Literals.NULL)
-            .build();
-
-    exception =
-        Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                tableCatalog.createTable(
-                    tableIdentifier,
-                    new Column[] {withDefaultValue},
-                    ICEBERG_COMMENT,
-                    properties,
-                    EMPTY_TRANSFORM,
-                    Distributions.NONE,
-                    null));
-    Assertions.assertTrue(
-        exception.getMessage().contains("Iceberg does not support column default value"),
-        "The exception message is: " + exception.getMessage());
   }
 
   @Test
@@ -480,21 +453,6 @@ public class TestIcebergTable {
               .build()
         };
     Assertions.assertArrayEquals(expected, alteredTable.columns());
-
-    // test add column with default value exception
-    TableChange withDefaultValue =
-        TableChange.addColumn(
-            new String[] {"col_3"}, Types.StringType.get(), "comment", Literals.NULL);
-    exception =
-        Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                tableCatalog.alterTable(
-                    NameIdentifier.of(tableIdentifier.namespace(), "test_iceberg_table_new"),
-                    withDefaultValue));
-    Assertions.assertTrue(
-        exception.getMessage().contains("Iceberg does not support column default value"),
-        "The exception message is: " + exception.getMessage());
 
     // test delete column change
     icebergCatalog

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergIT.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergIT.java
@@ -701,7 +701,8 @@ public class CatalogIcebergIT extends AbstractIT {
     Assertions.assertTrue(
         illegalArgumentException
             .getMessage()
-            .contains("Iceberg doesn't support update column default value"));
+            .contains("Iceberg does not support column default value. Illegal column: name"),
+        "The exception is: " + illegalArgumentException.getMessage());
 
     catalog
         .asTableCatalog()

--- a/core/src/main/java/com/datastrato/gravitino/connector/BaseCatalog.java
+++ b/core/src/main/java/com/datastrato/gravitino/connector/BaseCatalog.java
@@ -77,7 +77,7 @@ public abstract class BaseCatalog<T extends BaseCatalog>
    */
   @Evolving
   protected Capability newCapability() {
-    return new Capability() {};
+    return Capability.DEFAULT;
   }
 
   /**

--- a/core/src/main/java/com/datastrato/gravitino/connector/capability/Capability.java
+++ b/core/src/main/java/com/datastrato/gravitino/connector/capability/Capability.java
@@ -13,6 +13,8 @@ import com.datastrato.gravitino.annotation.Evolving;
 @Evolving
 public interface Capability {
 
+  Capability DEFAULT = new DefaultCapability();
+
   /** The scope of the capability. */
   enum Scope {
     CATALOG,
@@ -30,7 +32,7 @@ public interface Capability {
    * @return The check result of the not null constraint.
    */
   default CapabilityResult columnNotNull() {
-    return CapabilityResult.SUPPORTED;
+    return DEFAULT.columnNotNull();
   }
 
   /**
@@ -39,7 +41,7 @@ public interface Capability {
    * @return The check result of the default value.
    */
   default CapabilityResult columnDefaultValue() {
-    return CapabilityResult.SUPPORTED;
+    return DEFAULT.columnDefaultValue();
   }
 
   /**
@@ -49,7 +51,7 @@ public interface Capability {
    * @return The capability of the case-sensitive on name.
    */
   default CapabilityResult caseSensitiveOnName(Scope scope) {
-    return CapabilityResult.SUPPORTED;
+    return DEFAULT.caseSensitiveOnName(scope);
   }
 
   /**
@@ -60,7 +62,7 @@ public interface Capability {
    * @return The capability of the specification on name.
    */
   default CapabilityResult specificationOnName(Scope scope, String name) {
-    return CapabilityResult.SUPPORTED;
+    return DEFAULT.specificationOnName(scope, name);
   }
 
   /**
@@ -70,7 +72,35 @@ public interface Capability {
    * @return The capability of the managed storage.
    */
   default CapabilityResult managedStorage(Scope scope) {
-    return CapabilityResult.unsupported(
-        String.format("The %s entity is not fully managed by Gravitino.", scope));
+    return DEFAULT.managedStorage(scope);
+  }
+
+  /** The default implementation of the capability. */
+  class DefaultCapability implements Capability {
+    @Override
+    public CapabilityResult columnNotNull() {
+      return CapabilityResult.SUPPORTED;
+    }
+
+    @Override
+    public CapabilityResult columnDefaultValue() {
+      return CapabilityResult.SUPPORTED;
+    }
+
+    @Override
+    public CapabilityResult caseSensitiveOnName(Scope scope) {
+      return CapabilityResult.SUPPORTED;
+    }
+
+    @Override
+    public CapabilityResult specificationOnName(Scope scope, String name) {
+      return CapabilityResult.SUPPORTED;
+    }
+
+    @Override
+    public CapabilityResult managedStorage(Scope scope) {
+      return CapabilityResult.unsupported(
+          String.format("The %s entity is not fully managed by Gravitino.", scope));
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

- remove the column default value validation in Hive catalog and Iceberg catalog
- available column default capability in the framework

### Why are the changes needed?

Fix: #2953 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

tests added
