### PR TITLE
[#2896] improve(IT): Add e2e test case for verifying fileset schema level and kafka topic level

### DIFF
--- a/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
+++ b/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
@@ -154,7 +154,8 @@ public class ContainerSuite implements Closeable {
     if (kafkaContainer == null) {
       synchronized (ContainerSuite.class) {
         if (kafkaContainer == null) {
-          KafkaContainer container = closer.register(KafkaContainer.builder().build());
+          KafkaContainer.Builder builder = KafkaContainer.builder().withNetwork(network);
+          KafkaContainer container = closer.register(builder.build());
           try {
             container.start();
           } catch (Exception e) {

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -155,6 +155,7 @@ tasks.test {
       // Gravitino CI Docker image
       environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "datastrato/gravitino-ci-hive:0.1.10")
       environment("GRAVITINO_CI_TRINO_DOCKER_IMAGE", "datastrato/gravitino-ci-trino:0.1.5")
+      environment("GRAVITINO_CI_KAFKA_DOCKER_IMAGE", "apache/kafka:3.7.0")
 
       copy {
         from("${project.rootDir}/dev/docker/trino/conf")

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageKafkaTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageKafkaTest.java
@@ -144,7 +144,7 @@ public class CatalogsPageKafkaTest extends AbstractWebIT {
             FILESET_CATALOG_NAME,
             KAFKA_CATALOG_NAME,
             SCHEMA_NAME);
-    Assertions.assertTrue(catalogsPage.verifyTreeNodes(treeNodes)); 
+    Assertions.assertTrue(catalogsPage.verifyTreeNodes(treeNodes));
   }
 
   @Test

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageKafkaTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageKafkaTest.java
@@ -177,12 +177,12 @@ public class CatalogsPageKafkaTest extends AbstractWebIT {
   @Test
   @Order(3)
   public void testKafkaTopicDetail() throws InterruptedException {
-    // 1. click toptic tree node
-    String topticNode =
+    // 1. click topic tree node
+    String topicNode =
         String.format(
             "{{%s}}{{%s}}{{%s}}{{%s}}{{%s}}",
             METALAKE_NAME, KAFKA_CATALOG_NAME, CATALOG_TYPE_MESSAGING, SCHEMA_NAME, TOPIC_NAME);
-    catalogsPage.clickTreeNode(topticNode);
+    catalogsPage.clickTreeNode(topicNode);
     // 2. verify show tab details
     Assertions.assertTrue(catalogsPage.verifyShowDetailsContent());
     // 3. verify show highlight properties

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageKafkaTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageKafkaTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+
+package com.datastrato.gravitino.integration.test.web.ui;
+
+import com.datastrato.gravitino.Catalog;
+import com.datastrato.gravitino.NameIdentifier;
+import com.datastrato.gravitino.client.GravitinoAdminClient;
+import com.datastrato.gravitino.client.GravitinoMetalake;
+import com.datastrato.gravitino.integration.test.container.ContainerSuite;
+import com.datastrato.gravitino.integration.test.util.AbstractIT;
+import com.datastrato.gravitino.integration.test.web.ui.pages.CatalogsPage;
+import com.datastrato.gravitino.integration.test.web.ui.pages.MetalakePage;
+import com.datastrato.gravitino.integration.test.web.ui.utils.AbstractWebIT;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+@Tag("gravitino-docker-it")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class CatalogsPageKafkaTest extends AbstractWebIT {
+  MetalakePage metalakePage = new MetalakePage();
+  CatalogsPage catalogsPage = new CatalogsPage();
+
+  private static final ContainerSuite containerSuite = ContainerSuite.getInstance();
+  protected static GravitinoAdminClient gravitinoClient;
+  private static GravitinoMetalake metalake;
+
+  protected static String gravitinoUri = "http://127.0.0.1:8090";
+  protected static String kafkaUri = "http://127.0.0.1:9092";
+
+  private static final String CATALOG_TABLE_TITLE = "Schemas";
+  private static final String SCHEMA_TOPIC_TITLE = "Topics";
+  private static final String METALAKE_NAME = "test";
+  private static final String CATALOG_TYPE_MESSAGING = "messaging";
+  private static final String HIVE_CATALOG_NAME = "catalog_hive";
+  private static final String MODIFIED_HIVE_CATALOG_NAME = HIVE_CATALOG_NAME + "_edited";
+  private static final String ICEBERG_CATALOG_NAME = "catalog_iceberg";
+  private static final String FILESET_CATALOG_NAME = "catalog_fileset";
+  private static final String KAFKA_CATALOG_NAME = "catalog_kafka";
+  private static final String SCHEMA_NAME = "default";
+  private static final String TOPIC_NAME = "topic1";
+
+  private static final String MYSQL_CATALOG_NAME = "catalog_mysql";
+
+  private static final String PG_CATALOG_NAME = "catalog_pg";
+
+  @BeforeAll
+  public static void before() throws Exception {
+    gravitinoClient = AbstractIT.getGravitinoClient();
+
+    gravitinoUri = String.format("http://127.0.0.1:%d", AbstractIT.getGravitinoServerPort());
+
+    containerSuite.startKafkaContainer();
+
+    String address = containerSuite.getKafkaContainer().getContainerIpAddress();
+    kafkaUri = String.format("%s:%s", address, "9092");
+  }
+
+  /**
+   * Creates a Kafka topic within the specified Metalake, Catalog, Schema, and Topic names.
+   *
+   * @param metalakeName The name of the Metalake.
+   * @param catalogName The name of the Catalog.
+   * @param schemaName The name of the Schema.
+   * @param topicName The name of the Kafka topic.
+   */
+  void createTopic(String metalakeName, String catalogName, String schemaName, String topicName) {
+    Catalog catalog_kafka =
+        metalake.loadCatalog(NameIdentifier.ofCatalog(metalakeName, catalogName));
+    catalog_kafka
+        .asTopicCatalog()
+        .createTopic(
+            NameIdentifier.of(metalakeName, catalogName, schemaName, topicName),
+            "comment",
+            null,
+            Collections.emptyMap());
+  }
+
+  /**
+   * Drops a Kafka topic from the specified Metalake, Catalog, and Schema.
+   *
+   * @param metalakeName The name of the Metalake where the topic resides.
+   * @param catalogName The name of the Catalog that contains the topic.
+   * @param schemaName The name of the Schema under which the topic exists.
+   * @param topicName The name of the Kafka topic to be dropped.
+   */
+  void dropTopic(String metalakeName, String catalogName, String schemaName, String topicName) {
+    Catalog catalog_kafka =
+        metalake.loadCatalog(NameIdentifier.ofCatalog(metalakeName, catalogName));
+    catalog_kafka
+        .asTopicCatalog()
+        .dropTopic(NameIdentifier.of(metalakeName, catalogName, schemaName, topicName));
+  }
+
+  @Test
+  @Order(0)
+  public void testCreateKafkaCatalog() throws InterruptedException {
+    // create metalake
+    clickAndWait(metalakePage.createMetalakeBtn);
+    metalakePage.setMetalakeNameField(METALAKE_NAME);
+    clickAndWait(metalakePage.submitHandleMetalakeBtn);
+    // load metalake
+    metalake = gravitinoClient.loadMetalake(NameIdentifier.of(METALAKE_NAME));
+    metalakePage.clickMetalakeLink(METALAKE_NAME);
+    // create kafka catalog actions
+    clickAndWait(catalogsPage.createCatalogBtn);
+    catalogsPage.setCatalogNameField(KAFKA_CATALOG_NAME);
+    clickAndWait(catalogsPage.catalogTypeSelector);
+    catalogsPage.clickSelectType("messaging");
+    catalogsPage.setCatalogCommentField("kafka catalog comment");
+    // set kafka catalog props
+    catalogsPage.setCatalogFixedProp("bootstrap.servers", kafkaUri);
+    clickAndWait(catalogsPage.handleSubmitCatalogBtn);
+    Assertions.assertTrue(catalogsPage.verifyGetCatalog(KAFKA_CATALOG_NAME));
+  }
+
+  @Test
+  @Order(1)
+  public void testKafkaSchemaTreeNode() throws InterruptedException {
+    // click kafka catalog tree node
+    String kafkaCatalogNode =
+        String.format(
+            "{{%s}}{{%s}}{{%s}}", METALAKE_NAME, KAFKA_CATALOG_NAME, CATALOG_TYPE_MESSAGING);
+    catalogsPage.clickTreeNode(kafkaCatalogNode);
+    // verify show table title、 schema name and tree node
+    Assertions.assertTrue(catalogsPage.verifyShowTableTitle(CATALOG_TABLE_TITLE));
+    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(SCHEMA_NAME, false));
+    List<String> treeNodes =
+        Arrays.asList(
+            MODIFIED_HIVE_CATALOG_NAME,
+            ICEBERG_CATALOG_NAME,
+            MYSQL_CATALOG_NAME,
+            PG_CATALOG_NAME,
+            FILESET_CATALOG_NAME,
+            KAFKA_CATALOG_NAME,
+            SCHEMA_NAME);
+    Assertions.assertTrue(catalogsPage.verifyTreeNodes(treeNodes)); 
+  }
+
+  @Test
+  @Order(2)
+  public void testKafkaTopicTreeNode() throws InterruptedException {
+    // 1. create topic of kafka catalog
+    createTopic(METALAKE_NAME, KAFKA_CATALOG_NAME, SCHEMA_NAME, TOPIC_NAME);
+    // 2. click schema tree node
+    String kafkaSchemaNode =
+        String.format(
+            "{{%s}}{{%s}}{{%s}}{{%s}}",
+            METALAKE_NAME, KAFKA_CATALOG_NAME, CATALOG_TYPE_MESSAGING, SCHEMA_NAME);
+    catalogsPage.clickTreeNode(kafkaSchemaNode);
+    // 3. verify show table title、 default schema name and tree node
+    Assertions.assertTrue(catalogsPage.verifyShowTableTitle(SCHEMA_TOPIC_TITLE));
+    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(TOPIC_NAME, false));
+    List<String> treeNodes =
+        Arrays.asList(
+            MODIFIED_HIVE_CATALOG_NAME,
+            ICEBERG_CATALOG_NAME,
+            MYSQL_CATALOG_NAME,
+            PG_CATALOG_NAME,
+            FILESET_CATALOG_NAME,
+            KAFKA_CATALOG_NAME,
+            SCHEMA_NAME,
+            TOPIC_NAME);
+    Assertions.assertTrue(catalogsPage.verifyTreeNodes(treeNodes));
+  }
+
+  @Test
+  @Order(3)
+  public void testKafkaTopicDetail() throws InterruptedException {
+    // 1. click toptic tree node
+    String topticNode =
+        String.format(
+            "{{%s}}{{%s}}{{%s}}{{%s}}{{%s}}",
+            METALAKE_NAME, KAFKA_CATALOG_NAME, CATALOG_TYPE_MESSAGING, SCHEMA_NAME, TOPIC_NAME);
+    catalogsPage.clickTreeNode(topticNode);
+    // 2. verify show tab details
+    Assertions.assertTrue(catalogsPage.verifyShowDetailsContent());
+    // 3. verify show highlight properties
+    Assertions.assertTrue(
+        catalogsPage.verifyShowPropertiesItemInList(
+            "key", "partition-count", "partition-count", true));
+    Assertions.assertTrue(
+        catalogsPage.verifyShowPropertiesItemInList("value", "partition-count", "1", true));
+    Assertions.assertTrue(
+        catalogsPage.verifyShowPropertiesItemInList(
+            "key", "replication-factor", "replication-factor", true));
+    Assertions.assertTrue(
+        catalogsPage.verifyShowPropertiesItemInList("value", "replication-factor", "1", true));
+  }
+
+  @Test
+  @Order(4)
+  public void testDropKafkaTopic() throws InterruptedException {
+    // delete topic of kafka catalog
+    dropTopic(METALAKE_NAME, KAFKA_CATALOG_NAME, SCHEMA_NAME, TOPIC_NAME);
+    // click schema tree node
+    String kafkaSchemaNode =
+        String.format(
+            "{{%s}}{{%s}}{{%s}}{{%s}}",
+            METALAKE_NAME, KAFKA_CATALOG_NAME, CATALOG_TYPE_MESSAGING, SCHEMA_NAME);
+    catalogsPage.clickTreeNode(kafkaSchemaNode);
+    // verify empty topic list
+    Assertions.assertTrue(catalogsPage.verifyEmptyTableData());
+  }
+
+  @Test
+  @Order(5)
+  public void testBackHomePage() throws InterruptedException {
+    clickAndWait(catalogsPage.backHomeBtn);
+    Assertions.assertTrue(catalogsPage.verifyBackHomePage());
+  }
+}

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
@@ -526,42 +526,7 @@ public class CatalogsPageTest extends AbstractWebIT {
 
   @Test
   @Order(17)
-  public void testSelectMetalake() throws InterruptedException {
-    catalogsPage.metalakeSelectChange(METALAKE_SELECT_NAME);
-    Assertions.assertTrue(catalogsPage.verifyEmptyCatalog());
-
-    catalogsPage.metalakeSelectChange(METALAKE_NAME);
-    Assertions.assertTrue(catalogsPage.verifyGetCatalog(MODIFIED_HIVE_CATALOG_NAME));
-  }
-
-  @Test
-  @Order(18)
-  public void testClickTreeList() throws InterruptedException {
-    String icebergNode =
-        String.format(
-            "{{%s}}{{%s}}{{%s}}", METALAKE_NAME, ICEBERG_CATALOG_NAME, CATALOG_TYPE_RELATIONAL);
-    catalogsPage.clickTreeNode(icebergNode);
-    Assertions.assertTrue(catalogsPage.verifyGetCatalog(ICEBERG_CATALOG_NAME));
-    String mysqlNode =
-        String.format(
-            "{{%s}}{{%s}}{{%s}}", METALAKE_NAME, MYSQL_CATALOG_NAME, CATALOG_TYPE_RELATIONAL);
-    catalogsPage.clickTreeNode(mysqlNode);
-    Assertions.assertTrue(catalogsPage.verifyGetCatalog(MYSQL_CATALOG_NAME));
-    String pgNode =
-        String.format(
-            "{{%s}}{{%s}}{{%s}}", METALAKE_NAME, PG_CATALOG_NAME, CATALOG_TYPE_RELATIONAL);
-    catalogsPage.clickTreeNode(pgNode);
-    Assertions.assertTrue(catalogsPage.verifyGetCatalog(PG_CATALOG_NAME));
-    String filesetNode =
-        String.format(
-            "{{%s}}{{%s}}{{%s}}", METALAKE_NAME, FILESET_CATALOG_NAME, CATALOG_TYPE_FILESET);
-    catalogsPage.clickTreeNode(filesetNode);
-    Assertions.assertTrue(catalogsPage.verifyGetCatalog(FILESET_CATALOG_NAME));
-    String kafkaNode =
-        String.format(
-            "{{%s}}{{%s}}{{%s}}", METALAKE_NAME, KAFKA_CATALOG_NAME, CATALOG_TYPE_MESSAGING);
-    catalogsPage.clickTreeNode(kafkaNode);
-    Assertions.assertTrue(catalogsPage.verifyGetCatalog(KAFKA_CATALOG_NAME));
+  public void testRelationalCatalogTreeNode() throws InterruptedException {
     String hiveNode =
         String.format(
             "{{%s}}{{%s}}{{%s}}",
@@ -591,7 +556,7 @@ public class CatalogsPageTest extends AbstractWebIT {
   }
 
   @Test
-  @Order(19)
+  @Order(18)
   public void testTreeNodeRefresh() throws InterruptedException {
     createTableAndColumn(
         METALAKE_NAME, MODIFIED_HIVE_CATALOG_NAME, SCHEMA_NAME, TABLE_NAME_2, COLUMN_NAME_2);
@@ -620,8 +585,8 @@ public class CatalogsPageTest extends AbstractWebIT {
   }
 
   @Test
-  @Order(20)
-  public void testViewFilesetCatalog() throws InterruptedException {
+  @Order(19)
+  public void testFilesetCatalogTreeNode() throws InterruptedException {
     // 1. back to the list catalog of metalake
     catalogsPage.clickMetalakeLink(METALAKE_NAME);
     // 2. create schema and fileset of fileset catalog
@@ -686,8 +651,8 @@ public class CatalogsPageTest extends AbstractWebIT {
   }
 
   @Test
-  @Order(21)
-  public void testViewKafkaCatalog() throws InterruptedException {
+  @Order(20)
+  public void testKafkaCatalogTreeNode() throws InterruptedException {
     // 1. back to the list catalog of metalake
     catalogsPage.metalakeSelectChange(METALAKE_SELECT_NAME);
     Assertions.assertTrue(catalogsPage.verifyEmptyCatalog());
@@ -719,7 +684,7 @@ public class CatalogsPageTest extends AbstractWebIT {
             "{{%s}}{{%s}}{{%s}}{{%s}}",
             METALAKE_NAME, KAFKA_CATALOG_NAME, CATALOG_TYPE_MESSAGING, SCHEMA_NAME);
     catalogsPage.clickTreeNode(kafkaSchemaNode);
-    // 6. verify show table title、 fileset name and tree node
+    // 6. verify show table title、 default schema name and tree node
     Assertions.assertTrue(catalogsPage.verifyShowTableTitle(SCHEMA_TOPIC_TITLE));
     Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(TOPIC_NAME, false));
     treeNodes =
@@ -733,12 +698,12 @@ public class CatalogsPageTest extends AbstractWebIT {
             SCHEMA_NAME,
             TOPIC_NAME);
     Assertions.assertTrue(catalogsPage.verifyTreeNodes(treeNodes));
-    // 7. click fileset tree node
-    String filesetNode =
+    // 7. click toptic tree node
+    String topticNode =
         String.format(
             "{{%s}}{{%s}}{{%s}}{{%s}}{{%s}}",
             METALAKE_NAME, KAFKA_CATALOG_NAME, CATALOG_TYPE_MESSAGING, SCHEMA_NAME, TOPIC_NAME);
-    catalogsPage.clickTreeNode(filesetNode);
+    catalogsPage.clickTreeNode(topticNode);
     // 8. verify show tab details
     Assertions.assertTrue(catalogsPage.verifyShowDetailsContent());
     // 9. verify show highlight properties
@@ -754,6 +719,26 @@ public class CatalogsPageTest extends AbstractWebIT {
         catalogsPage.verifyShowPropertiesItemInList("value", "replication-factor", "1", true));
     // 10. delete topic of kafka catalog
     dropTopic(METALAKE_NAME, KAFKA_CATALOG_NAME, SCHEMA_NAME, TOPIC_NAME);
+  }
+
+  @Test
+  @Order(21)
+  public void testOrtherCatalogTreeNode() throws InterruptedException {
+    String icebergNode =
+        String.format(
+            "{{%s}}{{%s}}{{%s}}", METALAKE_NAME, ICEBERG_CATALOG_NAME, CATALOG_TYPE_RELATIONAL);
+    catalogsPage.clickTreeNode(icebergNode);
+    Assertions.assertTrue(catalogsPage.verifyGetCatalog(ICEBERG_CATALOG_NAME));
+    String mysqlNode =
+        String.format(
+            "{{%s}}{{%s}}{{%s}}", METALAKE_NAME, MYSQL_CATALOG_NAME, CATALOG_TYPE_RELATIONAL);
+    catalogsPage.clickTreeNode(mysqlNode);
+    Assertions.assertTrue(catalogsPage.verifyGetCatalog(MYSQL_CATALOG_NAME));
+    String pgNode =
+        String.format(
+            "{{%s}}{{%s}}{{%s}}", METALAKE_NAME, PG_CATALOG_NAME, CATALOG_TYPE_RELATIONAL);
+    catalogsPage.clickTreeNode(pgNode);
+    Assertions.assertTrue(catalogsPage.verifyGetCatalog(PG_CATALOG_NAME));
   }
 
   @Test

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
@@ -545,7 +545,7 @@ public class CatalogsPageTest extends AbstractWebIT {
     Assertions.assertTrue(catalogsPage.verifyEmptyTableData());
 
     catalogsPage.metalakeSelectChange(METALAKE_NAME);
-    Assertions.assertTrue(catalogsPage.verifyGetCatalog(MODIFIED_HIVE_CATALOG_NAME));
+    driver.navigate().refresh();
   }
 
   @Test

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
@@ -164,10 +164,7 @@ public class CatalogsPageTest extends AbstractWebIT {
   private static String defaultBaseLocation(String schemaName) {
     if (defaultBaseLocation == null) {
       defaultBaseLocation =
-          String.format(
-              "%s/user/hadoop/%s.db",
-              hdfsUri,
-              schemaName.toLowerCase());
+          String.format("%s/user/hadoop/%s.db", hdfsUri, schemaName.toLowerCase());
     }
     return defaultBaseLocation;
   }
@@ -241,8 +238,7 @@ public class CatalogsPageTest extends AbstractWebIT {
         metalake.loadCatalog(NameIdentifier.ofCatalog(metalakeName, catalogName));
     catalog_kafka
         .asTopicCatalog()
-        .dropTopic(
-            NameIdentifier.of(metalakeName, catalogName, schemaName, topicName));
+        .dropTopic(NameIdentifier.of(metalakeName, catalogName, schemaName, topicName));
   }
 
   @AfterAll

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
@@ -9,7 +9,9 @@ import com.datastrato.gravitino.Catalog;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.client.GravitinoAdminClient;
 import com.datastrato.gravitino.client.GravitinoMetalake;
+import com.datastrato.gravitino.file.Fileset;
 import com.datastrato.gravitino.integration.test.container.ContainerSuite;
+import com.datastrato.gravitino.integration.test.container.HiveContainer;
 import com.datastrato.gravitino.integration.test.container.TrinoITContainers;
 import com.datastrato.gravitino.integration.test.util.AbstractIT;
 import com.datastrato.gravitino.integration.test.web.ui.pages.CatalogsPage;
@@ -19,6 +21,7 @@ import com.datastrato.gravitino.rel.Column;
 import com.datastrato.gravitino.rel.types.Types;
 import com.google.common.collect.Maps;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.AfterAll;
@@ -37,6 +40,7 @@ public class CatalogsPageTest extends AbstractWebIT {
   CatalogsPage catalogsPage = new CatalogsPage();
 
   protected static TrinoITContainers trinoITContainers;
+  private static final ContainerSuite containerSuite = ContainerSuite.getInstance();
   protected static GravitinoAdminClient gravitinoClient;
   private static GravitinoMetalake metalake;
   private static Catalog catalog;
@@ -52,21 +56,30 @@ public class CatalogsPageTest extends AbstractWebIT {
   private static final String WEB_TITLE = "Gravitino";
   private static final String CATALOG_TABLE_TITLE = "Schemas";
   private static final String SCHEMA_TABLE_TITLE = "Tables";
+  private static final String SCHEMA_FILESET_TITLE = "Filesets";
+  private static final String SCHEMA_TOPIC_TITLE = "Topics";
   private static final String TABLE_TABLE_TITLE = "Columns";
   private static final String METALAKE_NAME = "test";
   private static final String METALAKE_SELECT_NAME = "metalake_select_name";
-  private static final String CATALOG_TYPE = "relational";
+  private static final String CATALOG_TYPE_RELATIONAL = "relational";
+  private static final String CATALOG_TYPE_FILESET = "fileset";
+  private static final String CATALOG_TYPE_MESSAGING = "messaging";
   private static final String DEFAULT_CATALOG_NAME = "default_catalog";
   private static final String HIVE_CATALOG_NAME = "catalog_hive";
-  private static final String MODIFIED_CATALOG_NAME = HIVE_CATALOG_NAME + "_edited";
+  private static final String MODIFIED_HIVE_CATALOG_NAME = HIVE_CATALOG_NAME + "_edited";
   private static final String ICEBERG_CATALOG_NAME = "catalog_iceberg";
   private static final String FILESET_CATALOG_NAME = "catalog_fileset";
   private static final String KAFKA_CATALOG_NAME = "catalog_kafka";
   private static final String SCHEMA_NAME = "default";
+  private static final String SCHEMA_NAME_FILESET = "schema_fileset";
+  private static final String FILESET_NAME = "fileset1";
+  private static final String TOPIC_NAME = "topic1";
   private static final String TABLE_NAME = "table1";
   private static final String TABLE_NAME_2 = "table2";
   private static final String COLUMN_NAME = "column";
   private static final String COLUMN_NAME_2 = "column_2";
+  private static final String PROPERTIES_KEY1 = "key1";
+  private static final String PROPERTIES_VALUE1 = "val1";
 
   private static final String MYSQL_CATALOG_NAME = "catalog_mysql";
   private static final String MYSQL_JDBC_DRIVER = "com.mysql.cj.jdbc.Driver";
@@ -77,6 +90,8 @@ public class CatalogsPageTest extends AbstractWebIT {
 
   private static final String COMMON_JDBC_USER = "trino";
   private static final String COMMON_JDBC_PWD = "ds123";
+
+  private static String defaultBaseLocation;
 
   @BeforeAll
   public static void before() throws Exception {
@@ -92,8 +107,35 @@ public class CatalogsPageTest extends AbstractWebIT {
     hdfsUri = trinoITContainers.getHdfsUri();
     mysqlUri = trinoITContainers.getMysqlUri();
     postgresqlUri = trinoITContainers.getPostgresqlUri();
+
+    containerSuite.startHiveContainer();
   }
 
+  /**
+   * Create the specified schema
+   *
+   * @param metalakeName The name of the Metalake where the schema will be created.
+   * @param catalogName The name of the Catalog where the schema will be created.
+   * @param schemaName The name of the Schema where the schema will be created.
+   */
+  void createSchema(String metalakeName, String catalogName, String schemaName) {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(PROPERTIES_KEY1, PROPERTIES_VALUE1);
+    catalog
+        .asSchemas()
+        .createSchema(
+            NameIdentifier.of(metalakeName, catalogName, schemaName), "comment", properties);
+  }
+
+  /**
+   * Creates a table with a single column in the specified Metalake, Catalog, Schema, and Table.
+   *
+   * @param metalakeName The name of the Metalake where the table will be created.
+   * @param catalogName The name of the Catalog where the table will be created.
+   * @param schemaName The name of the Schema where the table will be created.
+   * @param tableName The name of the Table to be created.
+   * @param colName The name of the Column to be created in the Table.
+   */
   void createTableAndColumn(
       String metalakeName,
       String catalogName,
@@ -109,6 +151,80 @@ public class CatalogsPageTest extends AbstractWebIT {
             new Column[] {column},
             "comment",
             properties);
+  }
+
+  /**
+   * Retrieves the default base location for the given schema name.
+   *
+   * @param schemaName The name of the schema.
+   * @return The default HDFS storage location for the schema.
+   */
+  private static String defaultBaseLocation(String schemaName) {
+    if (defaultBaseLocation == null) {
+      defaultBaseLocation =
+          String.format(
+              "hdfs://%s:%d/user/hadoop/%s.db",
+              containerSuite.getHiveContainer().getContainerIpAddress(),
+              HiveContainer.HDFS_DEFAULTFS_PORT,
+              schemaName.toLowerCase());
+    }
+    return defaultBaseLocation;
+  }
+
+  /**
+   * Retrieves the storage location for the given schema name and fileset name.
+   *
+   * @param schemaName The name of the schema.
+   * @param filesetName The name of the fileset.
+   * @return The storage path for the combination of schema and fileset.
+   */
+  private static String storageLocation(String schemaName, String filesetName) {
+    return defaultBaseLocation(schemaName) + "/" + filesetName;
+  }
+
+  /**
+   * Creates a fileset within the specified Metalake, Catalog, Schema, and Fileset names.
+   *
+   * @param metalakeName The name of the Metalake.
+   * @param catalogName The name of the Catalog.
+   * @param schemaName The name of the Schema.
+   * @param filesetName The name of the Fileset.
+   */
+  void createFileset(
+      String metalakeName, String catalogName, String schemaName, String filesetName) {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(PROPERTIES_KEY1, PROPERTIES_VALUE1);
+    String storageLocation = storageLocation(schemaName, filesetName);
+    Catalog catalog_fileset =
+        metalake.loadCatalog(NameIdentifier.ofCatalog(metalakeName, catalogName));
+    catalog_fileset
+        .asFilesetCatalog()
+        .createFileset(
+            NameIdentifier.of(metalakeName, catalogName, schemaName, filesetName),
+            "comment",
+            Fileset.Type.MANAGED,
+            storageLocation,
+            properties);
+  }
+
+  /**
+   * Creates a Kafka topic within the specified Metalake, Catalog, Schema, and Topic names.
+   *
+   * @param metalakeName The name of the Metalake.
+   * @param catalogName The name of the Catalog.
+   * @param schemaName The name of the Schema.
+   * @param topicName The name of the Kafka topic.
+   */
+  void createTopic(String metalakeName, String catalogName, String schemaName, String topicName) {
+    Catalog catalog_kafka =
+        metalake.loadCatalog(NameIdentifier.ofCatalog(metalakeName, catalogName));
+    catalog_kafka
+        .asTopicCatalog()
+        .createTopic(
+            NameIdentifier.of(metalakeName, catalogName, schemaName, topicName),
+            "comment",
+            null,
+            Collections.emptyMap());
   }
 
   @AfterAll
@@ -283,21 +399,22 @@ public class CatalogsPageTest extends AbstractWebIT {
 
   @Test
   @Order(10)
-  public void testEditCatalog() throws InterruptedException {
+  public void testEditHiveCatalog() throws InterruptedException {
     catalogsPage.clickEditCatalogBtn(HIVE_CATALOG_NAME);
-    catalogsPage.setCatalogNameField(MODIFIED_CATALOG_NAME);
+    catalogsPage.setCatalogNameField(MODIFIED_HIVE_CATALOG_NAME);
     clickAndWait(catalogsPage.handleSubmitCatalogBtn);
-    Assertions.assertTrue(catalogsPage.verifyEditedCatalog(MODIFIED_CATALOG_NAME));
+    Assertions.assertTrue(catalogsPage.verifyEditedCatalog(MODIFIED_HIVE_CATALOG_NAME));
   }
 
   // test catalog show schema list
   @Test
   @Order(11)
   public void testClickCatalogLink() {
-    catalogsPage.clickCatalogLink(METALAKE_NAME, MODIFIED_CATALOG_NAME, CATALOG_TYPE);
+    catalogsPage.clickCatalogLink(
+        METALAKE_NAME, MODIFIED_HIVE_CATALOG_NAME, CATALOG_TYPE_RELATIONAL);
     Assertions.assertTrue(catalogsPage.verifyShowTableTitle(CATALOG_TABLE_TITLE));
     Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(SCHEMA_NAME, false));
-    Assertions.assertTrue(catalogsPage.verifySelectedNode(MODIFIED_CATALOG_NAME));
+    Assertions.assertTrue(catalogsPage.verifySelectedNode(MODIFIED_HIVE_CATALOG_NAME));
   }
 
   @Test
@@ -309,7 +426,7 @@ public class CatalogsPageTest extends AbstractWebIT {
     Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(SCHEMA_NAME, false));
     List<String> treeNodes =
         Arrays.asList(
-            MODIFIED_CATALOG_NAME,
+            MODIFIED_HIVE_CATALOG_NAME,
             SCHEMA_NAME,
             ICEBERG_CATALOG_NAME,
             MYSQL_CATALOG_NAME,
@@ -317,7 +434,7 @@ public class CatalogsPageTest extends AbstractWebIT {
             FILESET_CATALOG_NAME,
             KAFKA_CATALOG_NAME);
     Assertions.assertTrue(catalogsPage.verifyTreeNodes(treeNodes));
-    Assertions.assertTrue(catalogsPage.verifySelectedNode(MODIFIED_CATALOG_NAME));
+    Assertions.assertTrue(catalogsPage.verifySelectedNode(MODIFIED_HIVE_CATALOG_NAME));
   }
 
   // test schema show table list
@@ -326,8 +443,9 @@ public class CatalogsPageTest extends AbstractWebIT {
   public void testClickSchemaLink() {
     // create table
     createTableAndColumn(
-        METALAKE_NAME, MODIFIED_CATALOG_NAME, SCHEMA_NAME, TABLE_NAME, COLUMN_NAME);
-    catalogsPage.clickSchemaLink(METALAKE_NAME, MODIFIED_CATALOG_NAME, CATALOG_TYPE, SCHEMA_NAME);
+        METALAKE_NAME, MODIFIED_HIVE_CATALOG_NAME, SCHEMA_NAME, TABLE_NAME, COLUMN_NAME);
+    catalogsPage.clickSchemaLink(
+        METALAKE_NAME, MODIFIED_HIVE_CATALOG_NAME, CATALOG_TYPE_RELATIONAL, SCHEMA_NAME);
     Assertions.assertTrue(catalogsPage.verifyShowTableTitle(SCHEMA_TABLE_TITLE));
     Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(TABLE_NAME, false));
     Assertions.assertTrue(catalogsPage.verifySelectedNode(SCHEMA_NAME));
@@ -342,7 +460,7 @@ public class CatalogsPageTest extends AbstractWebIT {
     Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(TABLE_NAME, false));
     List<String> treeNodes =
         Arrays.asList(
-            MODIFIED_CATALOG_NAME,
+            MODIFIED_HIVE_CATALOG_NAME,
             SCHEMA_NAME,
             TABLE_NAME,
             ICEBERG_CATALOG_NAME,
@@ -359,7 +477,11 @@ public class CatalogsPageTest extends AbstractWebIT {
   @Order(15)
   public void testClickTableLink() {
     catalogsPage.clickTableLink(
-        METALAKE_NAME, MODIFIED_CATALOG_NAME, CATALOG_TYPE, SCHEMA_NAME, TABLE_NAME);
+        METALAKE_NAME,
+        MODIFIED_HIVE_CATALOG_NAME,
+        CATALOG_TYPE_RELATIONAL,
+        SCHEMA_NAME,
+        TABLE_NAME);
     Assertions.assertTrue(catalogsPage.verifyShowTableTitle(TABLE_TABLE_TITLE));
     Assertions.assertTrue(catalogsPage.verifyTableColumns());
     Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(COLUMN_NAME, true));
@@ -377,7 +499,7 @@ public class CatalogsPageTest extends AbstractWebIT {
     Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(COLUMN_NAME, true));
     List<String> treeNodes =
         Arrays.asList(
-            MODIFIED_CATALOG_NAME,
+            MODIFIED_HIVE_CATALOG_NAME,
             SCHEMA_NAME,
             TABLE_NAME,
             ICEBERG_CATALOG_NAME,
@@ -395,44 +517,59 @@ public class CatalogsPageTest extends AbstractWebIT {
     Assertions.assertTrue(catalogsPage.verifyEmptyCatalog());
 
     catalogsPage.metalakeSelectChange(METALAKE_NAME);
-    Assertions.assertTrue(catalogsPage.verifyGetCatalog(MODIFIED_CATALOG_NAME));
+    Assertions.assertTrue(catalogsPage.verifyGetCatalog(MODIFIED_HIVE_CATALOG_NAME));
   }
 
   @Test
   @Order(18)
   public void testClickTreeList() throws InterruptedException {
     String icebergNode =
-        String.format("{{%s}}{{%s}}{{%s}}", METALAKE_NAME, ICEBERG_CATALOG_NAME, CATALOG_TYPE);
+        String.format(
+            "{{%s}}{{%s}}{{%s}}", METALAKE_NAME, ICEBERG_CATALOG_NAME, CATALOG_TYPE_RELATIONAL);
     catalogsPage.clickTreeNode(icebergNode);
     Assertions.assertTrue(catalogsPage.verifyGetCatalog(ICEBERG_CATALOG_NAME));
     String mysqlNode =
-        String.format("{{%s}}{{%s}}{{%s}}", METALAKE_NAME, MYSQL_CATALOG_NAME, CATALOG_TYPE);
+        String.format(
+            "{{%s}}{{%s}}{{%s}}", METALAKE_NAME, MYSQL_CATALOG_NAME, CATALOG_TYPE_RELATIONAL);
     catalogsPage.clickTreeNode(mysqlNode);
     Assertions.assertTrue(catalogsPage.verifyGetCatalog(MYSQL_CATALOG_NAME));
     String pgNode =
-        String.format("{{%s}}{{%s}}{{%s}}", METALAKE_NAME, PG_CATALOG_NAME, CATALOG_TYPE);
+        String.format(
+            "{{%s}}{{%s}}{{%s}}", METALAKE_NAME, PG_CATALOG_NAME, CATALOG_TYPE_RELATIONAL);
     catalogsPage.clickTreeNode(pgNode);
     Assertions.assertTrue(catalogsPage.verifyGetCatalog(PG_CATALOG_NAME));
     String filesetNode =
-        String.format("{{%s}}{{%s}}{{%s}}", METALAKE_NAME, FILESET_CATALOG_NAME, "fileset");
+        String.format(
+            "{{%s}}{{%s}}{{%s}}", METALAKE_NAME, FILESET_CATALOG_NAME, CATALOG_TYPE_FILESET);
     catalogsPage.clickTreeNode(filesetNode);
     Assertions.assertTrue(catalogsPage.verifyGetCatalog(FILESET_CATALOG_NAME));
+    String kafkaNode =
+        String.format(
+            "{{%s}}{{%s}}{{%s}}", METALAKE_NAME, KAFKA_CATALOG_NAME, CATALOG_TYPE_MESSAGING);
+    catalogsPage.clickTreeNode(kafkaNode);
+    Assertions.assertTrue(catalogsPage.verifyGetCatalog(KAFKA_CATALOG_NAME));
     String hiveNode =
-        String.format("{{%s}}{{%s}}{{%s}}", METALAKE_NAME, MODIFIED_CATALOG_NAME, CATALOG_TYPE);
+        String.format(
+            "{{%s}}{{%s}}{{%s}}",
+            METALAKE_NAME, MODIFIED_HIVE_CATALOG_NAME, CATALOG_TYPE_RELATIONAL);
     catalogsPage.clickTreeNode(hiveNode);
     Assertions.assertTrue(catalogsPage.verifyShowTableTitle(CATALOG_TABLE_TITLE));
-    Assertions.assertTrue(catalogsPage.verifyGetCatalog(MODIFIED_CATALOG_NAME));
+    Assertions.assertTrue(catalogsPage.verifyGetCatalog(MODIFIED_HIVE_CATALOG_NAME));
     String schemaNode =
         String.format(
             "{{%s}}{{%s}}{{%s}}{{%s}}",
-            METALAKE_NAME, MODIFIED_CATALOG_NAME, CATALOG_TYPE, SCHEMA_NAME);
+            METALAKE_NAME, MODIFIED_HIVE_CATALOG_NAME, CATALOG_TYPE_RELATIONAL, SCHEMA_NAME);
     catalogsPage.clickTreeNode(schemaNode);
     Assertions.assertTrue(catalogsPage.verifyShowTableTitle(SCHEMA_TABLE_TITLE));
     Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(TABLE_NAME, false));
     String tableNode =
         String.format(
             "{{%s}}{{%s}}{{%s}}{{%s}}{{%s}}",
-            METALAKE_NAME, MODIFIED_CATALOG_NAME, CATALOG_TYPE, SCHEMA_NAME, TABLE_NAME);
+            METALAKE_NAME,
+            MODIFIED_HIVE_CATALOG_NAME,
+            CATALOG_TYPE_RELATIONAL,
+            SCHEMA_NAME,
+            TABLE_NAME);
     catalogsPage.clickTreeNode(tableNode);
     Assertions.assertTrue(catalogsPage.verifyShowTableTitle(TABLE_TABLE_TITLE));
     Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(COLUMN_NAME, true));
@@ -443,19 +580,25 @@ public class CatalogsPageTest extends AbstractWebIT {
   @Order(19)
   public void testTreeNodeRefresh() throws InterruptedException {
     createTableAndColumn(
-        METALAKE_NAME, MODIFIED_CATALOG_NAME, SCHEMA_NAME, TABLE_NAME_2, COLUMN_NAME_2);
+        METALAKE_NAME, MODIFIED_HIVE_CATALOG_NAME, SCHEMA_NAME, TABLE_NAME_2, COLUMN_NAME_2);
     String hiveNode =
-        String.format("{{%s}}{{%s}}{{%s}}", METALAKE_NAME, MODIFIED_CATALOG_NAME, CATALOG_TYPE);
+        String.format(
+            "{{%s}}{{%s}}{{%s}}",
+            METALAKE_NAME, MODIFIED_HIVE_CATALOG_NAME, CATALOG_TYPE_RELATIONAL);
     catalogsPage.clickTreeNode(hiveNode);
     String schemaNode =
         String.format(
             "{{%s}}{{%s}}{{%s}}{{%s}}",
-            METALAKE_NAME, MODIFIED_CATALOG_NAME, CATALOG_TYPE, SCHEMA_NAME);
+            METALAKE_NAME, MODIFIED_HIVE_CATALOG_NAME, CATALOG_TYPE_RELATIONAL, SCHEMA_NAME);
     catalogsPage.clickTreeNodeRefresh(schemaNode);
     String tableNode =
         String.format(
             "{{%s}}{{%s}}{{%s}}{{%s}}{{%s}}",
-            METALAKE_NAME, MODIFIED_CATALOG_NAME, CATALOG_TYPE, SCHEMA_NAME, TABLE_NAME_2);
+            METALAKE_NAME,
+            MODIFIED_HIVE_CATALOG_NAME,
+            CATALOG_TYPE_RELATIONAL,
+            SCHEMA_NAME,
+            TABLE_NAME_2);
     catalogsPage.clickTreeNode(tableNode);
     Assertions.assertTrue(catalogsPage.verifyShowTableTitle(TABLE_TABLE_TITLE));
     Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(COLUMN_NAME_2, true));
@@ -464,6 +607,141 @@ public class CatalogsPageTest extends AbstractWebIT {
 
   @Test
   @Order(20)
+  public void testViewFilesetCatalog() throws InterruptedException {
+    // 1. back to the list catalog of metalake
+    catalogsPage.clickMetalakeLink(METALAKE_NAME);
+    // 2. create schema and fileset of fileset catalog
+    createSchema(METALAKE_NAME, FILESET_CATALOG_NAME, SCHEMA_NAME_FILESET);
+    createFileset(METALAKE_NAME, FILESET_CATALOG_NAME, SCHEMA_NAME_FILESET, FILESET_NAME);
+    // 3. click fileset catalog tree node
+    String filesetCatalogNode =
+        String.format(
+            "{{%s}}{{%s}}{{%s}}", METALAKE_NAME, FILESET_CATALOG_NAME, CATALOG_TYPE_FILESET);
+    catalogsPage.clickTreeNode(filesetCatalogNode);
+    // 4. verify show table title、 schema name and tree node
+    Assertions.assertTrue(catalogsPage.verifyShowTableTitle(CATALOG_TABLE_TITLE));
+    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(SCHEMA_NAME_FILESET));
+    List<String> treeNodes =
+        Arrays.asList(
+            MODIFIED_HIVE_CATALOG_NAME,
+            ICEBERG_CATALOG_NAME,
+            MYSQL_CATALOG_NAME,
+            PG_CATALOG_NAME,
+            FILESET_CATALOG_NAME,
+            SCHEMA_NAME_FILESET,
+            KAFKA_CATALOG_NAME);
+    Assertions.assertTrue(catalogsPage.verifyTreeNodes(treeNodes));
+    // 5. click schema tree node
+    String filesetSchemaNode =
+        String.format(
+            "{{%s}}{{%s}}{{%s}}{{%s}}",
+            METALAKE_NAME, FILESET_CATALOG_NAME, CATALOG_TYPE_FILESET, SCHEMA_NAME_FILESET);
+    catalogsPage.clickTreeNode(filesetSchemaNode);
+    // 6. verify show table title、 fileset name and tree node
+    Assertions.assertTrue(catalogsPage.verifyShowTableTitle(SCHEMA_FILESET_TITLE));
+    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(FILESET_NAME));
+    treeNodes =
+        Arrays.asList(
+            MODIFIED_HIVE_CATALOG_NAME,
+            ICEBERG_CATALOG_NAME,
+            MYSQL_CATALOG_NAME,
+            PG_CATALOG_NAME,
+            FILESET_CATALOG_NAME,
+            SCHEMA_NAME_FILESET,
+            FILESET_NAME,
+            KAFKA_CATALOG_NAME);
+    Assertions.assertTrue(catalogsPage.verifyTreeNodes(treeNodes));
+    // 7. click fileset tree node
+    String filesetNode =
+        String.format(
+            "{{%s}}{{%s}}{{%s}}{{%s}}{{%s}}",
+            METALAKE_NAME,
+            FILESET_CATALOG_NAME,
+            CATALOG_TYPE_FILESET,
+            SCHEMA_NAME_FILESET,
+            FILESET_NAME);
+    catalogsPage.clickTreeNode(filesetNode);
+    // 8. verify show tab details
+    Assertions.assertTrue(catalogsPage.verifyShowDetailsContent());
+    Assertions.assertTrue(
+        catalogsPage.verifyShowPropertiesItemInList(
+            "key", PROPERTIES_KEY1, PROPERTIES_KEY1, false));
+    Assertions.assertTrue(
+        catalogsPage.verifyShowPropertiesItemInList(
+            "value", PROPERTIES_KEY1, PROPERTIES_VALUE1, false));
+  }
+
+  @Test
+  @Order(21)
+  public void testViewKafkaCatalog() throws InterruptedException {
+    // 1. back to the list catalog of metalake
+    catalogsPage.metalakeSelectChange(METALAKE_SELECT_NAME);
+    Assertions.assertTrue(catalogsPage.verifyEmptyCatalog());
+
+    catalogsPage.metalakeSelectChange(METALAKE_NAME);
+    // 2. create topic of kafka catalog
+    createTopic(METALAKE_NAME, KAFKA_CATALOG_NAME, SCHEMA_NAME, TOPIC_NAME);
+    // 3. click kafka catalog tree node
+    String kafkaCatalogNode =
+        String.format(
+            "{{%s}}{{%s}}{{%s}}", METALAKE_NAME, KAFKA_CATALOG_NAME, CATALOG_TYPE_MESSAGING);
+    catalogsPage.clickTreeNode(kafkaCatalogNode);
+    // 4. verify show table title、 schema name and tree node
+    Assertions.assertTrue(catalogsPage.verifyShowTableTitle(CATALOG_TABLE_TITLE));
+    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(SCHEMA_NAME));
+    List<String> treeNodes =
+        Arrays.asList(
+            MODIFIED_HIVE_CATALOG_NAME,
+            ICEBERG_CATALOG_NAME,
+            MYSQL_CATALOG_NAME,
+            PG_CATALOG_NAME,
+            FILESET_CATALOG_NAME,
+            KAFKA_CATALOG_NAME,
+            SCHEMA_NAME);
+    Assertions.assertTrue(catalogsPage.verifyTreeNodes(treeNodes));
+    // 5. click schema tree node
+    String kafkaSchemaNode =
+        String.format(
+            "{{%s}}{{%s}}{{%s}}{{%s}}",
+            METALAKE_NAME, KAFKA_CATALOG_NAME, CATALOG_TYPE_MESSAGING, SCHEMA_NAME);
+    catalogsPage.clickTreeNode(kafkaSchemaNode);
+    // 6. verify show table title、 fileset name and tree node
+    Assertions.assertTrue(catalogsPage.verifyShowTableTitle(SCHEMA_TOPIC_TITLE));
+    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(TOPIC_NAME));
+    treeNodes =
+        Arrays.asList(
+            MODIFIED_HIVE_CATALOG_NAME,
+            ICEBERG_CATALOG_NAME,
+            MYSQL_CATALOG_NAME,
+            PG_CATALOG_NAME,
+            FILESET_CATALOG_NAME,
+            KAFKA_CATALOG_NAME,
+            SCHEMA_NAME,
+            TOPIC_NAME);
+    Assertions.assertTrue(catalogsPage.verifyTreeNodes(treeNodes));
+    // 7. click fileset tree node
+    String filesetNode =
+        String.format(
+            "{{%s}}{{%s}}{{%s}}{{%s}}{{%s}}",
+            METALAKE_NAME, KAFKA_CATALOG_NAME, CATALOG_TYPE_MESSAGING, SCHEMA_NAME, TOPIC_NAME);
+    catalogsPage.clickTreeNode(filesetNode);
+    // 8. verify show tab details
+    Assertions.assertTrue(catalogsPage.verifyShowDetailsContent());
+    // 9. verify show highlight properties
+    Assertions.assertTrue(
+        catalogsPage.verifyShowPropertiesItemInList(
+            "key", "partition-count", "partition-count", true));
+    Assertions.assertTrue(
+        catalogsPage.verifyShowPropertiesItemInList("value", "partition-count", "1", true));
+    Assertions.assertTrue(
+        catalogsPage.verifyShowPropertiesItemInList(
+            "key", "replication-factor", "replication-factor", true));
+    Assertions.assertTrue(
+        catalogsPage.verifyShowPropertiesItemInList("value", "replication-factor", "1", true));
+  }
+
+  @Test
+  @Order(22)
   public void testBackHomePage() throws InterruptedException {
     clickAndWait(catalogsPage.backHomeBtn);
     Assertions.assertTrue(catalogsPage.verifyBackHomePage());

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
@@ -11,7 +11,6 @@ import com.datastrato.gravitino.client.GravitinoAdminClient;
 import com.datastrato.gravitino.client.GravitinoMetalake;
 import com.datastrato.gravitino.file.Fileset;
 import com.datastrato.gravitino.integration.test.container.ContainerSuite;
-import com.datastrato.gravitino.integration.test.container.HiveContainer;
 import com.datastrato.gravitino.integration.test.container.TrinoITContainers;
 import com.datastrato.gravitino.integration.test.util.AbstractIT;
 import com.datastrato.gravitino.integration.test.web.ui.pages.CatalogsPage;
@@ -40,7 +39,7 @@ public class CatalogsPageTest extends AbstractWebIT {
   CatalogsPage catalogsPage = new CatalogsPage();
 
   protected static TrinoITContainers trinoITContainers;
-  private static final ContainerSuite containerSuite = ContainerSuite.getInstance();
+  // private static final ContainerSuite containerSuite = ContainerSuite.getInstance();
   protected static GravitinoAdminClient gravitinoClient;
   private static GravitinoMetalake metalake;
   private static Catalog catalog;
@@ -108,7 +107,10 @@ public class CatalogsPageTest extends AbstractWebIT {
     mysqlUri = trinoITContainers.getMysqlUri();
     postgresqlUri = trinoITContainers.getPostgresqlUri();
 
-    containerSuite.startHiveContainer();
+    // containerSuite.startKafkaContainer();
+
+    // String address = containerSuite.getKafkaContainer().getContainerIpAddress();
+    // kafkaUri = String.format("%s:%s", address, "9092");
   }
 
   /**
@@ -163,9 +165,8 @@ public class CatalogsPageTest extends AbstractWebIT {
     if (defaultBaseLocation == null) {
       defaultBaseLocation =
           String.format(
-              "hdfs://%s:%d/user/hadoop/%s.db",
-              containerSuite.getHiveContainer().getContainerIpAddress(),
-              HiveContainer.HDFS_DEFAULTFS_PORT,
+              "%s/user/hadoop/%s.db",
+              hdfsUri,
               schemaName.toLowerCase());
     }
     return defaultBaseLocation;

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
@@ -39,7 +39,7 @@ public class CatalogsPageTest extends AbstractWebIT {
   CatalogsPage catalogsPage = new CatalogsPage();
 
   protected static TrinoITContainers trinoITContainers;
-  // private static final ContainerSuite containerSuite = ContainerSuite.getInstance();
+  private static final ContainerSuite containerSuite = ContainerSuite.getInstance();
   protected static GravitinoAdminClient gravitinoClient;
   private static GravitinoMetalake metalake;
   private static Catalog catalog;
@@ -107,10 +107,10 @@ public class CatalogsPageTest extends AbstractWebIT {
     mysqlUri = trinoITContainers.getMysqlUri();
     postgresqlUri = trinoITContainers.getPostgresqlUri();
 
-    // containerSuite.startKafkaContainer();
+    containerSuite.startKafkaContainer();
 
-    // String address = containerSuite.getKafkaContainer().getContainerIpAddress();
-    // kafkaUri = String.format("%s:%s", address, "9092");
+    String address = containerSuite.getKafkaContainer().getContainerIpAddress();
+    kafkaUri = String.format("%s:%s", address, "9092");
   }
 
   /**
@@ -634,7 +634,7 @@ public class CatalogsPageTest extends AbstractWebIT {
     catalogsPage.clickTreeNode(filesetCatalogNode);
     // 4. verify show table title、 schema name and tree node
     Assertions.assertTrue(catalogsPage.verifyShowTableTitle(CATALOG_TABLE_TITLE));
-    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(SCHEMA_NAME_FILESET));
+    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(SCHEMA_NAME_FILESET, false));
     List<String> treeNodes =
         Arrays.asList(
             MODIFIED_HIVE_CATALOG_NAME,
@@ -653,7 +653,7 @@ public class CatalogsPageTest extends AbstractWebIT {
     catalogsPage.clickTreeNode(filesetSchemaNode);
     // 6. verify show table title、 fileset name and tree node
     Assertions.assertTrue(catalogsPage.verifyShowTableTitle(SCHEMA_FILESET_TITLE));
-    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(FILESET_NAME));
+    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(FILESET_NAME, false));
     treeNodes =
         Arrays.asList(
             MODIFIED_HIVE_CATALOG_NAME,
@@ -702,7 +702,7 @@ public class CatalogsPageTest extends AbstractWebIT {
     catalogsPage.clickTreeNode(kafkaCatalogNode);
     // 4. verify show table title、 schema name and tree node
     Assertions.assertTrue(catalogsPage.verifyShowTableTitle(CATALOG_TABLE_TITLE));
-    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(SCHEMA_NAME));
+    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(SCHEMA_NAME, false));
     List<String> treeNodes =
         Arrays.asList(
             MODIFIED_HIVE_CATALOG_NAME,
@@ -721,7 +721,7 @@ public class CatalogsPageTest extends AbstractWebIT {
     catalogsPage.clickTreeNode(kafkaSchemaNode);
     // 6. verify show table title、 fileset name and tree node
     Assertions.assertTrue(catalogsPage.verifyShowTableTitle(SCHEMA_TOPIC_TITLE));
-    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(TOPIC_NAME));
+    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(TOPIC_NAME, false));
     treeNodes =
         Arrays.asList(
             MODIFIED_HIVE_CATALOG_NAME,

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
@@ -227,6 +227,23 @@ public class CatalogsPageTest extends AbstractWebIT {
             Collections.emptyMap());
   }
 
+  /**
+   * Drops a Kafka topic from the specified Metalake, Catalog, and Schema.
+   *
+   * @param metalakeName The name of the Metalake where the topic resides.
+   * @param catalogName The name of the Catalog that contains the topic.
+   * @param schemaName The name of the Schema under which the topic exists.
+   * @param topicName The name of the Kafka topic to be dropped.
+   */
+  void dropTopic(String metalakeName, String catalogName, String schemaName, String topicName) {
+    Catalog catalog_kafka =
+        metalake.loadCatalog(NameIdentifier.ofCatalog(metalakeName, catalogName));
+    catalog_kafka
+        .asTopicCatalog()
+        .dropTopic(
+            NameIdentifier.of(metalakeName, catalogName, schemaName, topicName));
+  }
+
   @AfterAll
   public static void after() {
     try {
@@ -738,6 +755,8 @@ public class CatalogsPageTest extends AbstractWebIT {
             "key", "replication-factor", "replication-factor", true));
     Assertions.assertTrue(
         catalogsPage.verifyShowPropertiesItemInList("value", "replication-factor", "1", true));
+    // 10. delete topic of kafka catalog
+    dropTopic(METALAKE_NAME, KAFKA_CATALOG_NAME, SCHEMA_NAME, TOPIC_NAME);
   }
 
   @Test

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
@@ -526,7 +526,7 @@ public class CatalogsPageTest extends AbstractWebIT {
 
   @Test
   @Order(17)
-  public void testRelationalCatalogTreeNode() throws InterruptedException {
+  public void testRelationalHiveCatalogTreeNode() throws InterruptedException {
     String hiveNode =
         String.format(
             "{{%s}}{{%s}}{{%s}}",
@@ -586,6 +586,26 @@ public class CatalogsPageTest extends AbstractWebIT {
 
   @Test
   @Order(19)
+  public void testOrtherRelationaCatalogTreeNode() throws InterruptedException {
+    String icebergNode =
+        String.format(
+            "{{%s}}{{%s}}{{%s}}", METALAKE_NAME, ICEBERG_CATALOG_NAME, CATALOG_TYPE_RELATIONAL);
+    catalogsPage.clickTreeNode(icebergNode);
+    Assertions.assertTrue(catalogsPage.verifyGetCatalog(ICEBERG_CATALOG_NAME));
+    String mysqlNode =
+        String.format(
+            "{{%s}}{{%s}}{{%s}}", METALAKE_NAME, MYSQL_CATALOG_NAME, CATALOG_TYPE_RELATIONAL);
+    catalogsPage.clickTreeNode(mysqlNode);
+    Assertions.assertTrue(catalogsPage.verifyGetCatalog(MYSQL_CATALOG_NAME));
+    String pgNode =
+        String.format(
+            "{{%s}}{{%s}}{{%s}}", METALAKE_NAME, PG_CATALOG_NAME, CATALOG_TYPE_RELATIONAL);
+    catalogsPage.clickTreeNode(pgNode);
+    Assertions.assertTrue(catalogsPage.verifyGetCatalog(PG_CATALOG_NAME));
+  }
+
+  @Test
+  @Order(20)
   public void testFilesetCatalogTreeNode() throws InterruptedException {
     // 1. back to the list catalog of metalake
     catalogsPage.clickMetalakeLink(METALAKE_NAME);
@@ -651,7 +671,7 @@ public class CatalogsPageTest extends AbstractWebIT {
   }
 
   @Test
-  @Order(20)
+  @Order(21)
   public void testKafkaCatalogTreeNode() throws InterruptedException {
     // 1. back to the list catalog of metalake
     catalogsPage.metalakeSelectChange(METALAKE_SELECT_NAME);
@@ -719,26 +739,6 @@ public class CatalogsPageTest extends AbstractWebIT {
         catalogsPage.verifyShowPropertiesItemInList("value", "replication-factor", "1", true));
     // 10. delete topic of kafka catalog
     dropTopic(METALAKE_NAME, KAFKA_CATALOG_NAME, SCHEMA_NAME, TOPIC_NAME);
-  }
-
-  @Test
-  @Order(21)
-  public void testOrtherCatalogTreeNode() throws InterruptedException {
-    String icebergNode =
-        String.format(
-            "{{%s}}{{%s}}{{%s}}", METALAKE_NAME, ICEBERG_CATALOG_NAME, CATALOG_TYPE_RELATIONAL);
-    catalogsPage.clickTreeNode(icebergNode);
-    Assertions.assertTrue(catalogsPage.verifyGetCatalog(ICEBERG_CATALOG_NAME));
-    String mysqlNode =
-        String.format(
-            "{{%s}}{{%s}}{{%s}}", METALAKE_NAME, MYSQL_CATALOG_NAME, CATALOG_TYPE_RELATIONAL);
-    catalogsPage.clickTreeNode(mysqlNode);
-    Assertions.assertTrue(catalogsPage.verifyGetCatalog(MYSQL_CATALOG_NAME));
-    String pgNode =
-        String.format(
-            "{{%s}}{{%s}}{{%s}}", METALAKE_NAME, PG_CATALOG_NAME, CATALOG_TYPE_RELATIONAL);
-    catalogsPage.clickTreeNode(pgNode);
-    Assertions.assertTrue(catalogsPage.verifyGetCatalog(PG_CATALOG_NAME));
   }
 
   @Test

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
@@ -520,7 +520,7 @@ public class CatalogsPageTest extends AbstractWebIT {
 
   @Test
   @Order(18)
-  public void testOrtherRelationaCatalogTreeNode() throws InterruptedException {
+  public void testOtherRelationaCatalogTreeNode() throws InterruptedException {
     String icebergNode =
         String.format(
             "{{%s}}{{%s}}{{%s}}", METALAKE_NAME, ICEBERG_CATALOG_NAME, CATALOG_TYPE_RELATIONAL);

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
@@ -201,6 +201,18 @@ public class CatalogsPage extends AbstractWebIT {
     }
   }
 
+  public void clickMetalakeLink(String metalakeName) {
+    try {
+      String xpath = "//a[@href='?metalake=" + metalakeName + "']";
+      WebElement link = tableGrid.findElement(By.xpath(xpath));
+      WebDriverWait wait = new WebDriverWait(driver, MAX_TIMEOUT);
+      wait.until(ExpectedConditions.elementToBeClickable(By.xpath(xpath)));
+      clickAndWait(link);
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+    }
+  }
+
   public void clickCatalogLink(String metalakeName, String catalogName, String catalogType) {
     try {
       String xpath =
@@ -443,6 +455,40 @@ public class CatalogsPage extends AbstractWebIT {
         LOG.error("table title: {} does not match with title: {}", text.getText(), title);
         return false;
       }
+      return true;
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      return false;
+    }
+  }
+
+  /**
+   * Verifies if a given property item is present in a specified list.
+   *
+   * @param item The key or value item of the property.
+   * @param key The key of the property.
+   * @param value The value of key item of the property.
+   * @param isHighlight Whether to highlight the property item or not.
+   * @return True if the property item is found in the list, false otherwise.
+   */
+  public boolean verifyShowPropertiesItemInList(
+      String item, String key, String value, Boolean isHighlight) {
+    try {
+      Thread.sleep(ACTION_SLEEP_MILLIS);
+      String xpath;
+      if (isHighlight) {
+        xpath = "//div[@data-refer='props-" + item + "-" + key + "-highlight']";
+      } else {
+        xpath = "//div[@data-refer='props-" + item + "-" + key + "']";
+      }
+      WebElement propertyElement = driver.findElement(By.xpath(xpath));
+      boolean match = Objects.equals(propertyElement.getText(), value);
+
+      if (!match) {
+        LOG.error("Prop: does not include itemName: {}", value);
+        return false;
+      }
+
       return true;
     } catch (Exception e) {
       LOG.error(e.getMessage(), e);

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
@@ -427,7 +427,7 @@ public class CatalogsPage extends AbstractWebIT {
     }
   }
 
-  public boolean verifyEmptyCatalog() {
+  public boolean verifyEmptyTableData() {
     try {
       // Check is empty table
       boolean isNoRows = waitShowText("No rows", tableWrapper);

--- a/integration-test/src/test/resources/run
+++ b/integration-test/src/test/resources/run
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is originally from the official Kafka docker image container `/etc/kafka/docker/run`
+# and has been modified to be used to modify the Kafka configuration `advertised.listeners` to use the container's IP address
+IP=$(hostname -i)
+export KAFKA_ADVERTISED_LISTENERS="PLAINTEXT://$IP:$DEFAULT_BROKER_PORT"
+echo "KAFKA_ADVERTISED_LISTENERS is set to $KAFKA_ADVERTISED_LISTENERS"
+
+
+. /etc/kafka/docker/bash-config
+
+# Set environment values if they exist as arguments
+if [ $# -ne 0 ]; then
+  echo "===> Overriding env params with args ..."
+  for var in "$@"
+  do
+    export "$var"
+  done
+fi
+
+echo "===> User"
+id
+
+echo "===> Setting default values of environment variables if not already set."
+. /etc/kafka/docker/configureDefaults
+
+echo "===> Configuring ..."
+. /etc/kafka/docker/configure
+
+echo "===> Launching ... "
+. /etc/kafka/docker/launch

--- a/web/src/app/metalakes/metalake/rightContent/tabsContent/detailsView/DetailsView.js
+++ b/web/src/app/metalakes/metalake/rightContent/tabsContent/detailsView/DetailsView.js
@@ -130,7 +130,7 @@ const DetailsView = () => {
             Properties
           </Typography>
 
-          <TableContainer>
+          <TableContainer data-refer='details-table-grid'>
             <Table>
               <TableHead
                 sx={{
@@ -155,7 +155,15 @@ const DetailsView = () => {
                                 : 400
                           }}
                         >
-                          {item.key}
+                          <div
+                            data-refer={
+                              searchParams.get('topic') && ['partition-count', 'replication-factor'].includes(item.key)
+                                ? `props-key-${item.key}-highlight`
+                                : `props-key-${item.key}`
+                            }
+                          >
+                            {item.key}
+                          </div>
                         </Typography>
                       </TableCell>
                       <TableCell sx={{ py: theme => `${theme.spacing(2.75)} !important` }}>
@@ -167,7 +175,15 @@ const DetailsView = () => {
                                 : 400
                           }}
                         >
-                          {item.value}
+                          <div
+                            data-refer={
+                              searchParams.get('topic') && ['partition-count', 'replication-factor'].includes(item.key)
+                                ? `props-value-${item.key}-highlight`
+                                : `props-value-${item.key}`
+                            }
+                          >
+                            {item.value}
+                          </div>
                         </Typography>
                       </TableCell>
                     </TableRow>


### PR DESCRIPTION
…a topic level

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Improvement of fileset and kafka test case

### Why are the changes needed?

Fix: #2896

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
<img width="340" alt="image" src="https://github.com/datastrato/gravitino/assets/9210625/520204d9-2d5b-4050-b020-ad47275d2469">