### PR TITLE
[#2869] feat(server): Add the AccessControlAuthorizationFilter

### DIFF
--- a/common/src/main/java/com/datastrato/gravitino/config/ConfigEntry.java
+++ b/common/src/main/java/com/datastrato/gravitino/config/ConfigEntry.java
@@ -169,10 +169,15 @@ public class ConfigEntry<T> {
    * @return The ConfigEntry instance.
    */
   public ConfigEntry<List<T>> toSequence() {
+    if (validator != null) {
+      throw new IllegalArgumentException(
+          "You can't call the method `checkValue` before calling the method `toSequence`");
+    }
+
     ConfigEntry<List<T>> conf =
         new ConfigEntry<>(key, version, doc, alternatives, isPublic, isDeprecated);
     conf.setValueConverter((String str) -> strToSeq(str, valueConverter));
-    conf.setStringConverter((List<T> val) -> seqToStr(val, stringConverter));
+    conf.setStringConverter((List<T> val) -> val == null ? "null" : seqToStr(val, stringConverter));
     return conf;
   }
 

--- a/common/src/test/java/com/datastrato/gravitino/config/TestConfigEntryList.java
+++ b/common/src/test/java/com/datastrato/gravitino/config/TestConfigEntryList.java
@@ -39,7 +39,6 @@ public class TestConfigEntryList {
             .doc("test")
             .internal()
             .stringConf()
-            .checkValue(value -> value == null, "error")
             .toSequence()
             .checkValue(valueList -> valueList.stream().allMatch("test-string"::equals), "error")
             .createWithDefault(Lists.newArrayList("test-string", "test-string", "test-string"));
@@ -130,6 +129,14 @@ public class TestConfigEntryList {
             .checkValue(Objects::nonNull, "error")
             .create();
     Assertions.assertThrows(
-        NullPointerException.class, () -> testConfNoDefault.readFrom(configMap));
+        IllegalArgumentException.class, () -> testConfNoDefault.readFrom(configMap));
+
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new ConfigBuilder("gravitino.test")
+                .intConf()
+                .checkValue(value -> value > 0, "error")
+                .toSequence());
   }
 }

--- a/core/src/main/java/com/datastrato/gravitino/Configs.java
+++ b/core/src/main/java/com/datastrato/gravitino/Configs.java
@@ -253,7 +253,10 @@ public interface Configs {
           .doc("The admins of Gravitino service")
           .version(ConfigConstants.VERSION_0_5_0)
           .stringConf()
-          .checkValue(StringUtils::isNotBlank, ConfigConstants.NOT_BLANK_ERROR_MSG)
           .toSequence()
+          .checkValue(
+              valueList ->
+                  valueList != null && valueList.stream().allMatch(StringUtils::isNotBlank),
+              ConfigConstants.NOT_BLANK_ERROR_MSG)
           .create();
 }

--- a/server/src/main/java/com/datastrato/gravitino/server/GravitinoServer.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/GravitinoServer.java
@@ -20,6 +20,7 @@ import com.datastrato.gravitino.server.web.JettyServer;
 import com.datastrato.gravitino.server.web.JettyServerConfig;
 import com.datastrato.gravitino.server.web.ObjectMapperProvider;
 import com.datastrato.gravitino.server.web.VersioningFilter;
+import com.datastrato.gravitino.server.web.filter.AccessControlAuthorizationFilter;
 import com.datastrato.gravitino.server.web.filter.AccessControlNotAllowedFilter;
 import com.datastrato.gravitino.server.web.ui.WebUIFilter;
 import java.io.File;
@@ -95,7 +96,9 @@ public class GravitinoServer extends ResourceConfig {
         });
     register(ObjectMapperProvider.class).register(JacksonFeature.class);
 
-    if (!enableAuthorization) {
+    if (enableAuthorization) {
+      register(AccessControlAuthorizationFilter.class);
+    } else {
       register(AccessControlNotAllowedFilter.class);
     }
 

--- a/server/src/main/java/com/datastrato/gravitino/server/web/filter/AccessControlAuthorizationFilter.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/filter/AccessControlAuthorizationFilter.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.server.web.filter;
+
+import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+
+import com.datastrato.gravitino.GravitinoEnv;
+import com.datastrato.gravitino.NameIdentifier;
+import com.datastrato.gravitino.auth.AuthConstants;
+import com.datastrato.gravitino.authorization.AccessControlManager;
+import com.datastrato.gravitino.exceptions.NoSuchMetalakeException;
+import com.datastrato.gravitino.metalake.MetalakeManager;
+import com.datastrato.gravitino.server.authorization.NameBindings;
+import com.datastrato.gravitino.server.web.rest.MetalakeAdminOperations;
+import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.security.Principal;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * AccessControlAuthorizationFilter is used for filter access control requests. First, only service
+ * admins can manage metalake admins. Second, only metalake admins can manage access control of his
+ * metalake. For some SaaS services, an organization is created by one user, the user will bind to a
+ * credit card to pay for this service, and only the user can manage access control of the
+ * organization. Maybe Gravitino can support one metalake is managed by multiple admins in the
+ * future. But Gravitino prefers adopting a cautious style now. Some operations like `getUser`,
+ * `getGroup` , `getRole` aren't allowed for non-admins. Because admin should be responsible to
+ * manage access control, non-admins can't do more things though they have the privileges.
+ */
+@Provider
+@NameBindings.AccessControlInterfaces
+public class AccessControlAuthorizationFilter implements ContainerRequestFilter {
+
+  @Context private HttpServletRequest httpRequest;
+  @Context private ResourceInfo resourceInfo;
+
+  private AccessControlManager accessControlManager =
+      GravitinoEnv.getInstance().accessControlManager();
+  private MetalakeManager metalakeManager = GravitinoEnv.getInstance().metalakesManager();
+
+  @Override
+  public void filter(ContainerRequestContext requestContext) throws IOException {
+    Principal principal =
+        (Principal) httpRequest.getAttribute(AuthConstants.AUTHENTICATED_PRINCIPAL_ATTRIBUTE_NAME);
+
+    if (isManageMetalakeAminOperation()) {
+      if (!accessControlManager.isServiceAdmin(principal.getName())) {
+        requestContext.abortWith(
+            Response.status(SC_FORBIDDEN, "Only service admins can manage metalake admins")
+                .build());
+      }
+
+    } else {
+
+      if (!accessControlManager.isMetalakeAdmin(principal.getName())) {
+        requestContext.abortWith(
+            Response.status(SC_FORBIDDEN, "Only metalake admins can use access control interfaces")
+                .build());
+        return;
+      }
+
+      String metalake = requestContext.getUriInfo().getPathParameters().getFirst("metalake");
+
+      try {
+        if (!principal
+            .getName()
+            .equals(
+                metalakeManager
+                    .loadMetalake(NameIdentifier.ofMetalake(metalake))
+                    .auditInfo()
+                    .creator())) {
+          requestContext.abortWith(
+              Response.status(
+                      SC_FORBIDDEN,
+                      "Only the creator can use access control interfaces of this metalake")
+                  .build());
+        }
+      } catch (NoSuchMetalakeException nsm) {
+        // If a metalake doesn't exist, authorization filter shouldn't block it, let the operations
+        // related to access control to handle it.
+      }
+    }
+  }
+
+  private boolean isManageMetalakeAminOperation() {
+    return resourceInfo.getResourceClass() == MetalakeAdminOperations.class;
+  }
+
+  @VisibleForTesting
+  void setAccessControlManager(AccessControlManager accessControlManager) {
+    this.accessControlManager = accessControlManager;
+  }
+
+  @VisibleForTesting
+  void setMetalakeManager(MetalakeManager metalakeManager) {
+    this.metalakeManager = metalakeManager;
+  }
+
+  @VisibleForTesting
+  void setHttpRequest(HttpServletRequest httpRequest) {
+    this.httpRequest = httpRequest;
+  }
+
+  @VisibleForTesting
+  void setResourceInfo(ResourceInfo resourceInfo) {
+    this.resourceInfo = resourceInfo;
+  }
+}

--- a/server/src/main/java/com/datastrato/gravitino/server/web/filter/AccessControlNotAllowedFilter.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/filter/AccessControlNotAllowedFilter.java
@@ -28,6 +28,7 @@ public class AccessControlNotAllowedFilter implements ContainerRequestFilter {
 
   @Override
   public void filter(ContainerRequestContext requestContext) throws IOException {
+
     requestContext.abortWith(
         Response.status(
                 SC_METHOD_NOT_ALLOWED,

--- a/server/src/test/java/com/datastrato/gravitino/server/web/filter/TestAccessControlAuthorizationFilter.java
+++ b/server/src/test/java/com/datastrato/gravitino/server/web/filter/TestAccessControlAuthorizationFilter.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.server.web.filter;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.datastrato.gravitino.UserPrincipal;
+import com.datastrato.gravitino.authorization.AccessControlManager;
+import com.datastrato.gravitino.meta.AuditInfo;
+import com.datastrato.gravitino.meta.BaseMetalake;
+import com.datastrato.gravitino.metalake.MetalakeManager;
+import com.datastrato.gravitino.server.web.rest.MetalakeAdminOperations;
+import com.datastrato.gravitino.server.web.rest.UserOperations;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.time.Instant;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestAccessControlAuthorizationFilter {
+
+  private static final AccessControlManager accessControlManager = mock(AccessControlManager.class);
+  private static final MetalakeManager metalakeManager = mock(MetalakeManager.class);
+  private static final ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
+  private static final HttpServletRequest httpRequest = mock(HttpServletRequest.class);
+  private static final BaseMetalake metalake = mock(BaseMetalake.class);
+  private static final UriInfo uriInfo = mock(UriInfo.class);
+  private static final MultivaluedMap pathParameters = mock(MultivaluedMap.class);
+
+  private static Class<?> expectedClass;
+
+  // Mock method can't return a value with type Class<?>, so we use create a stub class to test.
+  private static final ResourceInfo resourceInfo =
+      new ResourceInfo() {
+        @Override
+        public Method getResourceMethod() {
+          return null;
+        }
+
+        @Override
+        public Class<?> getResourceClass() {
+          return expectedClass;
+        }
+      };
+
+  @Test
+  public void TestAccessControlAuthorizationForbidden() {
+    AccessControlAuthorizationFilter filter = new AccessControlAuthorizationFilter();
+    filter.setHttpRequest(httpRequest);
+    filter.setResourceInfo(resourceInfo);
+    filter.setMetalakeManager(metalakeManager);
+    filter.setAccessControlManager(accessControlManager);
+    filter.setResourceInfo(resourceInfo);
+
+    // Test with  forbidden service admin operation
+    expectedClass = MetalakeAdminOperations.class;
+    when(httpRequest.getAttribute(any())).thenReturn(new UserPrincipal("user"));
+    when(accessControlManager.isServiceAdmin(any())).thenReturn(false);
+    Assertions.assertDoesNotThrow(() -> filter.filter(requestContext));
+    verify(requestContext).abortWith(any());
+
+    // Test with forbidden user operations if user is not metalake admin
+    reset(requestContext);
+    expectedClass = UserOperations.class;
+    when(httpRequest.getAttribute(any())).thenReturn(new UserPrincipal("user"));
+    when(accessControlManager.isMetalakeAdmin(any())).thenReturn(false);
+    Assertions.assertDoesNotThrow(() -> filter.filter(requestContext));
+    verify(requestContext).abortWith(any());
+
+    // Test with forbidden user operations if user is not creator
+    reset(requestContext);
+    expectedClass = UserOperations.class;
+    when(httpRequest.getAttribute(any())).thenReturn(new UserPrincipal("user"));
+    when(accessControlManager.isMetalakeAdmin(any())).thenReturn(true);
+    when(metalakeManager.loadMetalake(any())).thenReturn(metalake);
+    AuditInfo auditInfo =
+        AuditInfo.builder().withCreator("user-not").withCreateTime(Instant.now()).build();
+    when(metalake.auditInfo()).thenReturn(auditInfo);
+    when(requestContext.getUriInfo()).thenReturn(uriInfo);
+    when(uriInfo.getPathParameters()).thenReturn(pathParameters);
+    when(pathParameters.getFirst(any())).thenReturn("metalake");
+
+    Assertions.assertDoesNotThrow(() -> filter.filter(requestContext));
+    verify(requestContext).abortWith(any());
+    verify(requestContext).getUriInfo();
+  }
+
+  @Test
+  public void TestAccessControlAuthorizationPassed() throws IOException {
+    AccessControlAuthorizationFilter filter = new AccessControlAuthorizationFilter();
+    filter.setHttpRequest(httpRequest);
+    filter.setResourceInfo(resourceInfo);
+    filter.setMetalakeManager(metalakeManager);
+    filter.setAccessControlManager(accessControlManager);
+    filter.setResourceInfo(resourceInfo);
+
+    // Test with service admin operations
+    expectedClass = MetalakeAdminOperations.class;
+    when(httpRequest.getAttribute(any())).thenReturn(new UserPrincipal("user"));
+    when(accessControlManager.isServiceAdmin(any())).thenReturn(true);
+
+    Assertions.assertDoesNotThrow(() -> filter.filter(requestContext));
+    verify(requestContext, never()).abortWith(any());
+
+    // Test with metalake admin operations
+    reset(requestContext);
+
+    expectedClass = UserOperations.class;
+    when(httpRequest.getAttribute(any())).thenReturn(new UserPrincipal("user"));
+    when(accessControlManager.isMetalakeAdmin(any())).thenReturn(true);
+    when(metalakeManager.loadMetalake(any())).thenReturn(metalake);
+    AuditInfo auditInfo =
+        AuditInfo.builder().withCreator("user").withCreateTime(Instant.now()).build();
+    when(metalake.auditInfo()).thenReturn(auditInfo);
+    when(requestContext.getUriInfo()).thenReturn(uriInfo);
+    when(uriInfo.getPathParameters()).thenReturn(pathParameters);
+    when(pathParameters.getFirst(any())).thenReturn("metalake");
+
+    Assertions.assertDoesNotThrow(() -> filter.filter(requestContext));
+    verify(requestContext, never()).abortWith(any());
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
For the interfaces related to the access control, I add the a filter for it.
More information, you can read the comment of `AccessControlAuthorizationFilter`.

I fix the bug of `Config` by the way. 
If we call `checkValue` before `toSequeue`. It doesn't wok.
I add more check and error message to tell users not do so. 
And I fix the error of origin logic about handling `NullExceptionPointer`

### Why are the changes needed?

Fix: #2869

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Add a new UT.
I also run the command to test it

```
curl -i -X DELETE -H "Accept: application/vnd.gravitino.v1+json" \
-H "Content-Type: application/json"  http://localhost:8090/api/admins/user1
HTTP/1.1 403 Only service admins can manage metalake admins
Content-Length: 0
Server: Jetty(9.4.51.v20230217)
```