### PR TITLE
[#2786] improvement(jdbc-common): Make value `testOnBorrow` configurable in JDBC catalog

### DIFF
--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/config/JdbcConfig.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/config/JdbcConfig.java
@@ -70,6 +70,13 @@ public class JdbcConfig extends Config {
           .checkValue(value -> value > 0, ConfigConstants.POSITIVE_NUMBER_ERROR_MSG)
           .createWithDefault(10);
 
+  public static final ConfigEntry<Boolean> TEST_ON_BORROW =
+      new ConfigBuilder("jdbc.pool.test-on-borrow")
+          .doc("Whether to test the connection on borrow")
+          .version(ConfigConstants.VERSION_0_5_0)
+          .booleanConf()
+          .createWithDefault(true);
+
   public String getJdbcUrl() {
     return get(JDBC_URL);
   }
@@ -96,6 +103,10 @@ public class JdbcConfig extends Config {
 
   public String getJdbcDatabase() {
     return get(JDBC_DATABASE);
+  }
+
+  public boolean getTestOnBorrow() {
+    return get(TEST_ON_BORROW);
   }
 
   public JdbcConfig(Map<String, String> properties) {

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/utils/DataSourceUtils.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/utils/DataSourceUtils.java
@@ -51,7 +51,7 @@ public class DataSourceUtils {
     basicDataSource.setMinIdle(jdbcConfig.getPoolMinSize());
     // Set each time a connection is taken out from the connection pool, a test statement will be
     // executed to confirm whether the connection is valid.
-    basicDataSource.setTestOnBorrow(true);
+    basicDataSource.setTestOnBorrow(jdbcConfig.getTestOnBorrow());
     basicDataSource.setValidationQuery(POOL_TEST_QUERY);
     return basicDataSource;
   }

--- a/catalogs/catalog-jdbc-common/src/test/java/com/datastrato/gravitino/catalog/jdbc/utils/TestJdbcConfig.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/com/datastrato/gravitino/catalog/jdbc/utils/TestJdbcConfig.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+
+package com.datastrato.gravitino.catalog.jdbc.utils;
+
+import com.datastrato.gravitino.catalog.jdbc.config.JdbcConfig;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestJdbcConfig {
+
+  @Test
+  void testOnBorrow() {
+    JdbcConfig jdbcConfig = new JdbcConfig(Maps.newHashMap());
+    Assertions.assertTrue(jdbcConfig.getTestOnBorrow());
+
+    ImmutableMap immutableMap = ImmutableMap.of("jdbc.pool.test-on-borrow", "false");
+    jdbcConfig = new JdbcConfig(immutableMap);
+    Assertions.assertFalse(jdbcConfig.getTestOnBorrow());
+  }
+}

--- a/docs/jdbc-mysql-catalog.md
+++ b/docs/jdbc-mysql-catalog.md
@@ -47,6 +47,7 @@ If you use a JDBC catalog, you must provide `jdbc-url`, `jdbc-driver`, `jdbc-use
 | `jdbc-password`      | The JDBC password.                                                                                     | (none)        | Yes      | 0.3.0         |
 | `jdbc.pool.min-size` | The minimum number of connections in the pool. `2` by default.                                         | `2`           | No       | 0.3.0         |
 | `jdbc.pool.max-size` | The maximum number of connections in the pool. `10` by default.                                        | `10`          | No       | 0.3.0         |
+
 :::caution
 You must download the corresponding JDBC driver to the `catalogs/jdbc-mysql/libs` directory.
 :::

--- a/docs/jdbc-mysql-catalog.md
+++ b/docs/jdbc-mysql-catalog.md
@@ -39,15 +39,15 @@ Check the relevant data source configuration in [data source properties](https:/
 
 If you use a JDBC catalog, you must provide `jdbc-url`, `jdbc-driver`, `jdbc-user` and `jdbc-password` to catalog properties.
 
-| Configuration item      | Description                                                                                             | Default value | Required | Since Version |
-|-------------------------|---------------------------------------------------------------------------------------------------------|---------------|----------|---------------|
-| `jdbc-url`              | JDBC URL for connecting to the database. For example, `jdbc:mysql://localhost:3306`                     | (none)        | Yes      | 0.3.0         |
-| `jdbc-driver`           | The driver of the JDBC connection. For example, `com.mysql.jdbc.Driver` or `com.mysql.cj.jdbc.Driver`.  | (none)        | Yes      | 0.3.0         |
-| `jdbc-user`             | The JDBC user name.                                                                                     | (none)        | Yes      | 0.3.0         |
-| `jdbc-password`         | The JDBC password.                                                                                      | (none)        | Yes      | 0.3.0         |
-| `jdbc.pool.min-size`    | The minimum number of connections in the pool. `2` by default.                                          | `2`           | No       | 0.3.0         |
-| `jdbc.pool.max-size`    | The maximum number of connections in the pool. `10` by default.                                         | `10`          | No       | 0.3.0         |
-
+| Configuration item         | Description                                                                                            | Default value | Required | Since Version |
+|----------------------------|--------------------------------------------------------------------------------------------------------|---------------|----------|---------------|
+| `jdbc-url`                 | JDBC URL for connecting to the database. For example, `jdbc:mysql://localhost:3306`                    | (none)        | Yes      | 0.3.0         |
+| `jdbc-driver`              | The driver of the JDBC connection. For example, `com.mysql.jdbc.Driver` or `com.mysql.cj.jdbc.Driver`. | (none)        | Yes      | 0.3.0         |
+| `jdbc-user`                | The JDBC user name.                                                                                    | (none)        | Yes      | 0.3.0         |
+| `jdbc-password`            | The JDBC password.                                                                                     | (none)        | Yes      | 0.3.0         |
+| `jdbc.pool.min-size`       | The minimum number of connections in the pool. `2` by default.                                         | `2`           | No       | 0.3.0         |
+| `jdbc.pool.max-size`       | The maximum number of connections in the pool. `10` by default.                                        | `10`          | No       | 0.3.0         |
+| `jdbc.pool.test-on-borrow` | Whether to test the connection on borrow.                                                              | `true`        | No       | 0.5.0         |
 :::caution
 You must download the corresponding JDBC driver to the `catalogs/jdbc-mysql/libs` directory.
 :::

--- a/docs/jdbc-mysql-catalog.md
+++ b/docs/jdbc-mysql-catalog.md
@@ -39,15 +39,14 @@ Check the relevant data source configuration in [data source properties](https:/
 
 If you use a JDBC catalog, you must provide `jdbc-url`, `jdbc-driver`, `jdbc-user` and `jdbc-password` to catalog properties.
 
-| Configuration item         | Description                                                                                            | Default value | Required | Since Version |
-|----------------------------|--------------------------------------------------------------------------------------------------------|---------------|----------|---------------|
-| `jdbc-url`                 | JDBC URL for connecting to the database. For example, `jdbc:mysql://localhost:3306`                    | (none)        | Yes      | 0.3.0         |
-| `jdbc-driver`              | The driver of the JDBC connection. For example, `com.mysql.jdbc.Driver` or `com.mysql.cj.jdbc.Driver`. | (none)        | Yes      | 0.3.0         |
-| `jdbc-user`                | The JDBC user name.                                                                                    | (none)        | Yes      | 0.3.0         |
-| `jdbc-password`            | The JDBC password.                                                                                     | (none)        | Yes      | 0.3.0         |
-| `jdbc.pool.min-size`       | The minimum number of connections in the pool. `2` by default.                                         | `2`           | No       | 0.3.0         |
-| `jdbc.pool.max-size`       | The maximum number of connections in the pool. `10` by default.                                        | `10`          | No       | 0.3.0         |
-| `jdbc.pool.test-on-borrow` | Whether to test the connection on borrow.                                                              | `true`        | No       | 0.5.0         |
+| Configuration item   | Description                                                                                            | Default value | Required | Since Version |
+|----------------------|--------------------------------------------------------------------------------------------------------|---------------|----------|---------------|
+| `jdbc-url`           | JDBC URL for connecting to the database. For example, `jdbc:mysql://localhost:3306`                    | (none)        | Yes      | 0.3.0         |
+| `jdbc-driver`        | The driver of the JDBC connection. For example, `com.mysql.jdbc.Driver` or `com.mysql.cj.jdbc.Driver`. | (none)        | Yes      | 0.3.0         |
+| `jdbc-user`          | The JDBC user name.                                                                                    | (none)        | Yes      | 0.3.0         |
+| `jdbc-password`      | The JDBC password.                                                                                     | (none)        | Yes      | 0.3.0         |
+| `jdbc.pool.min-size` | The minimum number of connections in the pool. `2` by default.                                         | `2`           | No       | 0.3.0         |
+| `jdbc.pool.max-size` | The maximum number of connections in the pool. `10` by default.                                        | `10`          | No       | 0.3.0         |
 :::caution
 You must download the corresponding JDBC driver to the `catalogs/jdbc-mysql/libs` directory.
 :::

--- a/docs/jdbc-postgresql-catalog.md
+++ b/docs/jdbc-postgresql-catalog.md
@@ -37,15 +37,16 @@ You can check the relevant data source configuration in [data source properties]
 
 If you use JDBC catalog, you must provide `jdbc-url`, `jdbc-driver`, `jdbc-database`, `jdbc-user` and `jdbc-password` to catalog properties.
 
-| Configuration item   | Description                                                                                                                                                       | Default value | Required | Since Version |
-|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|----------|---------------|
-| `jdbc-url`           | JDBC URL for connecting to the database. You need to specify the database in the URL. For example `jdbc:postgresql://localhost:3306/pg_database?sslmode=require`. | (none)        | Yes      | 0.3.0         |
-| `jdbc-driver`        | The driver of the JDBC connection. For example `org.postgresql.Driver`.                                                                                           | (none)        | Yes      | 0.3.0         |
-| `jdbc-database`      | The database of the JDBC connection. Configure it with the same value as the database in the `jdbc-url`. For example `pg_database`.                             | (none)        | Yes      | 0.3.0         |
-| `jdbc-user`          | The JDBC user name.                                                                                                                                               | (none)        | Yes      | 0.3.0         |
-| `jdbc-password`      | The JDBC password.                                                                                                                                                | (none)        | Yes      | 0.3.0         |
-| `jdbc.pool.min-size` | The minimum number of connections in the pool. `2` by default.                                                                                                    | `2`           | No       | 0.3.0         |
-| `jdbc.pool.max-size` | The maximum number of connections in the pool. `10` by default.                                                                                                   | `10`          | No       | 0.3.0         |
+| Configuration item         | Description                                                                                                                                                        | Default value | Required | Since Version |
+|----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|----------|---------------|
+| `jdbc-url`                 | JDBC URL for connecting to the database. You need to specify the database in the URL. For example `jdbc:postgresql://localhost:3306/pg_database?sslmode=require`.  | (none)        | Yes      | 0.3.0         |
+| `jdbc-driver`              | The driver of the JDBC connection. For example `org.postgresql.Driver`.                                                                                            | (none)        | Yes      | 0.3.0         |
+| `jdbc-database`            | The database of the JDBC connection. Configure it with the same value as the database in the `jdbc-url`. For example `pg_database`.                                | (none)        | Yes      | 0.3.0         |
+| `jdbc-user`                | The JDBC user name.                                                                                                                                                | (none)        | Yes      | 0.3.0         |
+| `jdbc-password`            | The JDBC password.                                                                                                                                                 | (none)        | Yes      | 0.3.0         |
+| `jdbc.pool.min-size`       | The minimum number of connections in the pool. `2` by default.                                                                                                     | `2`           | No       | 0.3.0         |
+| `jdbc.pool.max-size`       | The maximum number of connections in the pool. `10` by default.                                                                                                    | `10`          | No       | 0.3.0         |
+| `jdbc.pool.test-on-borrow` | Whether to test the connection on borrow.                                                                                                                          | `true`        | No       | 0.5.0         |
 
 :::caution
 You must download the corresponding JDBC driver to the `catalogs/jdbc-postgresql/libs` directory.

--- a/docs/jdbc-postgresql-catalog.md
+++ b/docs/jdbc-postgresql-catalog.md
@@ -46,6 +46,7 @@ If you use JDBC catalog, you must provide `jdbc-url`, `jdbc-driver`, `jdbc-datab
 | `jdbc-password`      | The JDBC password.                                                                                                                                                 | (none)        | Yes      | 0.3.0         |
 | `jdbc.pool.min-size` | The minimum number of connections in the pool. `2` by default.                                                                                                     | `2`           | No       | 0.3.0         |
 | `jdbc.pool.max-size` | The maximum number of connections in the pool. `10` by default.                                                                                                    | `10`          | No       | 0.3.0         |
+
 :::caution
 You must download the corresponding JDBC driver to the `catalogs/jdbc-postgresql/libs` directory.
 You must explicitly specify the database in both `jdbc-url` and `jdbc-database`. An error may occur if the values in both aren't consistent.

--- a/docs/jdbc-postgresql-catalog.md
+++ b/docs/jdbc-postgresql-catalog.md
@@ -37,17 +37,15 @@ You can check the relevant data source configuration in [data source properties]
 
 If you use JDBC catalog, you must provide `jdbc-url`, `jdbc-driver`, `jdbc-database`, `jdbc-user` and `jdbc-password` to catalog properties.
 
-| Configuration item         | Description                                                                                                                                                        | Default value | Required | Since Version |
-|----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|----------|---------------|
-| `jdbc-url`                 | JDBC URL for connecting to the database. You need to specify the database in the URL. For example `jdbc:postgresql://localhost:3306/pg_database?sslmode=require`.  | (none)        | Yes      | 0.3.0         |
-| `jdbc-driver`              | The driver of the JDBC connection. For example `org.postgresql.Driver`.                                                                                            | (none)        | Yes      | 0.3.0         |
-| `jdbc-database`            | The database of the JDBC connection. Configure it with the same value as the database in the `jdbc-url`. For example `pg_database`.                                | (none)        | Yes      | 0.3.0         |
-| `jdbc-user`                | The JDBC user name.                                                                                                                                                | (none)        | Yes      | 0.3.0         |
-| `jdbc-password`            | The JDBC password.                                                                                                                                                 | (none)        | Yes      | 0.3.0         |
-| `jdbc.pool.min-size`       | The minimum number of connections in the pool. `2` by default.                                                                                                     | `2`           | No       | 0.3.0         |
-| `jdbc.pool.max-size`       | The maximum number of connections in the pool. `10` by default.                                                                                                    | `10`          | No       | 0.3.0         |
-| `jdbc.pool.test-on-borrow` | Whether to test the connection on borrow.                                                                                                                          | `true`        | No       | 0.5.0         |
-
+| Configuration item   | Description                                                                                                                                                        | Default value | Required | Since Version |
+|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|----------|---------------|
+| `jdbc-url`           | JDBC URL for connecting to the database. You need to specify the database in the URL. For example `jdbc:postgresql://localhost:3306/pg_database?sslmode=require`.  | (none)        | Yes      | 0.3.0         |
+| `jdbc-driver`        | The driver of the JDBC connection. For example `org.postgresql.Driver`.                                                                                            | (none)        | Yes      | 0.3.0         |
+| `jdbc-database`      | The database of the JDBC connection. Configure it with the same value as the database in the `jdbc-url`. For example `pg_database`.                                | (none)        | Yes      | 0.3.0         |
+| `jdbc-user`          | The JDBC user name.                                                                                                                                                | (none)        | Yes      | 0.3.0         |
+| `jdbc-password`      | The JDBC password.                                                                                                                                                 | (none)        | Yes      | 0.3.0         |
+| `jdbc.pool.min-size` | The minimum number of connections in the pool. `2` by default.                                                                                                     | `2`           | No       | 0.3.0         |
+| `jdbc.pool.max-size` | The maximum number of connections in the pool. `10` by default.                                                                                                    | `10`          | No       | 0.3.0         |
 :::caution
 You must download the corresponding JDBC driver to the `catalogs/jdbc-postgresql/libs` directory.
 You must explicitly specify the database in both `jdbc-url` and `jdbc-database`. An error may occur if the values in both aren't consistent.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make the value `testOnBorrow` in JDBC catalogs can be tuned by users.

### Why are the changes needed?

When we do performance test for the JDBC catalog, we'd better set `testOnBorrow` to false as testing connection is time-consuming 

Fix: #2786 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Add unit test. 