### PR TITLE
[#2614][#2530]feat(web): Add web UI support for Kafka catalog and add default page for no data tree

### DIFF
--- a/web/src/app/metalakes/metalake/MetalakeTree.js
+++ b/web/src/app/metalakes/metalake/MetalakeTree.js
@@ -9,7 +9,7 @@ import { useEffect, useRef, useState } from 'react'
 
 import { useRouter } from 'next/navigation'
 
-import { IconButton, Typography } from '@mui/material'
+import { IconButton, Typography, Box } from '@mui/material'
 import { Tree } from 'antd'
 
 import Icon from '@/components/Icon'
@@ -23,7 +23,8 @@ import {
   setSelectedNodes,
   setLoadedNodes,
   getTableDetails,
-  getFilesetDetails
+  getFilesetDetails,
+  getTopicDetails
 } from '@/lib/store/metalakes'
 
 import { extractPlaceholder } from '@/lib/utils'
@@ -63,20 +64,33 @@ const MetalakeTree = props => {
   const handleClickIcon = (e, nodeProps) => {
     e.stopPropagation()
 
-    if (nodeProps.data.node === 'table') {
-      if (store.selectedNodes.includes(nodeProps.data.key)) {
-        const pathArr = extractPlaceholder(nodeProps.data.key)
-        const [metalake, catalog, schema, table] = pathArr
-        dispatch(getTableDetails({ init: true, metalake, catalog, schema, table }))
+    switch (nodeProps.data.node) {
+      case 'table': {
+        if (store.selectedNodes.includes(nodeProps.data.key)) {
+          const pathArr = extractPlaceholder(nodeProps.data.key)
+          const [metalake, catalog, schema, table] = pathArr
+          dispatch(getTableDetails({ init: true, metalake, catalog, schema, table }))
+        }
+        break
       }
-    } else if (nodeProps.data.node === 'fileset') {
-      if (store.selectedNodes.includes(nodeProps.data.key)) {
-        const pathArr = extractPlaceholder(nodeProps.data.key)
-        const [metalake, catalog, schema, fileset] = pathArr
-        dispatch(getFilesetDetails({ init: true, metalake, catalog, schema, fileset }))
+      case 'fileset': {
+        if (store.selectedNodes.includes(nodeProps.data.key)) {
+          const pathArr = extractPlaceholder(nodeProps.data.key)
+          const [metalake, catalog, schema, fileset] = pathArr
+          dispatch(getFilesetDetails({ init: true, metalake, catalog, schema, fileset }))
+        }
+        break
       }
-    } else {
-      dispatch(setIntoTreeNodeWithFetch({ key: nodeProps.data.key }))
+      case 'topic': {
+        if (store.selectedNodes.includes(nodeProps.data.key)) {
+          const pathArr = extractPlaceholder(nodeProps.data.key)
+          const [metalake, catalog, schema, topic] = pathArr
+          dispatch(getTopicDetails({ init: true, metalake, catalog, schema, topic }))
+        }
+        break
+      }
+      default:
+        dispatch(setIntoTreeNodeWithFetch({ key: nodeProps.data.key }))
     }
   }
 
@@ -195,6 +209,22 @@ const MetalakeTree = props => {
             <Icon icon={isHover !== nodeProps.data.key ? 'bx:file' : 'mdi:reload'} fontSize='inherit' />
           </IconButton>
         )
+      case 'topic':
+        return (
+          <IconButton
+            disableRipple={!store.selectedNodes.includes(nodeProps.data.key)}
+            size='small'
+            sx={{ color: '#666' }}
+            onClick={e => handleClickIcon(e, nodeProps)}
+            onMouseEnter={e => onMouseEnter(e, nodeProps)}
+            onMouseLeave={e => onMouseLeave(e, nodeProps)}
+          >
+            <Icon
+              icon={isHover !== nodeProps.data.key ? 'material-symbols:topic-outline' : 'mdi:reload'}
+              fontSize='inherit'
+            />
+          </IconButton>
+        )
 
       default:
         return <></>
@@ -225,51 +255,63 @@ const MetalakeTree = props => {
 
   useEffect(() => {
     if (store.selectedNodes.length !== 0) {
-      treeRef.current.scrollTo({ key: store.selectedNodes[0] })
+      treeRef.current && treeRef.current.scrollTo({ key: store.selectedNodes[0] })
     }
-  }, [store.selectedNodes])
+  }, [store.selectedNodes, treeRef])
+
+  useEffect(() => {
+    dispatch(setExpandedNodes(store.expandedNodes))
+  }, [store.metalakeTree, dispatch])
 
   return (
     <>
-      <Tree
-        ref={treeRef}
-        rootStyle={{
-          '& .antTreeTitle': {
-            width: '100%'
-          }
-        }}
-        treeData={store.metalakeTree}
-        loadData={onLoadData}
-        loadedKeys={store.loadedNodes}
-        selectedKeys={store.selectedNodes}
-        expandedKeys={store.expandedNodes}
-        onExpand={onExpand}
-        onSelect={onSelect}
-        height={height}
-        defaultExpandAll
-        blockNode
-        showIcon
-        className={clsx([
-          '[&_.ant-tree-switcher]:twc-inline-flex',
-          '[&_.ant-tree-switcher]:twc-justify-center',
-          '[&_.ant-tree-switcher]:twc-items-center',
+      {store.metalakeTree.length ? (
+        <Tree
+          ref={treeRef}
+          rootStyle={{
+            '& .antTreeTitle': {
+              width: '100%'
+            }
+          }}
+          treeData={store.metalakeTree}
+          loadData={onLoadData}
+          loadedKeys={store.loadedNodes}
+          selectedKeys={store.selectedNodes}
+          expandedKeys={store.expandedNodes}
+          onExpand={onExpand}
+          onSelect={onSelect}
+          height={height}
+          defaultExpandAll
+          blockNode
+          showIcon
+          className={clsx([
+            '[&_.ant-tree-switcher]:twc-inline-flex',
+            '[&_.ant-tree-switcher]:twc-justify-center',
+            '[&_.ant-tree-switcher]:twc-items-center',
 
-          '[&_.ant-tree-iconEle]:twc-w-[unset]',
-          '[&_.ant-tree-iconEle]:twc-inline-flex',
-          '[&_.ant-tree-iconEle]:twc-items-center',
+            '[&_.ant-tree-iconEle]:twc-w-[unset]',
+            '[&_.ant-tree-iconEle]:twc-inline-flex',
+            '[&_.ant-tree-iconEle]:twc-items-center',
 
-          '[&_.ant-tree-title]:twc-inline-flex',
-          '[&_.ant-tree-title]:twc-w-[calc(100%-24px)]',
-          '[&_.ant-tree-title]:twc-text-lg',
+            '[&_.ant-tree-title]:twc-inline-flex',
+            '[&_.ant-tree-title]:twc-w-[calc(100%-24px)]',
+            '[&_.ant-tree-title]:twc-text-lg',
 
-          '[&_.ant-tree-node-content-wrapper]:twc-inline-flex',
-          '[&_.ant-tree-node-content-wrapper]:twc-items-center',
-          '[&_.ant-tree-node-content-wrapper]:twc-leading-[28px]'
-        ])}
-        data-refer='tree-view'
-        icon={nodeProps => renderIcon(nodeProps)}
-        titleRender={nodeData => renderNode(nodeData)}
-      />
+            '[&_.ant-tree-node-content-wrapper]:twc-inline-flex',
+            '[&_.ant-tree-node-content-wrapper]:twc-items-center',
+            '[&_.ant-tree-node-content-wrapper]:twc-leading-[28px]'
+          ])}
+          data-refer='tree-view'
+          icon={nodeProps => renderIcon(nodeProps)}
+          titleRender={nodeData => renderNode(nodeData)}
+        />
+      ) : (
+        <Box className={`twc-h-full twc-grow twc-flex twc-items-center twc-flex-col twc-justify-center`}>
+          <Typography sx={{ color: theme => theme.palette.text.primary }} data-refer='no-data'>
+            No data
+          </Typography>
+        </Box>
+      )}
     </>
   )
 }

--- a/web/src/app/metalakes/metalake/MetalakeTree.js
+++ b/web/src/app/metalakes/metalake/MetalakeTree.js
@@ -55,6 +55,8 @@ const MetalakeTree = props => {
           default:
             return 'bx:book'
         }
+      case 'messaging':
+        return 'skill-icons:kafka'
       case 'fileset':
       default:
         return 'bx:book'

--- a/web/src/app/metalakes/metalake/MetalakeView.js
+++ b/web/src/app/metalakes/metalake/MetalakeView.js
@@ -19,11 +19,13 @@ import {
   fetchSchemas,
   fetchTables,
   fetchFilesets,
+  fetchTopics,
   getMetalakeDetails,
   getCatalogDetails,
   getSchemaDetails,
   getTableDetails,
   getFilesetDetails,
+  getTopicDetails,
   setSelectedNodes
 } from '@/lib/store/metalakes'
 
@@ -40,10 +42,11 @@ const MetalakeView = () => {
       type: searchParams.get('type'),
       schema: searchParams.get('schema'),
       table: searchParams.get('table'),
-      fileset: searchParams.get('fileset')
+      fileset: searchParams.get('fileset'),
+      topic: searchParams.get('topic')
     }
     if ([...searchParams.keys()].length) {
-      const { metalake, catalog, type, schema, table, fileset } = routeParams
+      const { metalake, catalog, type, schema, table, fileset, topic } = routeParams
 
       if (paramsSize === 1 && metalake) {
         dispatch(fetchCatalogs({ init: true, page: 'metalakes', metalake }))
@@ -56,10 +59,18 @@ const MetalakeView = () => {
       }
 
       if (paramsSize === 4 && catalog && type && schema) {
-        if (type === 'fileset') {
-          dispatch(fetchFilesets({ init: true, page: 'schemas', metalake, catalog, schema }))
-        } else {
-          dispatch(fetchTables({ init: true, page: 'schemas', metalake, catalog, schema }))
+        switch (type) {
+          case 'relational':
+            dispatch(fetchTables({ init: true, page: 'schemas', metalake, catalog, schema }))
+            break
+          case 'fileset':
+            dispatch(fetchFilesets({ init: true, page: 'schemas', metalake, catalog, schema }))
+            break
+          case 'messaging':
+            dispatch(fetchTopics({ init: true, page: 'schemas', metalake, catalog, schema }))
+            break
+          default:
+            break
         }
         dispatch(getSchemaDetails({ metalake, catalog, schema }))
       }
@@ -71,6 +82,10 @@ const MetalakeView = () => {
       if (paramsSize === 5 && catalog && schema && fileset) {
         dispatch(getFilesetDetails({ init: true, metalake, catalog, schema, fileset }))
       }
+
+      if (paramsSize === 5 && catalog && schema && topic) {
+        dispatch(getTopicDetails({ init: true, metalake, catalog, schema, topic }))
+      }
     }
 
     dispatch(
@@ -81,7 +96,7 @@ const MetalakeView = () => {
                 routeParams.schema ? `{{${routeParams.schema}}}` : ''
               }${routeParams.table ? `{{${routeParams.table}}}` : ''}${
                 routeParams.fileset ? `{{${routeParams.fileset}}}` : ''
-              }`
+              }${routeParams.topic ? `{{${routeParams.topic}}}` : ''}`
             ]
           : []
       )

--- a/web/src/app/metalakes/metalake/rightContent/CreateCatalogDialog.js
+++ b/web/src/app/metalakes/metalake/rightContent/CreateCatalogDialog.js
@@ -36,7 +36,7 @@ import { yupResolver } from '@hookform/resolvers/yup'
 
 import { groupBy } from 'lodash-es'
 import { genUpdates } from '@/lib/utils'
-import { providers } from '@/lib/utils/initial'
+import { providers, filesetProviders, messagingProviders } from '@/lib/utils/initial'
 import { nameRegex, keyRegex } from '@/lib/utils/regex'
 import { useSearchParams } from 'next/navigation'
 
@@ -45,10 +45,8 @@ const defaultValues = {
   type: 'relational',
   provider: '',
   comment: '',
-  propItems: providers[0].defaultProps
+  propItems: []
 }
-
-const providerTypeValues = providers.map(i => i.value)
 
 const schema = yup.object().shape({
   name: yup
@@ -58,8 +56,19 @@ const schema = yup.object().shape({
       nameRegex,
       'This field must start with a letter or underscore, and can only contain letters, numbers, and underscores'
     ),
-  type: yup.mixed().oneOf(['relational', 'fileset']).required(),
-  provider: yup.mixed().oneOf(providerTypeValues).required(),
+  type: yup.mixed().oneOf(['relational', 'fileset', 'messaging']).required(),
+  provider: yup.string().when('type', (type, schema) => {
+    switch (type) {
+      case 'relational':
+        return schema.oneOf(providers.map(i => i.value)).required()
+      case 'fileset':
+        return schema.oneOf(filesetProviders.map(i => i.value)).required()
+      case 'messaging':
+        return schema.oneOf(messagingProviders.map(i => i.value)).required()
+      default:
+        return schema
+    }
+  }),
   propItems: yup.array().of(
     yup.object().shape({
       required: yup.boolean(),
@@ -284,12 +293,22 @@ const CreateCatalogDialog = props => {
   }
 
   useEffect(() => {
-    if (typeSelect === 'fileset') {
-      setProviderTypes(providers.filter(p => p.value === 'hadoop'))
-      setValue('provider', 'hadoop')
-    } else {
-      setProviderTypes(providers.filter(p => p.value !== 'hadoop'))
-      setValue('provider', 'hive')
+    switch (typeSelect) {
+      case 'relational': {
+        setProviderTypes(providers)
+        setValue('provider', 'hive')
+        break
+      }
+      case 'fileset': {
+        setProviderTypes(filesetProviders)
+        setValue('provider', 'hadoop')
+        break
+      }
+      case 'messaging': {
+        setProviderTypes(messagingProviders)
+        setValue('provider', 'kafka')
+        break
+      }
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -298,16 +317,16 @@ const CreateCatalogDialog = props => {
   useEffect(() => {
     let defaultProps = []
 
-    const providerItemIndex = providers.findIndex(i => i.value === providerSelect)
+    const providerItemIndex = providerTypes.findIndex(i => i.value === providerSelect)
 
     if (providerItemIndex !== -1) {
-      defaultProps = providers[providerItemIndex].defaultProps
+      defaultProps = providerTypes[providerItemIndex].defaultProps
 
-      resetPropsFields(providers, providerItemIndex)
+      resetPropsFields(providerTypes, providerItemIndex)
 
       if (type === 'create') {
         setInnerProps(defaultProps)
-        setValue('propItems', providers[providerItemIndex].defaultProps)
+        setValue('propItems', providerTypes[providerItemIndex].defaultProps)
       }
     }
 
@@ -324,7 +343,26 @@ const CreateCatalogDialog = props => {
       setValue('type', data.type)
       setValue('provider', data.provider)
 
-      const providerItem = providers.find(i => i.value === data.provider)
+      let providersItems = []
+
+      switch (data.type) {
+        case 'relational': {
+          providersItems = providers
+          break
+        }
+        case 'fileset': {
+          providersItems = filesetProviders
+          break
+        }
+        case 'messaging': {
+          providersItems = messagingProviders
+          break
+        }
+      }
+
+      setProviderTypes(providersItems)
+
+      const providerItem = providersItems.find(i => i.value === data.provider)
       let propsItems = [...providerItem.defaultProps]
 
       propsItems = propsItems.map((it, idx) => {
@@ -427,6 +465,7 @@ const CreateCatalogDialog = props => {
                     >
                       <MenuItem value={'relational'}>relational</MenuItem>
                       <MenuItem value={'fileset'}>fileset</MenuItem>
+                      <MenuItem value={'messaging'}>messaging</MenuItem>
                     </Select>
                   )}
                 />

--- a/web/src/app/metalakes/metalake/rightContent/MetalakePath.js
+++ b/web/src/app/metalakes/metalake/rightContent/MetalakePath.js
@@ -27,16 +27,18 @@ const MetalakePath = props => {
     type: searchParams.get('type'),
     schema: searchParams.get('schema'),
     table: searchParams.get('table'),
-    fileset: searchParams.get('fileset')
+    fileset: searchParams.get('fileset'),
+    topic: searchParams.get('topic')
   }
 
-  const { metalake, catalog, type, schema, table, fileset } = routeParams
+  const { metalake, catalog, type, schema, table, fileset, topic } = routeParams
 
   const metalakeUrl = `?metalake=${metalake}`
   const catalogUrl = `?metalake=${metalake}&catalog=${catalog}&type=${type}`
   const schemaUrl = `?metalake=${metalake}&catalog=${catalog}&type=${type}&schema=${schema}`
   const tableUrl = `?metalake=${metalake}&catalog=${catalog}&type=${type}&schema=${schema}&table=${table}`
   const filesetUrl = `?metalake=${metalake}&catalog=${catalog}&type=${type}&schema=${schema}&fileset=${fileset}`
+  const topicUrl = `?metalake=${metalake}&catalog=${catalog}&type=${type}&schema=${schema}&topic=${topic}`
 
   const handleClick = (event, path) => {
     path === `?${searchParams.toString()}` && event.preventDefault()
@@ -104,6 +106,14 @@ const MetalakePath = props => {
           >
             <Icon icon='bx:file' fontSize={20} />
             <Text>{fileset}</Text>
+          </MUILink>
+        </Tooltip>
+      )}
+      {topic && (
+        <Tooltip title={topic} placement='top'>
+          <MUILink component={Link} href={topicUrl} onClick={event => handleClick(event, topicUrl)} underline='hover'>
+            <Icon icon='bx:file' fontSize={20} />
+            <Text>{topic}</Text>
           </MUILink>
         </Tooltip>
       )}

--- a/web/src/app/metalakes/metalake/rightContent/tabsContent/TabsContent.js
+++ b/web/src/app/metalakes/metalake/rightContent/tabsContent/TabsContent.js
@@ -54,7 +54,7 @@ const TabsContent = () => {
   const paramsSize = [...searchParams.keys()].length
   const type = searchParams.get('type')
   const [tab, setTab] = useState('table')
-  const isNotNeedTableTab = type && type === 'fileset' && paramsSize === 5
+  const isNotNeedTableTab = type && ['fileset', 'messaging'].includes(type) && paramsSize === 5
 
   const handleChangeTab = (event, newValue) => {
     setTab(newValue)
@@ -68,7 +68,16 @@ const TabsContent = () => {
       tableTitle = 'Schemas'
       break
     case 4:
-      tableTitle = type === 'fileset' ? 'Filesets' : 'Tables'
+      switch (type) {
+        case 'fileset':
+          tableTitle = 'Filesets'
+          break
+        case 'messaging':
+          tableTitle = 'Topics'
+          break
+        default:
+          tableTitle = 'Tables'
+      }
       break
     case 5:
       tableTitle = 'Columns'

--- a/web/src/app/metalakes/metalake/rightContent/tabsContent/detailsView/DetailsView.js
+++ b/web/src/app/metalakes/metalake/rightContent/tabsContent/detailsView/DetailsView.js
@@ -23,12 +23,24 @@ const DetailsView = () => {
 
   const audit = activatedItem?.audit || {}
 
-  const properties = Object.keys(activatedItem?.properties || []).map(item => {
-    return {
-      key: item,
-      value: JSON.stringify(activatedItem?.properties[item]).replace(/^"|"$/g, '')
-    }
-  })
+  const properties = Object.keys(activatedItem?.properties || [])
+    .filter(key => !['partition-count', 'replication-factor'].includes(key))
+    .map(item => {
+      return {
+        key: item,
+        value: JSON.stringify(activatedItem?.properties[item]).replace(/^"|"$/g, '')
+      }
+    })
+  if (paramsSize === 5 && searchParams.get('topic')) {
+    properties.unshift({
+      key: 'replication-factor',
+      value: JSON.stringify(activatedItem?.properties['replication-factor'])?.replace(/^"|"$/g, '')
+    })
+    properties.unshift({
+      key: 'partition-count',
+      value: JSON.stringify(activatedItem?.properties['partition-count'])?.replace(/^"|"$/g, '')
+    })
+  }
 
   const renderFieldText = ({ value, linkBreak = false, isDate = false }) => {
     if (!value) {
@@ -45,7 +57,7 @@ const DetailsView = () => {
   return (
     <Box sx={{ p: 4, height: '100%', overflow: 'auto' }}>
       <Grid container spacing={6}>
-        {paramsSize == 2 && searchParams.hasOwnProperty('catalog') ? (
+        {paramsSize == 3 && searchParams.get('catalog') && searchParams.get('type') ? (
           <>
             <Grid item xs={12} md={6} sx={{ mb: [0, 5] }}>
               <Typography variant='body2' sx={{ mb: 2 }}>
@@ -117,8 +129,30 @@ const DetailsView = () => {
                 {properties.map((item, index) => {
                   return (
                     <TableRow key={index}>
-                      <TableCell sx={{ py: theme => `${theme.spacing(2.75)} !important` }}>{item.key}</TableCell>
-                      <TableCell sx={{ py: theme => `${theme.spacing(2.75)} !important` }}>{item.value}</TableCell>
+                      <TableCell sx={{ py: theme => `${theme.spacing(2.75)} !important` }}>
+                        <Typography
+                          sx={{
+                            fontWeight:
+                              searchParams.get('topic') && ['partition-count', 'replication-factor'].includes(item.key)
+                                ? 500
+                                : 400
+                          }}
+                        >
+                          {item.key}
+                        </Typography>
+                      </TableCell>
+                      <TableCell sx={{ py: theme => `${theme.spacing(2.75)} !important` }}>
+                        <Typography
+                          sx={{
+                            fontWeight:
+                              searchParams.get('topic') && ['partition-count', 'replication-factor'].includes(item.key)
+                                ? 500
+                                : 400
+                          }}
+                        >
+                          {item.value}
+                        </Typography>
+                      </TableCell>
                     </TableRow>
                   )
                 })}

--- a/web/src/app/rootLayout/AppBar.js
+++ b/web/src/app/rootLayout/AppBar.js
@@ -38,13 +38,13 @@ const AppBar = () => {
   const router = useRouter()
 
   useEffect(() => {
-    if (!store.metalakes.length) {
+    if (!store.metalakes.length && metalake) {
       dispatch(fetchMetalakes())
     }
     const metalakeItems = store.metalakes.map(i => i.name)
     setMetalakes(metalakeItems)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [store.metalakes])
+  }, [store.metalakes, metalake, dispatch])
 
   return (
     <MuiAppBar

--- a/web/src/lib/api/topics/index.js
+++ b/web/src/lib/api/topics/index.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+
+import { defHttp } from '@/lib/utils/axios'
+
+const Apis = {
+  GET: ({ metalake, catalog, schema }) => `/api/metalakes/${metalake}/catalogs/${catalog}/schemas/${schema}/topics`,
+  GET_DETAIL: ({ metalake, catalog, schema, topic }) =>
+    `/api/metalakes/${metalake}/catalogs/${catalog}/schemas/${schema}/topics/${topic}`
+}
+
+export const getTopicsApi = params => {
+  return defHttp.get({
+    url: `${Apis.GET(params)}`
+  })
+}
+
+export const getTopicDetailsApi = ({ metalake, catalog, schema, topic }) => {
+  return defHttp.get({
+    url: `${Apis.GET_DETAIL({ metalake, catalog, schema, topic })}`
+  })
+}

--- a/web/src/lib/store/metalakes/index.js
+++ b/web/src/lib/store/metalakes/index.js
@@ -137,7 +137,7 @@ export const setIntoTreeNodeWithFetch = createAsyncThunk(
           children: []
         }
       })
-    } else if (pathArr.length === 4 && type === 'table') {
+    } else if (pathArr.length === 4 && type === 'relational') {
       const [err, res] = await to(getTablesApi({ metalake, catalog, schema }))
 
       const { identifiers = [] } = res

--- a/web/src/lib/store/metalakes/index.js
+++ b/web/src/lib/store/metalakes/index.js
@@ -28,6 +28,7 @@ import {
 import { getSchemasApi, getSchemaDetailsApi } from '@/lib/api/schemas'
 import { getTablesApi, getTableDetailsApi } from '@/lib/api/tables'
 import { getFilesetsApi, getFilesetDetailsApi } from '@/lib/api/filesets'
+import { getTopicsApi, getTopicDetailsApi } from '@/lib/api/topics'
 
 export const fetchMetalakes = createAsyncThunk('appMetalakes/fetchMetalakes', async (params, { getState }) => {
   const [err, res] = await to(getMetalakesApi())
@@ -136,7 +137,7 @@ export const setIntoTreeNodeWithFetch = createAsyncThunk(
           children: []
         }
       })
-    } else if (pathArr.length === 4 && type !== 'fileset') {
+    } else if (pathArr.length === 4 && type === 'table') {
       const [err, res] = await to(getTablesApi({ metalake, catalog, schema }))
 
       const { identifiers = [] } = res
@@ -177,6 +178,27 @@ export const setIntoTreeNodeWithFetch = createAsyncThunk(
           path: `?${new URLSearchParams({ metalake, catalog, type, schema, fileset: filesetItem.name }).toString()}`,
           name: filesetItem.name,
           title: filesetItem.name,
+          isLeaf: true
+        }
+      })
+    } else if (pathArr.length === 4 && type === 'messaging') {
+      const [err, res] = await to(getTopicsApi({ metalake, catalog, schema }))
+
+      const { identifiers = [] } = res
+
+      if (err || !res) {
+        throw new Error(err)
+      }
+
+      result.data = identifiers.map(topicItem => {
+        return {
+          ...topicItem,
+          node: 'topic',
+          id: `{{${metalake}}}{{${catalog}}}{{${type}}}{{${schema}}}{{${topicItem.name}}}`,
+          key: `{{${metalake}}}{{${catalog}}}{{${type}}}{{${schema}}}{{${topicItem.name}}}`,
+          path: `?${new URLSearchParams({ metalake, catalog, type, schema, topic: topicItem.name }).toString()}`,
+          name: topicItem.name,
+          title: topicItem.name,
           isLeaf: true
         }
       })
@@ -692,6 +714,104 @@ export const getFilesetDetails = createAsyncThunk(
   }
 )
 
+export const fetchTopics = createAsyncThunk(
+  'appMetalakes/fetchTopics',
+  async ({ init, page, metalake, catalog, schema }, { getState, dispatch }) => {
+    if (init) {
+      dispatch(setTableLoading(true))
+    }
+
+    const [err, res] = await to(getTopicsApi({ metalake, catalog, schema }))
+    dispatch(setTableLoading(false))
+
+    if (init && (err || !res)) {
+      dispatch(resetTableData())
+      throw new Error(err)
+    }
+
+    const { identifiers = [] } = res
+
+    const topics = identifiers.map(topic => {
+      return {
+        ...topic,
+        node: 'topic',
+        id: `{{${metalake}}}{{${catalog}}}{{${'messaging'}}}{{${schema}}}{{${topic.name}}}`,
+        key: `{{${metalake}}}{{${catalog}}}{{${'messaging'}}}{{${schema}}}{{${topic.name}}}`,
+        path: `?${new URLSearchParams({
+          metalake,
+          catalog,
+          type: 'messaging',
+          schema,
+          topic: topic.name
+        }).toString()}`,
+        name: topic.name,
+        title: topic.name,
+        isLeaf: true
+      }
+    })
+
+    if (
+      init &&
+      getState().metalakes.loadedNodes.includes(`{{${metalake}}}{{${catalog}}}{{${'messaging'}}}{{${schema}}}`)
+    ) {
+      dispatch(
+        setIntoTreeNodes({
+          key: `{{${metalake}}}{{${catalog}}}{{${'messaging'}}}{{${schema}}}`,
+          data: topics,
+          tree: getState().metalakes.metalakeTree
+        })
+      )
+    }
+
+    if (getState().metalakes.metalakeTree.length === 0) {
+      dispatch(fetchCatalogs({ metalake }))
+    }
+
+    dispatch(
+      setExpandedNodes([
+        `{{${metalake}}}`,
+        `{{${metalake}}}{{${catalog}}}{{${'messaging'}}}`,
+        `{{${metalake}}}{{${catalog}}}{{${'messaging'}}}{{${schema}}}`
+      ])
+    )
+
+    return { topics, page, init }
+  }
+)
+
+export const getTopicDetails = createAsyncThunk(
+  'appMetalakes/getTopicDetails',
+  async ({ init, metalake, catalog, schema, topic }, { getState, dispatch }) => {
+    dispatch(resetTableData())
+    if (init) {
+      dispatch(setTableLoading(true))
+    }
+    const [err, res] = await to(getTopicDetailsApi({ metalake, catalog, schema, topic }))
+    dispatch(setTableLoading(false))
+
+    if (err || !res) {
+      dispatch(resetTableData())
+      throw new Error(err)
+    }
+
+    const { topic: resTopic } = res
+
+    if (getState().metalakes.metalakeTree.length === 0) {
+      dispatch(fetchCatalogs({ metalake }))
+    }
+
+    dispatch(
+      setExpandedNodes([
+        `{{${metalake}}}`,
+        `{{${metalake}}}{{${catalog}}}{{${'messaging'}}}`,
+        `{{${metalake}}}{{${catalog}}}{{${'messaging'}}}{{${schema}}}`
+      ])
+    )
+
+    return resTopic
+  }
+)
+
 export const appMetalakesSlice = createSlice({
   name: 'appMetalakes',
   initialState: {
@@ -703,6 +823,7 @@ export const appMetalakesSlice = createSlice({
     tables: [],
     columns: [],
     filesets: [],
+    topics: [],
     metalakeTree: [],
     loadedNodes: [],
     selectedNodes: [],
@@ -754,6 +875,7 @@ export const appMetalakesSlice = createSlice({
       state.tables = []
       state.columns = []
       state.filesets = []
+      state.topics = []
     },
     setTableLoading(state, action) {
       state.tableLoading = action.payload
@@ -787,6 +909,7 @@ export const appMetalakesSlice = createSlice({
     })
     builder.addCase(setIntoTreeNodeWithFetch.fulfilled, (state, action) => {
       const { key, data, tree } = action.payload
+
       state.metalakeTree = updateTreeData(tree, key, data)
     })
     builder.addCase(setIntoTreeNodeWithFetch.rejected, (state, action) => {
@@ -872,6 +995,22 @@ export const appMetalakesSlice = createSlice({
       state.tableData = []
     })
     builder.addCase(getFilesetDetails.rejected, (state, action) => {
+      toast.error(action.error.message)
+    })
+    builder.addCase(fetchTopics.fulfilled, (state, action) => {
+      state.topics = action.payload.topics
+      if (action.payload.init) {
+        state.tableData = action.payload.topics
+      }
+    })
+    builder.addCase(fetchTopics.rejected, (state, action) => {
+      toast.error(action.error.message)
+    })
+    builder.addCase(getTopicDetails.fulfilled, (state, action) => {
+      state.activatedDetails = action.payload
+      state.tableData = []
+    })
+    builder.addCase(getTopicDetails.rejected, (state, action) => {
       toast.error(action.error.message)
     })
   }

--- a/web/src/lib/utils/initial.js
+++ b/web/src/lib/utils/initial.js
@@ -3,12 +3,30 @@
  * This software is licensed under the Apache License version 2.
  */
 
-export const providers = [
+export const filesetProviders = [
   {
     label: 'hadoop',
     value: 'hadoop',
     defaultProps: []
-  },
+  }
+]
+
+export const messagingProviders = [
+  {
+    label: 'kafka',
+    value: 'kafka',
+    defaultProps: [
+      {
+        key: 'bootstrap.servers',
+        value: '',
+        required: true,
+        description: 'The Kafka broker(s) to connect to, allowing for multiple brokers by comma-separating them'
+      }
+    ]
+  }
+]
+
+export const providers = [
   {
     label: 'hive',
     value: 'hive',


### PR DESCRIPTION
…age for no data tree

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

1. Add web UI support for Kafka catalog
<img width="1419" alt="image" src="https://github.com/datastrato/gravitino/assets/9210625/f71beeef-94d1-4f44-9e4e-272602c03d7b">

2. Add default page for no data tree
<img width="1410" alt="image" src="https://github.com/datastrato/gravitino/assets/9210625/5804adb5-0163-4b19-829d-c89a8010e888">


### Why are the changes needed?
N/A

Fix: #2614, #2530

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Local Smoke Test and e2e test
<img width="347" alt="image" src="https://github.com/datastrato/gravitino/assets/9210625/85b5b9e3-f3c3-43da-b9fa-92d97951659c">

