### PR TITLE
[#2927] Improvement(catalog-lakehouse-iceberg): Support more file formats in using clause when create iceberg tables

### DIFF
--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergTable.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergTable.java
@@ -48,10 +48,11 @@ public class IcebergTable extends BaseTable {
   /** The default provider of the table. */
   public static final String DEFAULT_ICEBERG_PROVIDER = "iceberg";
 
-  /** The supported file formats for Iceberg tables. */
+  /** The supported parquet file format for Iceberg tables. */
   public static final String ICEBERG_PARQUET_FILE_FORMAT = "parquet";
-
+  /** The supported orc file format for Iceberg tables. */
   public static final String ICEBERG_ORC_FILE_FORMAT = "orc";
+  /** The supported avro file format for Iceberg tables. */
   public static final String ICEBERG_AVRO_FILE_FORMAT = "avro";
 
   public static final String ICEBERG_COMMENT_FIELD_NAME = "comment";

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergTablePropertiesMetadata.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergTablePropertiesMetadata.java
@@ -23,6 +23,7 @@ public class IcebergTablePropertiesMetadata extends BasePropertiesMetadata {
   public static final String CHERRY_PICK_SNAPSHOT_ID = "cherry-pick-snapshot-id";
   public static final String SORT_ORDER = "sort-order";
   public static final String IDENTIFIER_FIELDS = "identifier-fields";
+  public static final String PROVIDER = "provider";
 
   public static final String DISTRIBUTION_MODE = TableProperties.WRITE_DISTRIBUTION_MODE;
 
@@ -47,7 +48,14 @@ public class IcebergTablePropertiesMetadata extends BasePropertiesMetadata {
                 SORT_ORDER, "Selecting a specific snapshot in a merge operation", false),
             stringReservedPropertyEntry(
                 IDENTIFIER_FIELDS, "The identifier field(s) for defining the table", false),
-            stringReservedPropertyEntry(DISTRIBUTION_MODE, "Write distribution mode", false));
+            stringReservedPropertyEntry(DISTRIBUTION_MODE, "Write distribution mode", false),
+            stringImmutablePropertyEntry(
+                PROVIDER,
+                "Iceberg provider for Iceberg table fileFormat, such as parquet, orc, avro, iceberg",
+                false,
+                null,
+                false,
+                false));
     PROPERTIES_METADATA = Maps.uniqueIndex(propertyEntries, PropertyEntry::getName);
   }
 

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergIT.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergIT.java
@@ -1085,6 +1085,7 @@ public class CatalogIcebergIT extends AbstractIT {
     Table loadTable = tableCatalog.loadTable(tableIdentifier);
     Assertions.assertFalse(loadTable.properties().containsKey(DEFAULT_FILE_FORMAT));
 
+    tableCatalog.dropTable(tableIdentifier);
     properties.put(DEFAULT_FILE_FORMAT, "iceberg");
     createdTable =
         tableCatalog.createTable(
@@ -1099,6 +1100,7 @@ public class CatalogIcebergIT extends AbstractIT {
     loadTable = tableCatalog.loadTable(tableIdentifier);
     Assertions.assertFalse(loadTable.properties().containsKey(DEFAULT_FILE_FORMAT));
 
+    tableCatalog.dropTable(tableIdentifier);
     properties.put(DEFAULT_FILE_FORMAT, "parquet");
     createdTable =
         tableCatalog.createTable(
@@ -1113,6 +1115,7 @@ public class CatalogIcebergIT extends AbstractIT {
     loadTable = tableCatalog.loadTable(tableIdentifier);
     Assertions.assertEquals("parquet", loadTable.properties().get(DEFAULT_FILE_FORMAT));
 
+    tableCatalog.dropTable(tableIdentifier);
     properties.put(DEFAULT_FILE_FORMAT, "orc");
     createdTable =
         tableCatalog.createTable(
@@ -1127,6 +1130,7 @@ public class CatalogIcebergIT extends AbstractIT {
     loadTable = tableCatalog.loadTable(tableIdentifier);
     Assertions.assertEquals("orc", loadTable.properties().get(DEFAULT_FILE_FORMAT));
 
+    tableCatalog.dropTable(tableIdentifier);
     properties.put(DEFAULT_FILE_FORMAT, "avro");
     createdTable =
         tableCatalog.createTable(
@@ -1141,6 +1145,7 @@ public class CatalogIcebergIT extends AbstractIT {
     loadTable = tableCatalog.loadTable(tableIdentifier);
     Assertions.assertEquals("avro", loadTable.properties().get(DEFAULT_FILE_FORMAT));
 
+    tableCatalog.dropTable(tableIdentifier);
     properties.put(DEFAULT_FILE_FORMAT, "text");
     Assertions.assertThrows(
         IllegalArgumentException.class,

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergIT.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergIT.java
@@ -1089,7 +1089,9 @@ public class CatalogIcebergIT extends AbstractIT {
     Arrays.stream(providers)
         .forEach(
             provider -> {
-              properties.put(PROP_PROVIDER, provider);
+              if (provider != null) {
+                properties.put(PROP_PROVIDER, provider);
+              }
               if (DEFAULT_ICEBERG_PROVIDER.equals(provider)) {
                 provider = null;
               }

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergIT.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergIT.java
@@ -1086,7 +1086,7 @@ public class CatalogIcebergIT extends AbstractIT {
     Assertions.assertFalse(loadTable.properties().containsKey(DEFAULT_FILE_FORMAT));
 
     tableCatalog.dropTable(tableIdentifier);
-    properties.put(DEFAULT_FILE_FORMAT, "iceberg");
+    properties.put("provider", "iceberg");
     createdTable =
         tableCatalog.createTable(
             tableIdentifier,
@@ -1101,7 +1101,7 @@ public class CatalogIcebergIT extends AbstractIT {
     Assertions.assertFalse(loadTable.properties().containsKey(DEFAULT_FILE_FORMAT));
 
     tableCatalog.dropTable(tableIdentifier);
-    properties.put(DEFAULT_FILE_FORMAT, "parquet");
+    properties.put("provider", "parquet");
     createdTable =
         tableCatalog.createTable(
             tableIdentifier,
@@ -1116,7 +1116,7 @@ public class CatalogIcebergIT extends AbstractIT {
     Assertions.assertEquals("parquet", loadTable.properties().get(DEFAULT_FILE_FORMAT));
 
     tableCatalog.dropTable(tableIdentifier);
-    properties.put(DEFAULT_FILE_FORMAT, "orc");
+    properties.put("provider", "orc");
     createdTable =
         tableCatalog.createTable(
             tableIdentifier,
@@ -1131,7 +1131,7 @@ public class CatalogIcebergIT extends AbstractIT {
     Assertions.assertEquals("orc", loadTable.properties().get(DEFAULT_FILE_FORMAT));
 
     tableCatalog.dropTable(tableIdentifier);
-    properties.put(DEFAULT_FILE_FORMAT, "avro");
+    properties.put("provider", "avro");
     createdTable =
         tableCatalog.createTable(
             tableIdentifier,
@@ -1146,7 +1146,7 @@ public class CatalogIcebergIT extends AbstractIT {
     Assertions.assertEquals("avro", loadTable.properties().get(DEFAULT_FILE_FORMAT));
 
     tableCatalog.dropTable(tableIdentifier);
-    properties.put(DEFAULT_FILE_FORMAT, "text");
+    properties.put("provider", "text");
     Assertions.assertThrows(
         IllegalArgumentException.class,
         () ->

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergIT.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergIT.java
@@ -1120,6 +1120,21 @@ public class CatalogIcebergIT extends AbstractIT {
                 partitioning,
                 distribution,
                 sortOrders));
+
+    properties.put(PROP_PROVIDER, ICEBERG_PARQUET_FILE_FORMAT);
+    tableCatalog.createTable(
+        tableIdentifier,
+        columns,
+        table_comment,
+        properties,
+        partitioning,
+        distribution,
+        sortOrders);
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            tableCatalog.alterTable(
+                tableIdentifier, TableChange.setProperty(PROP_PROVIDER, ICEBERG_ORC_FILE_FORMAT)));
   }
 
   private static void checkIcebergTableFileFormat(

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergIT.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergIT.java
@@ -1093,7 +1093,7 @@ public class CatalogIcebergIT extends AbstractIT {
               if (DEFAULT_ICEBERG_PROVIDER.equals(provider)) {
                 provider = null;
               }
-              assertionsTableProperties(
+              checkIcebergTableFileFormat(
                   tableCatalog,
                   tableIdentifier,
                   columns,
@@ -1120,7 +1120,7 @@ public class CatalogIcebergIT extends AbstractIT {
                 sortOrders));
   }
 
-  private static void assertionsTableProperties(
+  private static void checkIcebergTableFileFormat(
       TableCatalog tableCatalog,
       NameIdentifier tableIdentifier,
       Column[] columns,


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support more file formats in using clause when create iceberg tables, such as `using parquet`, `using orc`, `using avro`, `using iceberg`.

using other provider will throw an exception.


### Why are the changes needed?
Because Iceberg official supports using parquet/orc/avro/iceberg when create a new table.

Fix: https://github.com/datastrato/gravitino/issues/2927

### Does this PR introduce _any_ user-facing change?
Yes, users can using `parquet/orc/avro/iceberg` keywork in `using clause` when create a new table.

### How was this patch tested?
New IT.