### PR TITLE
[#2883] refactor(ITUtils): move assertion functions from AbstractIT for clarity

### DIFF
--- a/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
@@ -351,7 +351,7 @@ public class CatalogMysqlIT extends AbstractIT {
     Assertions.assertEquals(createdTable.columns().length, columns.length);
 
     for (int i = 0; i < columns.length; i++) {
-      assertColumn(columns[i], createdTable.columns()[i]);
+      ITUtils.assertColumn(columns[i], createdTable.columns()[i]);
     }
 
     Table loadTable = tableCatalog.loadTable(tableIdentifier);
@@ -364,7 +364,7 @@ public class CatalogMysqlIT extends AbstractIT {
     }
     Assertions.assertEquals(loadTable.columns().length, columns.length);
     for (int i = 0; i < columns.length; i++) {
-      assertColumn(columns[i], loadTable.columns()[i]);
+      ITUtils.assertColumn(columns[i], loadTable.columns()[i]);
     }
   }
 
@@ -821,10 +821,10 @@ public class CatalogMysqlIT extends AbstractIT {
             Distributions.NONE,
             new SortOrder[0],
             indexes);
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         tableName, table_comment, Arrays.asList(newColumns), properties, indexes, createdTable);
     Table table = tableCatalog.loadTable(tableIdentifier);
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         tableName, table_comment, Arrays.asList(newColumns), properties, indexes, table);
 
     NameIdentifier id = NameIdentifier.of(metalakeName, catalogName, schemaName, "test_failed");
@@ -922,10 +922,10 @@ public class CatalogMysqlIT extends AbstractIT {
             new SortOrder[0],
             indexes);
     // Test create auto increment key success.
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         tableName, table_comment, Arrays.asList(newColumns), properties, indexes, createdTable);
     Table table = tableCatalog.loadTable(tableIdentifier);
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         tableName, table_comment, Arrays.asList(newColumns), properties, indexes, table);
 
     // Test alter table. auto increment exist.
@@ -942,7 +942,7 @@ public class CatalogMysqlIT extends AbstractIT {
           col4,
           col5
         };
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         tableName, table_comment, Arrays.asList(alterColumns), properties, indexes, table);
 
     // UpdateColumnComment
@@ -957,7 +957,7 @@ public class CatalogMysqlIT extends AbstractIT {
           col4,
           col5
         };
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         tableName, table_comment, Arrays.asList(alterColumns), properties, indexes, table);
 
     // RenameColumn
@@ -977,7 +977,7 @@ public class CatalogMysqlIT extends AbstractIT {
           Indexes.createMysqlPrimaryKey(new String[][] {{"col_1_1"}, {"col_2"}}),
           Indexes.unique("u1_key", new String[][] {{"col_2"}, {"col_3"}})
         };
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         tableName, table_comment, Arrays.asList(alterColumns), properties, indexes, table);
 
     tableCatalog.dropTable(tableIdentifier);
@@ -1158,22 +1158,26 @@ public class CatalogMysqlIT extends AbstractIT {
     Table t1 =
         tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, t1_name));
     Arrays.stream(t1.columns()).anyMatch(c -> Objects.equals(c.name(), "t112"));
-    assertionsTableInfo(t1_name, table_comment, Arrays.asList(t1_col), properties, t1_indexes, t1);
+    ITUtils.assertionsTableInfo(
+        t1_name, table_comment, Arrays.asList(t1_col), properties, t1_indexes, t1);
 
     Table t2 =
         tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, t2_name));
     Arrays.stream(t2.columns()).anyMatch(c -> Objects.equals(c.name(), "t212"));
-    assertionsTableInfo(t2_name, table_comment, Arrays.asList(t2_col), properties, t2_indexes, t2);
+    ITUtils.assertionsTableInfo(
+        t2_name, table_comment, Arrays.asList(t2_col), properties, t2_indexes, t2);
 
     Table t3 =
         tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, t3_name));
     Arrays.stream(t3.columns()).anyMatch(c -> Objects.equals(c.name(), "t_12"));
-    assertionsTableInfo(t3_name, table_comment, Arrays.asList(t3_col), properties, t3_indexes, t3);
+    ITUtils.assertionsTableInfo(
+        t3_name, table_comment, Arrays.asList(t3_col), properties, t3_indexes, t3);
 
     Table t4 =
         tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, t4_name));
     Arrays.stream(t4.columns()).anyMatch(c -> Objects.equals(c.name(), "_1__"));
-    assertionsTableInfo(t4_name, table_comment, Arrays.asList(t4_col), properties, t4_indexes, t4);
+    ITUtils.assertionsTableInfo(
+        t4_name, table_comment, Arrays.asList(t4_col), properties, t4_indexes, t4);
   }
 
   @Test
@@ -1205,10 +1209,10 @@ public class CatalogMysqlIT extends AbstractIT {
             Distributions.NONE,
             new SortOrder[0],
             indexes);
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         "tableName", table_comment, Arrays.asList(newColumns), properties, indexes, createdTable);
     Table table = tableCatalog.loadTable(tableIdentifier);
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         "tableName", table_comment, Arrays.asList(newColumns), properties, indexes, table);
 
     // Test create table with same name but different case
@@ -1230,7 +1234,7 @@ public class CatalogMysqlIT extends AbstractIT {
     Assertions.assertEquals("TABLENAME", tableAgain.name());
 
     table = tableCatalog.loadTable(tableIdentifier2);
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         "TABLENAME", table_comment, Arrays.asList(newColumns), properties, indexes, table);
   }
 
@@ -1345,7 +1349,7 @@ public class CatalogMysqlIT extends AbstractIT {
           Indexes.unique("u1_key", new String[][] {{"col_2"}, {"col_3"}}),
           Indexes.createMysqlPrimaryKey(new String[][] {{"col_1"}})
         };
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         tableName, table_comment, Arrays.asList(newColumns), createProperties(), indexes, table);
 
     // delete index and add new column and index.
@@ -1367,7 +1371,7 @@ public class CatalogMysqlIT extends AbstractIT {
         tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, tableName));
     Column col4 = Column.of("col_4", Types.VarCharType.of(255), null, true, false, null);
     newColumns = new Column[] {col1, col2, col3, col4};
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         tableName, table_comment, Arrays.asList(newColumns), createProperties(), indexes, table);
 
     // Add a previously existing index
@@ -1387,7 +1391,7 @@ public class CatalogMysqlIT extends AbstractIT {
         };
     table =
         tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, tableName));
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         tableName, table_comment, Arrays.asList(newColumns), createProperties(), indexes, table);
   }
 
@@ -1454,7 +1458,7 @@ public class CatalogMysqlIT extends AbstractIT {
     Column col6 = Column.of("col_6", Types.LongType.get(), "id", false, true, null);
     Index[] indices = new Index[] {Indexes.createMysqlPrimaryKey(new String[][] {{"col_6"}})};
     newColumns = new Column[] {col1, col2, col3, col4, col5, col6};
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         tableName, table_comment, Arrays.asList(newColumns), properties, indices, table);
 
     // Test the auto-increment property of modified fields
@@ -1464,7 +1468,7 @@ public class CatalogMysqlIT extends AbstractIT {
     col6 = Column.of("col_6", Types.LongType.get(), "id", false, false, null);
     indices = new Index[] {Indexes.createMysqlPrimaryKey(new String[][] {{"col_6"}})};
     newColumns = new Column[] {col1, col2, col3, col4, col5, col6};
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         tableName, table_comment, Arrays.asList(newColumns), properties, indices, table);
 
     // Add the auto-increment attribute to the field
@@ -1474,7 +1478,7 @@ public class CatalogMysqlIT extends AbstractIT {
     col6 = Column.of("col_6", Types.LongType.get(), "id", false, true, null);
     indices = new Index[] {Indexes.createMysqlPrimaryKey(new String[][] {{"col_6"}})};
     newColumns = new Column[] {col1, col2, col3, col4, col5, col6};
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         tableName, table_comment, Arrays.asList(newColumns), properties, indices, table);
   }
 
@@ -1516,7 +1520,7 @@ public class CatalogMysqlIT extends AbstractIT {
     Table table = tableCatalog.loadTable(tableIdentifier);
     newColumns = new Column[] {col1, col2, col3, col4};
 
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         tableName,
         table_comment,
         Arrays.asList(newColumns),

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
@@ -255,14 +255,14 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     Assertions.assertEquals(tableName, createdTable.name());
     Assertions.assertEquals(columns.length, createdTable.columns().length);
     for (int i = 0; i < columns.length; i++) {
-      assertColumn(columns[i], createdTable.columns()[i]);
+      ITUtils.assertColumn(columns[i], createdTable.columns()[i]);
     }
 
     Table loadTable = tableCatalog.loadTable(tableIdentifier);
     Assertions.assertEquals(tableName, loadTable.name());
     Assertions.assertEquals(columns.length, loadTable.columns().length);
     for (int i = 0; i < columns.length; i++) {
-      assertColumn(columns[i], loadTable.columns()[i]);
+      ITUtils.assertColumn(columns[i], loadTable.columns()[i]);
     }
   }
 
@@ -406,7 +406,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     Assertions.assertEquals(createdTable.columns().length, columns.length);
 
     for (int i = 0; i < columns.length; i++) {
-      assertColumn(columns[i], createdTable.columns()[i]);
+      ITUtils.assertColumn(columns[i], createdTable.columns()[i]);
     }
 
     Table loadTable = tableCatalog.loadTable(tableIdentifier);
@@ -419,7 +419,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     }
     Assertions.assertEquals(loadTable.columns().length, columns.length);
     for (int i = 0; i < columns.length; i++) {
-      assertColumn(columns[i], loadTable.columns()[i]);
+      ITUtils.assertColumn(columns[i], loadTable.columns()[i]);
     }
   }
 
@@ -647,10 +647,10 @@ public class CatalogPostgreSqlIT extends AbstractIT {
             Distributions.NONE,
             new SortOrder[0],
             indexes);
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         tableName, table_comment, Arrays.asList(newColumns), properties, indexes, createdTable);
     Table table = tableCatalog.loadTable(tableIdentifier);
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         tableName, table_comment, Arrays.asList(newColumns), properties, indexes, table);
 
     // Test create index complex fields fail.
@@ -1019,22 +1019,26 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     Table t1 =
         tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, t1_name));
     Arrays.stream(t1.columns()).anyMatch(c -> Objects.equals(c.name(), "t112"));
-    assertionsTableInfo(t1_name, table_comment, Arrays.asList(t1_col), properties, t1_indexes, t1);
+    ITUtils.assertionsTableInfo(
+        t1_name, table_comment, Arrays.asList(t1_col), properties, t1_indexes, t1);
 
     Table t2 =
         tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, t2_name));
     Arrays.stream(t2.columns()).anyMatch(c -> Objects.equals(c.name(), "t212"));
-    assertionsTableInfo(t2_name, table_comment, Arrays.asList(t2_col), properties, t2_indexes, t2);
+    ITUtils.assertionsTableInfo(
+        t2_name, table_comment, Arrays.asList(t2_col), properties, t2_indexes, t2);
 
     Table t3 =
         tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, t3_name));
     Arrays.stream(t3.columns()).anyMatch(c -> Objects.equals(c.name(), "t_12"));
-    assertionsTableInfo(t3_name, table_comment, Arrays.asList(t3_col), properties, t3_indexes, t3);
+    ITUtils.assertionsTableInfo(
+        t3_name, table_comment, Arrays.asList(t3_col), properties, t3_indexes, t3);
 
     Table t4 =
         tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, t4_name));
     Arrays.stream(t4.columns()).anyMatch(c -> Objects.equals(c.name(), "_1__"));
-    assertionsTableInfo(t4_name, table_comment, Arrays.asList(t4_col), properties, t4_indexes, t4);
+    ITUtils.assertionsTableInfo(
+        t4_name, table_comment, Arrays.asList(t4_col), properties, t4_indexes, t4);
   }
 
   @Test
@@ -1061,7 +1065,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
             Distributions.NONE,
             new SortOrder[0],
             indexes);
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         "tablename",
         "low case table name",
         Arrays.asList(newColumns),
@@ -1069,7 +1073,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
         indexes,
         createdTable);
     Table table = tableCatalog.loadTable(tableIdentifier);
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         "tablename", "low case table name", Arrays.asList(newColumns), properties, indexes, table);
 
     // Test create table with same name but different case
@@ -1260,7 +1264,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
           Indexes.unique("u1_key", new String[][] {{"col_2"}, {"col_3"}}),
           Indexes.primary("pk1_key", new String[][] {{"col_1"}})
         };
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         tableName, table_comment, Arrays.asList(newColumns), createProperties(), indexes, table);
 
     // delete index and add new column and index.
@@ -1282,7 +1286,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
         tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, tableName));
     Column col4 = Column.of("col_4", Types.VarCharType.of(255), null, true, false, null);
     newColumns = new Column[] {col1, col2, col3, col4};
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         tableName, table_comment, Arrays.asList(newColumns), createProperties(), indexes, table);
 
     // Add a previously existing index
@@ -1302,7 +1306,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
         };
     table =
         tableCatalog.loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, tableName));
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         tableName, table_comment, Arrays.asList(newColumns), createProperties(), indexes, table);
   }
 
@@ -1342,7 +1346,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
 
     Column col5 = Column.of("col_5", Types.LongType.get(), "id", false, true, null);
     newColumns = new Column[] {col1, col2, col3, col4, col5};
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         tableName,
         table_comment,
         Arrays.asList(newColumns),
@@ -1356,7 +1360,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     table = tableCatalog.loadTable(tableIdentifier);
     col5 = Column.of("col_5", Types.LongType.get(), "id", false, false, null);
     newColumns = new Column[] {col1, col2, col3, col4, col5};
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         tableName,
         table_comment,
         Arrays.asList(newColumns),
@@ -1370,7 +1374,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     table = tableCatalog.loadTable(tableIdentifier);
     col5 = Column.of("col_5", Types.LongType.get(), "id", false, true, null);
     newColumns = new Column[] {col1, col2, col3, col4, col5};
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         tableName,
         table_comment,
         Arrays.asList(newColumns),
@@ -1418,7 +1422,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     Table table = tableCatalog.loadTable(tableIdentifier);
 
     newColumns = new Column[] {col1, col2, col3};
-    assertionsTableInfo(
+    ITUtils.assertionsTableInfo(
         tableName,
         table_comment,
         Arrays.asList(newColumns),

--- a/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/util/ITUtils.java
+++ b/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/util/ITUtils.java
@@ -4,6 +4,13 @@
  */
 package com.datastrato.gravitino.integration.test.util;
 
+import static com.datastrato.gravitino.dto.util.DTOConverters.toDTO;
+
+import com.datastrato.gravitino.dto.rel.ColumnDTO;
+import com.datastrato.gravitino.dto.rel.expressions.LiteralDTO;
+import com.datastrato.gravitino.rel.Column;
+import com.datastrato.gravitino.rel.Table;
+import com.datastrato.gravitino.rel.indexes.Index;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -11,8 +18,13 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.jupiter.api.Assertions;
 
 public class ITUtils {
   public static final String TEST_MODE = "testMode";
@@ -50,6 +62,63 @@ public class ITUtils {
         // Use customized write functions to avoid escaping `:` into `\:`.
         outputStream.write((key + " = " + value + "\n").getBytes(StandardCharsets.UTF_8));
       }
+    }
+  }
+
+  public static void assertionsTableInfo(
+      String tableName,
+      String tableComment,
+      List<Column> columns,
+      Map<String, String> properties,
+      Index[] indexes,
+      Table table) {
+    Assertions.assertEquals(tableName, table.name());
+    Assertions.assertEquals(tableComment, table.comment());
+    Assertions.assertEquals(columns.size(), table.columns().length);
+    for (int i = 0; i < columns.size(); i++) {
+      assertColumn(columns.get(i), table.columns()[i]);
+    }
+    for (Map.Entry<String, String> entry : properties.entrySet()) {
+      Assertions.assertEquals(entry.getValue(), table.properties().get(entry.getKey()));
+    }
+    if (ArrayUtils.isNotEmpty(indexes)) {
+      Assertions.assertEquals(indexes.length, table.index().length);
+
+      Map<String, Index> indexByName =
+          Arrays.stream(indexes).collect(Collectors.toMap(Index::name, index -> index));
+
+      for (int i = 0; i < table.index().length; i++) {
+        Assertions.assertTrue(indexByName.containsKey(table.index()[i].name()));
+        Assertions.assertEquals(
+            indexByName.get(table.index()[i].name()).type(), table.index()[i].type());
+        for (int j = 0; j < table.index()[i].fieldNames().length; j++) {
+          for (int k = 0; k < table.index()[i].fieldNames()[j].length; k++) {
+            Assertions.assertEquals(
+                indexByName.get(table.index()[i].name()).fieldNames()[j][k],
+                table.index()[i].fieldNames()[j][k]);
+          }
+        }
+      }
+    }
+  }
+
+  public static void assertColumn(Column expected, Column actual) {
+    if (!(actual instanceof ColumnDTO)) {
+      actual = toDTO(actual);
+    }
+    if (!(expected instanceof ColumnDTO)) {
+      expected = toDTO(expected);
+    }
+
+    Assertions.assertEquals(expected.name(), actual.name());
+    Assertions.assertEquals(expected.dataType(), actual.dataType());
+    Assertions.assertEquals(expected.nullable(), actual.nullable());
+    Assertions.assertEquals(expected.comment(), actual.comment());
+    Assertions.assertEquals(expected.autoIncrement(), actual.autoIncrement());
+    if (expected.defaultValue().equals(Column.DEFAULT_VALUE_NOT_SET) && expected.nullable()) {
+      Assertions.assertEquals(LiteralDTO.NULL, actual.defaultValue());
+    } else {
+      Assertions.assertEquals(expected.defaultValue(), actual.defaultValue());
     }
   }
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Move the two utility-oriented functions, assertionsTableInfo and assertColumn, from AbstractIT.java to ITUtils.java, and make them public.
Update all references to these functions accordingly.

### Why are the changes needed?

Currently, the AbstractIT class in the Gravitino project contains two functions, assertionsTableInfo and assertColumn, which are more utility-oriented rather than integral to the abstract test class itself.

Fix: # 2883

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
