### PR TITLE
[#2910] improvement(filesystem-hadoop3): Make `getWorkingDirectory` method synchronized

### DIFF
--- a/clients/filesystem-hadoop3/src/main/java/com/datastrato/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
+++ b/clients/filesystem-hadoop3/src/main/java/com/datastrato/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
@@ -118,7 +118,7 @@ public class GravitinoVirtualFileSystem extends FileSystem {
             .removalListener(
                 (key, value, cause) -> {
                   try {
-                    Pair<Fileset, FileSystem> pair = ((Pair<Fileset, FileSystem>) value);
+                    Pair<Fileset, FileSystem> pair = (Pair<Fileset, FileSystem>) value;
                     if (pair != null && pair.getRight() != null) pair.getRight().close();
                   } catch (IOException e) {
                     Logger.error("Cannot close the file system for fileset: {}", key, e);
@@ -360,7 +360,7 @@ public class GravitinoVirtualFileSystem extends FileSystem {
   }
 
   @Override
-  public Path getWorkingDirectory() {
+  public synchronized Path getWorkingDirectory() {
     return this.workingDirectory;
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make `getWorkingDirectory` method synchronized to avoid some concurrent issues.

### Why are the changes needed?

Fix: #2910
