### PR TITLE
[#2634] fix(jdbc-mysql): Fix the backquote issues in drop schema

### DIFF
--- a/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlDatabaseOperations.java
@@ -67,7 +67,7 @@ public class MysqlDatabaseOperations extends JdbcDatabaseOperations {
     }
 
     try (final Connection connection = this.dataSource.getConnection()) {
-      String query = "SHOW TABLES IN " + databaseName;
+      String query = "SHOW TABLES IN `" + databaseName + "`";
       try (Statement statement = connection.createStatement()) {
         // Execute the query and check if there exists any tables in the database
         try (ResultSet resultSet = statement.executeQuery(query)) {

--- a/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/TestMysqlDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/TestMysqlDatabaseOperations.java
@@ -6,10 +6,17 @@ package com.datastrato.gravitino.catalog.mysql.integration.test;
 
 import static com.datastrato.gravitino.catalog.mysql.operation.MysqlDatabaseOperations.SYS_MYSQL_DATABASE_NAMES;
 
+import com.datastrato.gravitino.catalog.jdbc.JdbcColumn;
+import com.datastrato.gravitino.rel.expressions.distributions.Distributions;
+import com.datastrato.gravitino.rel.expressions.transforms.Transform;
+import com.datastrato.gravitino.rel.indexes.Index;
+import com.datastrato.gravitino.rel.types.Types;
 import com.datastrato.gravitino.utils.RandomNameUtils;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -28,5 +35,38 @@ public class TestMysqlDatabaseOperations extends TestMysqlAbstractIT {
         sysMysqlDatabaseName -> Assertions.assertFalse(databases.contains(sysMysqlDatabaseName)));
     testBaseOperation(databaseName, properties, comment);
     testDropDatabase(databaseName);
+  }
+
+  @Test
+  void testDropTableWithSpecificName() {
+    String databaseName = RandomNameUtils.genRandomName("ct_db") + "-abc-" + "end";
+    Map<String, String> properties = new HashMap<>();
+    DATABASE_OPERATIONS.create(databaseName, null, properties);
+    DATABASE_OPERATIONS.delete(databaseName, false);
+
+    databaseName = RandomNameUtils.genRandomName("ct_db") + "--------end";
+    DATABASE_OPERATIONS.create(databaseName, null, properties);
+
+    String tableName = RandomStringUtils.randomAlphabetic(16) + "_op_table";
+    String tableComment = "test_comment";
+    List<JdbcColumn> columns = new ArrayList<>();
+    columns.add(
+        JdbcColumn.builder()
+            .withName("col_1")
+            .withType(Types.VarCharType.of(100))
+            .withComment("test_comment")
+            .withNullable(true)
+            .build());
+
+    TABLE_OPERATIONS.create(
+        databaseName,
+        tableName,
+        columns.toArray(new JdbcColumn[0]),
+        tableComment,
+        properties,
+        new Transform[0],
+        Distributions.NONE,
+        new Index[0]);
+    DATABASE_OPERATIONS.delete(databaseName, true);
   }
 }


### PR DESCRIPTION


### What changes were proposed in this pull request?

Backquote the schema(database) name when dropping it. 

### Why are the changes needed?

We must backquote the name if the name contains special character like `%`, '-', '/' and so on.

Fix: #2634

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?


Add new IT `testDropTableWithSpecificName`.
