### PR TITLE
[#2888] fix(core): Fix the possible concurrency for `KvGarbageCollector`

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/storage/kv/KvGarbageCollector.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/kv/KvGarbageCollector.java
@@ -107,7 +107,7 @@ public final class KvGarbageCollector implements Closeable {
                       // It may have concurrency issues with TransactionalKvBackendImpl#commit.
                       long writeTime = getTransactionId(transactionId) >> 18;
                       if (writeTime
-                          < (System.currentTimeMillis() - frequencyInMinutes * 60 * 1000)) {
+                          < (System.currentTimeMillis() - frequencyInMinutes * 60 * 1000 * 2)) {
                         return false;
                       }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a check mechanism in `KvGarbageCollector` to avoid removing uncommitted data wrote into kv storage a few seconds or minutes ago. 

### Why are the changes needed?

There is a potential that  `KvGarbageCollector` will take normal data as uncommitted data and remove it. For more please see #2888 

Fix: #2888 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

N/A.
