### PR TITLE
[#2874] improvement(CI): remove SSH service from Hive container

### DIFF
--- a/catalogs/catalog-hadoop/build.gradle.kts
+++ b/catalogs/catalog-hadoop/build.gradle.kts
@@ -98,7 +98,7 @@ tasks.test {
     dependsOn(tasks.jar)
 
     doFirst {
-      environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "datastrato/gravitino-ci-hive:0.1.9")
+      environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "datastrato/gravitino-ci-hive:0.1.10")
     }
 
     val init = project.extra.get("initIntegrationTest") as (Test) -> Unit

--- a/catalogs/catalog-hive/build.gradle.kts
+++ b/catalogs/catalog-hive/build.gradle.kts
@@ -164,7 +164,7 @@ tasks.test {
     dependsOn(tasks.jar)
 
     doFirst {
-      environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "datastrato/gravitino-ci-hive:0.1.9")
+      environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "datastrato/gravitino-ci-hive:0.1.10")
     }
 
     val init = project.extra.get("initIntegrationTest") as (Test) -> Unit

--- a/catalogs/catalog-lakehouse-iceberg/build.gradle.kts
+++ b/catalogs/catalog-lakehouse-iceberg/build.gradle.kts
@@ -162,7 +162,7 @@ tasks.test {
     dependsOn(tasks.jar)
 
     doFirst {
-      environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "datastrato/gravitino-ci-hive:0.1.9")
+      environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "datastrato/gravitino-ci-hive:0.1.10")
     }
 
     val init = project.extra.get("initIntegrationTest") as (Test) -> Unit

--- a/dev/docker/hive/start.sh
+++ b/dev/docker/hive/start.sh
@@ -4,15 +4,16 @@
 # This software is licensed under the Apache License version 2.
 #
 
-# start ssh
-service ssh start
-ssh-keyscan localhost > /root/.ssh/known_hosts
-ssh-keyscan 0.0.0.0 >> /root/.ssh/known_hosts
-
 # start hdfs
-${HADOOP_HOME}/sbin/start-dfs.sh
+echo "Starting HDFS..."
+echo "Starting NameNode..."
+${HADOOP_HOME}/sbin/hadoop-daemon.sh start namenode
+
+echo "Starting DataNode..."
+${HADOOP_HOME}/sbin/hadoop-daemon.sh start datanode
 
 # start mysql and create databases/users for hive
+echo "Starting MySQL..."
 chown -R mysql:mysql /var/lib/mysql
 usermod -d /var/lib/mysql/ mysql
 service mysql start
@@ -28,6 +29,7 @@ echo """
 """ | mysql --user=root --password=${MYSQL_PWD}
 
 # start hive
+echo "Starting Hive..."
 ${HIVE_HOME}/bin/schematool -initSchema -dbType mysql
 ${HIVE_HOME}/bin/hive --service hiveserver2 > /dev/null 2>&1 &
 ${HIVE_HOME}/bin/hive --service metastore > /dev/null 2>&1 &

--- a/docs/docker-image-details.md
+++ b/docs/docker-image-details.md
@@ -82,6 +82,10 @@ You can use this kind of image to test the catalog of Apache Hive.
 
 Changelog
 
+- gravitino-ci-hive:0.1.10
+  - Remove SSH service from the startup script.
+  - Use `hadoop-daemon.sh` to start HDFS services.
+
 - gravitino-ci-hive:0.1.9
   - Remove cache after installing packages.
 

--- a/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
+++ b/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
@@ -105,7 +105,7 @@ public class ContainerSuite implements Closeable {
               TrinoContainer.builder()
                   .withEnvVars(
                       ImmutableMap.<String, String>builder()
-                          .put("HADOOP_USER_NAME", "root")
+                          .put("HADOOP_USER_NAME", "datastrato")
                           .put("GRAVITINO_HOST_IP", "host.docker.internal")
                           .put("GRAVITINO_HOST_PORT", String.valueOf(gravitinoServerPort))
                           .put("GRAVITINO_METALAKE_NAME", metalakeName)

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -153,7 +153,7 @@ tasks.test {
 
     doFirst {
       // Gravitino CI Docker image
-      environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "datastrato/gravitino-ci-hive:0.1.9")
+      environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "datastrato/gravitino-ci-hive:0.1.10")
       environment("GRAVITINO_CI_TRINO_DOCKER_IMAGE", "datastrato/gravitino-ci-trino:0.1.5")
 
       copy {

--- a/integration-test/trino-it/docker-compose.yaml
+++ b/integration-test/trino-it/docker-compose.yaml
@@ -6,7 +6,7 @@ version: '3.0'
 services:
 
   hive:
-    image: datastrato/gravitino-ci-hive:0.1.9
+    image: datastrato/gravitino-ci-hive:0.1.10
     networks:
       - trino-net
     container_name: trino-ci-hive


### PR DESCRIPTION
### What changes were proposed in this pull request?

 - Remove SSH service from the startup script.
 - Use `hadoop-daemon.sh` to start HDFS services.

### Why are the changes needed?

Fix: #2874 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

CI pass
