### PR TITLE
[#2872] feat(server): Add MetalakeAuthorizationFilter

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/authorization/AccessControlManager.java
+++ b/core/src/main/java/com/datastrato/gravitino/authorization/AccessControlManager.java
@@ -72,6 +72,17 @@ public class AccessControlManager {
   }
 
   /**
+   * Judges whether the user is in the metalake.
+   *
+   * @param user The name of the User
+   * @param metalake The name of the Metalake
+   * @return true, if the user is in the metalake, otherwise false.
+   */
+  public boolean isUserInMetalake(String user, String metalake) {
+    return doWithNonAdminLock(() -> userGroupManager.isUserInMetalake(user, metalake));
+  }
+
+  /**
    * Adds a new Group.
    *
    * @param metalake The Metalake of the Group.

--- a/core/src/main/java/com/datastrato/gravitino/authorization/UserGroupManager.java
+++ b/core/src/main/java/com/datastrato/gravitino/authorization/UserGroupManager.java
@@ -212,6 +212,22 @@ public class UserGroupManager {
     }
   }
 
+  /**
+   * Judges whether the user is in the metalake.
+   *
+   * @param user The name of the User
+   * @param metalake The name of the Metalake
+   * @return true, if the user is in the metalake, otherwise false.
+   */
+  public boolean isUserInMetalake(String user, String metalake) {
+    try {
+      return store.exists(ofUser(metalake, user), Entity.EntityType.USER);
+    } catch (IOException ioe) {
+      LOG.error("Checking user {} failed due to storage issues", user, ioe);
+      throw new RuntimeException(ioe);
+    }
+  }
+
   private NameIdentifier ofUser(String metalake, String user) {
     return NameIdentifier.of(
         metalake, Entity.SYSTEM_CATALOG_RESERVED_NAME, Entity.USER_SCHEMA_NAME, user);

--- a/server-common/src/main/java/com/datastrato/gravitino/server/authorization/NameBindings.java
+++ b/server-common/src/main/java/com/datastrato/gravitino/server/authorization/NameBindings.java
@@ -16,4 +16,9 @@ public class NameBindings {
   @Target({ElementType.TYPE, ElementType.METHOD})
   @Retention(RetentionPolicy.RUNTIME)
   public @interface AccessControlInterfaces {}
+
+  @NameBinding
+  @Target({ElementType.TYPE, ElementType.METHOD})
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface MetalakeInterfaces {}
 }

--- a/server/src/main/java/com/datastrato/gravitino/server/GravitinoServer.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/GravitinoServer.java
@@ -21,6 +21,7 @@ import com.datastrato.gravitino.server.web.JettyServerConfig;
 import com.datastrato.gravitino.server.web.ObjectMapperProvider;
 import com.datastrato.gravitino.server.web.VersioningFilter;
 import com.datastrato.gravitino.server.web.filter.AccessControlNotAllowedFilter;
+import com.datastrato.gravitino.server.web.filter.MetalakeAuthorizationFilter;
 import com.datastrato.gravitino.server.web.ui.WebUIFilter;
 import java.io.File;
 import java.util.Properties;
@@ -95,7 +96,9 @@ public class GravitinoServer extends ResourceConfig {
         });
     register(ObjectMapperProvider.class).register(JacksonFeature.class);
 
-    if (!enableAuthorization) {
+    if (enableAuthorization) {
+      register(MetalakeAuthorizationFilter.class);
+    } else {
       register(AccessControlNotAllowedFilter.class);
     }
 

--- a/server/src/main/java/com/datastrato/gravitino/server/web/filter/MetalakeAuthorizationFilter.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/filter/MetalakeAuthorizationFilter.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.server.web.filter;
+
+import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+
+import com.datastrato.gravitino.GravitinoEnv;
+import com.datastrato.gravitino.NameIdentifier;
+import com.datastrato.gravitino.auth.AuthConstants;
+import com.datastrato.gravitino.authorization.AccessControlManager;
+import com.datastrato.gravitino.exceptions.NoSuchMetalakeException;
+import com.datastrato.gravitino.metalake.MetalakeManager;
+import com.datastrato.gravitino.server.authorization.NameBindings;
+import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.security.Principal;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * MetalakeAuthorizationFilter is responsible to manage the privileges of the metalake. First, only
+ * metalake admins can create the metalake or list metalakes. Second, only metalake admins can alter
+ * or drop the metalake which he created. Third, all the users of the metalake can load the
+ * metalake.
+ */
+@Provider
+@NameBindings.MetalakeInterfaces
+public class MetalakeAuthorizationFilter implements ContainerRequestFilter {
+
+  @Context private HttpServletRequest httpRequest;
+
+  private AccessControlManager accessControlManager =
+      GravitinoEnv.getInstance().accessControlManager();
+  private MetalakeManager metalakeManager = GravitinoEnv.getInstance().metalakesManager();
+
+  @Override
+  public void filter(ContainerRequestContext requestContext) throws IOException {
+    Principal principal =
+        (Principal) httpRequest.getAttribute(AuthConstants.AUTHENTICATED_PRINCIPAL_ATTRIBUTE_NAME);
+
+    String method = requestContext.getMethod();
+    if (HttpMethod.POST.equalsIgnoreCase(method)) {
+      if (!accessControlManager.isMetalakeAdmin(principal.getName())) {
+        requestContext.abortWith(
+            Response.status(SC_FORBIDDEN, "Only metalake admins can create metalake").build());
+      }
+    } else {
+      try {
+        String metalake = requestContext.getUriInfo().getPathParameters().getFirst("metalake");
+
+        if (HttpMethod.GET.equalsIgnoreCase(method)) {
+          // For list metalakes operation
+          if (metalake == null) {
+            if (!accessControlManager.isMetalakeAdmin(principal.getName())) {
+              requestContext.abortWith(
+                  Response.status(SC_FORBIDDEN, "Only metalake admins can list metalakes").build());
+            }
+          } else {
+            // For load a metalake operation
+            String creator =
+                metalakeManager
+                    .loadMetalake(NameIdentifier.ofMetalake(metalake))
+                    .auditInfo()
+                    .creator();
+            if (!principal.getName().equals(creator)
+                && !accessControlManager.isUserInMetalake(principal.getName(), metalake)) {
+              requestContext.abortWith(
+                  Response.status(
+                          SC_FORBIDDEN, "Only the users in the metalake can load the metalake")
+                      .build());
+            }
+          }
+        } else {
+          String creator =
+              metalakeManager
+                  .loadMetalake(NameIdentifier.ofMetalake(metalake))
+                  .auditInfo()
+                  .creator();
+
+          if (!principal.getName().equals(creator)) {
+            String operation = HttpMethod.PUT.equalsIgnoreCase(method) ? "alter" : "delete";
+            requestContext.abortWith(
+                Response.status(SC_FORBIDDEN, "Only the creator can " + operation + " the metalake")
+                    .build());
+          }
+        }
+
+      } catch (NoSuchMetalakeException nsm) {
+        // If a metalake doesn't exist, authorization filter shouldn't block it, let the operations
+        // related to access control to handle it.
+      }
+    }
+  }
+
+  @VisibleForTesting
+  void setAccessControlManager(AccessControlManager accessControlManager) {
+    this.accessControlManager = accessControlManager;
+  }
+
+  @VisibleForTesting
+  void setMetalakeManager(MetalakeManager metalakeManager) {
+    this.metalakeManager = metalakeManager;
+  }
+
+  @VisibleForTesting
+  void setHttpRequest(HttpServletRequest httpRequest) {
+    this.httpRequest = httpRequest;
+  }
+}

--- a/server/src/main/java/com/datastrato/gravitino/server/web/rest/MetalakeOperations.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/rest/MetalakeOperations.java
@@ -22,6 +22,7 @@ import com.datastrato.gravitino.lock.TreeLockUtils;
 import com.datastrato.gravitino.meta.BaseMetalake;
 import com.datastrato.gravitino.metalake.MetalakeManager;
 import com.datastrato.gravitino.metrics.MetricNames;
+import com.datastrato.gravitino.server.authorization.NameBindings;
 import com.datastrato.gravitino.server.web.Utils;
 import java.util.Arrays;
 import javax.inject.Inject;
@@ -40,6 +41,7 @@ import javax.ws.rs.core.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@NameBindings.MetalakeInterfaces
 @Path("/metalakes")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)

--- a/server/src/test/java/com/datastrato/gravitino/server/web/filter/TestMetalakeAuthorizationFilter.java
+++ b/server/src/test/java/com/datastrato/gravitino/server/web/filter/TestMetalakeAuthorizationFilter.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.server.web.filter;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.datastrato.gravitino.UserPrincipal;
+import com.datastrato.gravitino.authorization.AccessControlManager;
+import com.datastrato.gravitino.meta.AuditInfo;
+import com.datastrato.gravitino.meta.BaseMetalake;
+import com.datastrato.gravitino.metalake.MetalakeManager;
+import java.time.Instant;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class TestMetalakeAuthorizationFilter {
+
+  private static final AccessControlManager accessControlManager =
+      Mockito.mock(AccessControlManager.class);
+  private static final MetalakeManager metalakeManager = Mockito.mock(MetalakeManager.class);
+  private static final ContainerRequestContext requestContext =
+      Mockito.mock(ContainerRequestContext.class);
+  private static final HttpServletRequest httpRequest = Mockito.mock(HttpServletRequest.class);
+  private static final BaseMetalake metalake = Mockito.mock(BaseMetalake.class);
+  private static final UriInfo uriInfo = Mockito.mock(UriInfo.class);
+  private static final MultivaluedMap pathParameters = Mockito.mock(MultivaluedMap.class);
+
+  @Test
+  public void testMetalakeAuthorizationForbidden() {
+    MetalakeAuthorizationFilter filter = new MetalakeAuthorizationFilter();
+    filter.setHttpRequest(httpRequest);
+    filter.setMetalakeManager(metalakeManager);
+    filter.setAccessControlManager(accessControlManager);
+
+    // Test with user who isn't in the metalake to load the metalake
+    reset(requestContext);
+    when(httpRequest.getAttribute(any())).thenReturn(new UserPrincipal("user"));
+    when(accessControlManager.isServiceAdmin(any())).thenReturn(false);
+    when(metalakeManager.loadMetalake(any())).thenReturn(metalake);
+    when(requestContext.getMethod()).thenReturn(HttpMethod.GET);
+    when(requestContext.getUriInfo()).thenReturn(uriInfo);
+    when(uriInfo.getPathParameters()).thenReturn(pathParameters);
+    when(pathParameters.getFirst(any())).thenReturn("metalake");
+    AuditInfo auditInfo =
+        AuditInfo.builder().withCreator("user1").withCreateTime(Instant.now()).build();
+    when(metalake.auditInfo()).thenReturn(auditInfo);
+
+    assertDoesNotThrow(() -> filter.filter(requestContext));
+    verify(requestContext).abortWith(any());
+
+    // Test with user to list metalakes
+    reset(requestContext);
+    when(requestContext.getMethod()).thenReturn(HttpMethod.GET);
+    when(requestContext.getUriInfo()).thenReturn(uriInfo);
+    when(pathParameters.getFirst(any())).thenReturn(null);
+    Mockito.when(accessControlManager.isServiceAdmin(any())).thenReturn(false);
+
+    assertDoesNotThrow(() -> filter.filter(requestContext));
+    verify(requestContext).abortWith(any());
+
+    // Test with non-admin to create the metalake
+    reset(requestContext);
+    when(requestContext.getMethod()).thenReturn(HttpMethod.POST);
+    when(requestContext.getUriInfo()).thenReturn(uriInfo);
+    when(httpRequest.getAttribute(any())).thenReturn(new UserPrincipal("user"));
+    when(accessControlManager.isServiceAdmin(any())).thenReturn(false);
+
+    assertDoesNotThrow(() -> filter.filter(requestContext));
+    verify(requestContext).abortWith(any());
+
+    // Test with non-creator to alter/delete the metalake
+    reset(requestContext);
+    when(pathParameters.getFirst(any())).thenReturn("metalake");
+    when(requestContext.getMethod()).thenReturn(HttpMethod.PUT);
+    when(requestContext.getUriInfo()).thenReturn(uriInfo);
+
+    assertDoesNotThrow(() -> filter.filter(requestContext));
+    verify(requestContext).abortWith(any());
+
+    reset(requestContext);
+    when(requestContext.getMethod()).thenReturn(HttpMethod.DELETE);
+    when(requestContext.getUriInfo()).thenReturn(uriInfo);
+
+    assertDoesNotThrow(() -> filter.filter(requestContext));
+    verify(requestContext).abortWith(any());
+  }
+
+  @Test
+  public void testMetalakeAuthorizationPassed() {
+    MetalakeAuthorizationFilter filter = new MetalakeAuthorizationFilter();
+    filter.setHttpRequest(httpRequest);
+    filter.setMetalakeManager(metalakeManager);
+    filter.setAccessControlManager(accessControlManager);
+
+    // Test to create a metalake
+    reset(requestContext);
+    when(requestContext.getMethod()).thenReturn(HttpMethod.POST);
+    when(requestContext.getUriInfo()).thenReturn(uriInfo);
+    when(httpRequest.getAttribute(any())).thenReturn(new UserPrincipal("user"));
+    when(accessControlManager.isMetalakeAdmin(any())).thenReturn(true);
+
+    assertDoesNotThrow(() -> filter.filter(requestContext));
+
+    verify(requestContext, never()).abortWith(any());
+
+    // Test to list metalakes
+    reset(requestContext);
+    when(requestContext.getMethod()).thenReturn(HttpMethod.GET);
+    when(requestContext.getUriInfo()).thenReturn(uriInfo);
+    when(uriInfo.getPathParameters()).thenReturn(pathParameters);
+    when(pathParameters.getFirst(any())).thenReturn(null);
+
+    assertDoesNotThrow(() -> filter.filter(requestContext));
+
+    verify(requestContext, never()).abortWith(any());
+
+    // Test to alter a metalake
+    reset(requestContext);
+    when(requestContext.getMethod()).thenReturn(HttpMethod.PUT);
+    when(requestContext.getUriInfo()).thenReturn(uriInfo);
+    when(pathParameters.getFirst(any())).thenReturn("metalake");
+    when(metalakeManager.loadMetalake(any())).thenReturn(metalake);
+
+    AuditInfo auditInfo =
+        AuditInfo.builder().withCreator("user").withCreateTime(Instant.now()).build();
+    when(metalake.auditInfo()).thenReturn(auditInfo);
+
+    assertDoesNotThrow(() -> filter.filter(requestContext));
+
+    verify(requestContext, never()).abortWith(any());
+
+    // Test to drop a metalake
+    reset(requestContext);
+    when(requestContext.getMethod()).thenReturn(HttpMethod.DELETE);
+    when(requestContext.getUriInfo()).thenReturn(uriInfo);
+
+    assertDoesNotThrow(() -> filter.filter(requestContext));
+    verify(requestContext, never()).abortWith(any());
+
+    // Test to load a metalake
+    reset(requestContext);
+    when(requestContext.getMethod()).thenReturn(HttpMethod.GET);
+    when(requestContext.getUriInfo()).thenReturn(uriInfo);
+    assertDoesNotThrow(() -> filter.filter(requestContext));
+    verify(requestContext, never()).abortWith(any());
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add MetalakeAuthorizationFilter to filter the MetalakeOperations

### Why are the changes needed?

Fix: #2872 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
New ut + manual test
server conf
```
gravitino.authorization.enable = true
gravitino.authorization.servceAdmins = anonymous
```
test commands and results
```
curl -i -X GET -H "Accept: application/vnd.gravitino.v1+json" \
-H "Content-Type: application/json"  http://localhost:8090/api/metalakes/
HTTP/1.1 403 Only metalake admins can list metalakes

curl -X POST -H "Accept: application/vnd.gravitino.v1+json" \
-H "Content-Type: application/json" -d '{"name":"anonymous"}' \

http://localhost:8090/api/admins   
{"code":0,"user":{"name":"anonymous","audit":{"creator":"anonymous","createTime":"2024-04-11T09:12:48.419Z"},"roles":[]}

curl -i -X GET -H "Accept: application/vnd.gravitino.v1+json" \
-H "Content-Type: application/json"  http://localhost:8090/api/metalakes/
HTTP/1.1 200 OK
Date: Thu, 11 Apr 2024 09:13:11 GMT
Content-Type: application/json
Content-Length: 25
Server: Jetty(9.4.51.v20230217)

{"code":0,"metalakes":[]}
```
