### PR TITLE
[#2861][#2963][#2974] improve(web): add table properties and fileset fields displaying

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
@@ -296,7 +296,7 @@ public class CatalogsPageTest extends AbstractWebIT {
   public void testClickCatalogLink() {
     catalogsPage.clickCatalogLink(METALAKE_NAME, MODIFIED_CATALOG_NAME, CATALOG_TYPE);
     Assertions.assertTrue(catalogsPage.verifyShowTableTitle(CATALOG_TABLE_TITLE));
-    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(SCHEMA_NAME));
+    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(SCHEMA_NAME, false));
     Assertions.assertTrue(catalogsPage.verifySelectedNode(MODIFIED_CATALOG_NAME));
   }
 
@@ -306,7 +306,7 @@ public class CatalogsPageTest extends AbstractWebIT {
     driver.navigate().refresh();
     Assertions.assertEquals(driver.getTitle(), WEB_TITLE);
     Assertions.assertTrue(catalogsPage.verifyShowTableTitle(CATALOG_TABLE_TITLE));
-    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(SCHEMA_NAME));
+    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(SCHEMA_NAME, false));
     List<String> treeNodes =
         Arrays.asList(
             MODIFIED_CATALOG_NAME,
@@ -329,7 +329,7 @@ public class CatalogsPageTest extends AbstractWebIT {
         METALAKE_NAME, MODIFIED_CATALOG_NAME, SCHEMA_NAME, TABLE_NAME, COLUMN_NAME);
     catalogsPage.clickSchemaLink(METALAKE_NAME, MODIFIED_CATALOG_NAME, CATALOG_TYPE, SCHEMA_NAME);
     Assertions.assertTrue(catalogsPage.verifyShowTableTitle(SCHEMA_TABLE_TITLE));
-    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(TABLE_NAME));
+    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(TABLE_NAME, false));
     Assertions.assertTrue(catalogsPage.verifySelectedNode(SCHEMA_NAME));
   }
 
@@ -339,7 +339,7 @@ public class CatalogsPageTest extends AbstractWebIT {
     driver.navigate().refresh();
     Assertions.assertEquals(driver.getTitle(), WEB_TITLE);
     Assertions.assertTrue(catalogsPage.verifyShowTableTitle(SCHEMA_TABLE_TITLE));
-    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(TABLE_NAME));
+    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(TABLE_NAME, false));
     List<String> treeNodes =
         Arrays.asList(
             MODIFIED_CATALOG_NAME,
@@ -362,7 +362,7 @@ public class CatalogsPageTest extends AbstractWebIT {
         METALAKE_NAME, MODIFIED_CATALOG_NAME, CATALOG_TYPE, SCHEMA_NAME, TABLE_NAME);
     Assertions.assertTrue(catalogsPage.verifyShowTableTitle(TABLE_TABLE_TITLE));
     Assertions.assertTrue(catalogsPage.verifyTableColumns());
-    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(COLUMN_NAME));
+    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(COLUMN_NAME, true));
     Assertions.assertTrue(catalogsPage.verifySelectedNode(TABLE_NAME));
   }
 
@@ -374,7 +374,7 @@ public class CatalogsPageTest extends AbstractWebIT {
     Assertions.assertTrue(catalogsPage.verifyRefreshPage());
     Assertions.assertTrue(catalogsPage.verifyShowTableTitle(TABLE_TABLE_TITLE));
     Assertions.assertTrue(catalogsPage.verifyTableColumns());
-    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(COLUMN_NAME));
+    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(COLUMN_NAME, true));
     List<String> treeNodes =
         Arrays.asList(
             MODIFIED_CATALOG_NAME,
@@ -428,14 +428,14 @@ public class CatalogsPageTest extends AbstractWebIT {
             METALAKE_NAME, MODIFIED_CATALOG_NAME, CATALOG_TYPE, SCHEMA_NAME);
     catalogsPage.clickTreeNode(schemaNode);
     Assertions.assertTrue(catalogsPage.verifyShowTableTitle(SCHEMA_TABLE_TITLE));
-    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(TABLE_NAME));
+    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(TABLE_NAME, false));
     String tableNode =
         String.format(
             "{{%s}}{{%s}}{{%s}}{{%s}}{{%s}}",
             METALAKE_NAME, MODIFIED_CATALOG_NAME, CATALOG_TYPE, SCHEMA_NAME, TABLE_NAME);
     catalogsPage.clickTreeNode(tableNode);
     Assertions.assertTrue(catalogsPage.verifyShowTableTitle(TABLE_TABLE_TITLE));
-    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(COLUMN_NAME));
+    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(COLUMN_NAME, true));
     Assertions.assertTrue(catalogsPage.verifyTableColumns());
   }
 
@@ -458,7 +458,7 @@ public class CatalogsPageTest extends AbstractWebIT {
             METALAKE_NAME, MODIFIED_CATALOG_NAME, CATALOG_TYPE, SCHEMA_NAME, TABLE_NAME_2);
     catalogsPage.clickTreeNode(tableNode);
     Assertions.assertTrue(catalogsPage.verifyShowTableTitle(TABLE_TABLE_TITLE));
-    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(COLUMN_NAME_2));
+    Assertions.assertTrue(catalogsPage.verifyShowDataItemInList(COLUMN_NAME_2, true));
     Assertions.assertTrue(catalogsPage.verifyTableColumns());
   }
 

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
@@ -456,7 +456,7 @@ public class CatalogsPage extends AbstractWebIT {
       List<WebElement> list =
           driver.findElements(
               By.xpath(
-                  "//div[@data-refer='table-grid']//div[contains(@class, 'MuiDataGrid-main')]/div[contains(@class, 'MuiDataGrid-virtualScroller')]/div/div[@role='rowgroup']//div[@data-field='name']"));
+                  "//div[@data-refer='table-grid']//div[contains(@class, 'MuiDataGrid-main')]/div[contains(@class, 'MuiDataGrid-virtualScroller')]/div/div[@role='rowgroup']//div[@data-field='name']//p"));
       List<String> texts = new ArrayList<>();
       for (WebElement element : list) {
         texts.add(element.getText());
@@ -543,7 +543,7 @@ public class CatalogsPage extends AbstractWebIT {
       List<WebElement> list =
           tableGrid.findElements(
               By.xpath(
-                  "./div[contains(@class, 'MuiDataGrid-main')]/div[contains(@class, 'MuiDataGrid-virtualScroller')]/div/div[@role='rowgroup']//div[@data-field='name']"));
+                  "./div[contains(@class, 'MuiDataGrid-main')]/div[contains(@class, 'MuiDataGrid-virtualScroller')]/div/div[@role='rowgroup']//div[@data-field='name']//p"));
       List<String> texts = new ArrayList<>();
       for (WebElement webElement : list) {
         String rowItemColName = webElement.getText();

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
@@ -456,7 +456,7 @@ public class CatalogsPage extends AbstractWebIT {
       List<WebElement> list =
           driver.findElements(
               By.xpath(
-                  "//div[@data-refer='table-grid']//div[contains(@class, 'MuiDataGrid-main')]/div[contains(@class, 'MuiDataGrid-virtualScroller')]/div/div[@role='rowgroup']//div[@data-field='name']//p"));
+                  "//div[@data-refer='table-grid']//div[contains(@class, 'MuiDataGrid-main')]/div[contains(@class, 'MuiDataGrid-virtualScroller')]/div/div[@role='rowgroup']//div[@data-field='name']"));
       List<String> texts = new ArrayList<>();
       for (WebElement element : list) {
         texts.add(element.getText());
@@ -543,7 +543,7 @@ public class CatalogsPage extends AbstractWebIT {
       List<WebElement> list =
           tableGrid.findElements(
               By.xpath(
-                  "./div[contains(@class, 'MuiDataGrid-main')]/div[contains(@class, 'MuiDataGrid-virtualScroller')]/div/div[@role='rowgroup']//div[@data-field='name']//p"));
+                  "./div[contains(@class, 'MuiDataGrid-main')]/div[contains(@class, 'MuiDataGrid-virtualScroller')]/div/div[@role='rowgroup']//div[@data-field='name']"));
       List<String> texts = new ArrayList<>();
       for (WebElement webElement : list) {
         String rowItemColName = webElement.getText();

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
@@ -450,13 +450,15 @@ public class CatalogsPage extends AbstractWebIT {
     }
   }
 
-  public boolean verifyShowDataItemInList(String itemName) {
+  public boolean verifyShowDataItemInList(String itemName, Boolean isColumnLevel) {
     try {
       Thread.sleep(ACTION_SLEEP_MILLIS);
-      List<WebElement> list =
-          driver.findElements(
-              By.xpath(
-                  "//div[@data-refer='table-grid']//div[contains(@class, 'MuiDataGrid-main')]/div[contains(@class, 'MuiDataGrid-virtualScroller')]/div/div[@role='rowgroup']//div[@data-field='name']"));
+      String xpath =
+          "//div[@data-refer='table-grid']//div[contains(@class, 'MuiDataGrid-main')]/div[contains(@class, 'MuiDataGrid-virtualScroller')]/div/div[@role='rowgroup']//div[@data-field='name']";
+      if (isColumnLevel) {
+        xpath = xpath + "//p";
+      }
+      List<WebElement> list = driver.findElements(By.xpath(xpath));
       List<String> texts = new ArrayList<>();
       for (WebElement element : list) {
         texts.add(element.getText());

--- a/web/src/app/login/page.js
+++ b/web/src/app/login/page.js
@@ -62,7 +62,12 @@ const LoginPage = () => {
         <Card sx={{ width: 480 }}>
           <CardContent className={`twc-p-12`}>
             <Box className={`twc-mb-8 twc-flex twc-items-center twc-justify-center`}>
-              <Image src={'/icons/gravitino.svg'} width={24} height={24} alt='logo' />
+              <Image
+                src={`${process.env.NEXT_PUBLIC_BASE_PATH}/icons/gravitino.svg`}
+                width={24}
+                height={24}
+                alt='logo'
+              />
               <Typography variant='h6' className={`twc-ml-2 twc-font-semibold twc-text-[1.5rem] logoText`}>
                 Gravitino
               </Typography>

--- a/web/src/app/metalakes/metalake/MetalakeTree.js
+++ b/web/src/app/metalakes/metalake/MetalakeTree.js
@@ -71,7 +71,7 @@ const MetalakeTree = props => {
       case 'table': {
         if (store.selectedNodes.includes(nodeProps.data.key)) {
           const pathArr = extractPlaceholder(nodeProps.data.key)
-          const [metalake, catalog, schema, table] = pathArr
+          const [metalake, catalog, type, schema, table] = pathArr
           dispatch(getTableDetails({ init: true, metalake, catalog, schema, table }))
         }
         break

--- a/web/src/app/metalakes/metalake/MetalakeTree.js
+++ b/web/src/app/metalakes/metalake/MetalakeTree.js
@@ -58,6 +58,7 @@ const MetalakeTree = props => {
       case 'messaging':
         return 'skill-icons:kafka'
       case 'fileset':
+        return 'mdi:folder-text-outline'
       default:
         return 'bx:book'
     }

--- a/web/src/app/metalakes/metalake/MetalakeTree.js
+++ b/web/src/app/metalakes/metalake/MetalakeTree.js
@@ -58,7 +58,7 @@ const MetalakeTree = props => {
       case 'messaging':
         return 'skill-icons:kafka'
       case 'fileset':
-        return 'mdi:folder-text-outline'
+        return 'twemoji:file-folder'
       default:
         return 'bx:book'
     }

--- a/web/src/app/metalakes/metalake/MetalakeTree.js
+++ b/web/src/app/metalakes/metalake/MetalakeTree.js
@@ -264,6 +264,7 @@ const MetalakeTree = props => {
 
   useEffect(() => {
     dispatch(setExpandedNodes(store.expandedNodes))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [store.metalakeTree, dispatch])
 
   return (

--- a/web/src/app/metalakes/metalake/rightContent/tabsContent/TabsContent.js
+++ b/web/src/app/metalakes/metalake/rightContent/tabsContent/TabsContent.js
@@ -178,13 +178,26 @@ const TabsContent = () => {
                           <ListItemText
                             sx={{ m: 0 }}
                             primary={
-                              <Typography
-                                sx={{ display: 'flex', alignItems: 'center', textTransform: 'capitalize' }}
-                                fontWeight={700}
-                                fontSize={14}
+                              <Box
+                                sx={{
+                                  display: 'flex',
+                                  alignItems: 'center',
+                                  color: theme => theme.palette.text.primary
+                                }}
                               >
-                                {item.type} <Icon icon={item.icon} />
-                              </Typography>
+                                <Typography
+                                  component={'span'}
+                                  textTransform={'capitalize'}
+                                  fontWeight={700}
+                                  fontSize={14}
+                                  sx={{ display: 'inline-block', pr: 2 }}
+                                >
+                                  {item.type}
+                                </Typography>{' '}
+                                <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                                  <Icon icon={item.icon} />
+                                </Box>
+                              </Box>
                             }
                             secondary={
                               <Box

--- a/web/src/app/metalakes/metalake/rightContent/tabsContent/TabsContent.js
+++ b/web/src/app/metalakes/metalake/rightContent/tabsContent/TabsContent.js
@@ -21,7 +21,7 @@ import DetailsView from './detailsView/DetailsView'
 
 import Icon from '@/components/Icon'
 
-const fonts = Inconsolata({})
+const fonts = Inconsolata({ subsets: ['latin'] })
 
 const CustomTab = props => {
   const { icon, label, value, ...others } = props

--- a/web/src/app/metalakes/metalake/rightContent/tabsContent/detailsView/DetailsView.js
+++ b/web/src/app/metalakes/metalake/rightContent/tabsContent/detailsView/DetailsView.js
@@ -42,8 +42,6 @@ const DetailsView = () => {
     })
   }
 
-  console.log(paramsSize)
-
   const renderFieldText = ({ value, linkBreak = false, isDate = false }) => {
     if (!value) {
       return <EmptyText />

--- a/web/src/app/metalakes/metalake/rightContent/tabsContent/detailsView/DetailsView.js
+++ b/web/src/app/metalakes/metalake/rightContent/tabsContent/detailsView/DetailsView.js
@@ -42,6 +42,8 @@ const DetailsView = () => {
     })
   }
 
+  console.log(paramsSize)
+
   const renderFieldText = ({ value, linkBreak = false, isDate = false }) => {
     if (!value) {
       return <EmptyText />
@@ -70,6 +72,22 @@ const DetailsView = () => {
                 Provider
               </Typography>
               {renderFieldText({ value: activatedItem?.provider })}
+            </Grid>
+          </>
+        ) : null}
+        {paramsSize === 5 && searchParams.get('fileset') ? (
+          <>
+            <Grid item xs={12} sx={{ mb: [0, 5] }}>
+              <Typography variant='body2' sx={{ mb: 2 }}>
+                Type
+              </Typography>
+              {renderFieldText({ value: activatedItem?.type })}
+            </Grid>
+            <Grid item xs={12} sx={{ mb: [0, 5] }}>
+              <Typography variant='body2' sx={{ mb: 2 }}>
+                Storage location
+              </Typography>
+              {renderFieldText({ value: activatedItem?.storageLocation })}
             </Grid>
           </>
         ) : null}

--- a/web/src/app/metalakes/metalake/rightContent/tabsContent/tableView/TableView.js
+++ b/web/src/app/metalakes/metalake/rightContent/tabsContent/tableView/TableView.js
@@ -83,11 +83,11 @@ const TableView = () => {
 
   const renderIconTooltip = (type, name) => {
     const propsItem = store.tableProps.find(i => i.type === type)
-    const items = propsItem.items
+    const items = propsItem?.items || []
 
-    const isCond = propsItem.items.find(i => i.fields.find(v => (Array.isArray(v) ? v.includes(name) : v === name)))
+    const isCond = propsItem?.items.find(i => i.fields.find(v => (Array.isArray(v) ? v.includes(name) : v === name)))
 
-    const icon = propsItem.icon
+    const icon = propsItem?.icon
 
     return (
       <>

--- a/web/src/app/metalakes/metalake/rightContent/tabsContent/tableView/TableView.js
+++ b/web/src/app/metalakes/metalake/rightContent/tabsContent/tableView/TableView.js
@@ -34,7 +34,7 @@ import { to } from '@/lib/utils'
 import { getCatalogDetailsApi } from '@/lib/api/catalogs'
 import { useSearchParams } from 'next/navigation'
 
-const fonts = Inconsolata({})
+const fonts = Inconsolata({ subsets: ['latin'] })
 
 const EmptyText = () => {
   return (

--- a/web/src/app/metalakes/metalake/rightContent/tabsContent/tableView/TableView.js
+++ b/web/src/app/metalakes/metalake/rightContent/tabsContent/tableView/TableView.js
@@ -5,17 +5,22 @@
 
 'use client'
 
+import { Inconsolata } from 'next/font/google'
+
 import { useState, useEffect } from 'react'
 
 import Link from 'next/link'
 
-import { Box, Typography, IconButton } from '@mui/material'
+import { styled, Box, Typography, IconButton, Stack } from '@mui/material'
+import Tooltip, { tooltipClasses } from '@mui/material/Tooltip'
 import { DataGrid } from '@mui/x-data-grid'
 import {
   VisibilityOutlined as ViewIcon,
   EditOutlined as EditIcon,
   DeleteOutlined as DeleteIcon
 } from '@mui/icons-material'
+
+import Icon from '@/components/Icon'
 
 import ColumnTypeChip from '@/components/ColumnTypeChip'
 import DetailsDrawer from '@/components/DetailsDrawer'
@@ -29,6 +34,8 @@ import { to } from '@/lib/utils'
 import { getCatalogDetailsApi } from '@/lib/api/catalogs'
 import { useSearchParams } from 'next/navigation'
 
+const fonts = Inconsolata({})
+
 const EmptyText = () => {
   return (
     <Typography variant='caption' color={theme => theme.palette.text.disabled}>
@@ -36,6 +43,16 @@ const EmptyText = () => {
     </Typography>
   )
 }
+
+const CustomTooltip = styled(({ className, ...props }) => <Tooltip {...props} classes={{ popper: className }} />)(
+  ({ theme }) => ({
+    [`& .${tooltipClasses.tooltip}`]: {
+      backgroundColor: '#23282a',
+      padding: 0,
+      border: '1px solid #dadde9'
+    }
+  })
+)
 
 const TableView = () => {
   const searchParams = useSearchParams()
@@ -62,6 +79,56 @@ const TableView = () => {
     if (!path) {
       return
     }
+  }
+
+  const renderIconTooltip = (type, name) => {
+    const propsItem = store.tableProps.find(i => i.type === type)
+    const items = propsItem.items
+
+    const isCond = propsItem.items.find(i => i.fields.find(v => (Array.isArray(v) ? v.includes(name) : v === name)))
+
+    const icon = propsItem.icon
+
+    return (
+      <>
+        {isCond && (
+          <CustomTooltip
+            placement='right'
+            title={
+              <>
+                <Box
+                  sx={{
+                    backgroundColor: '#525c61',
+                    p: 1.5,
+                    px: 4,
+                    borderTopLeftRadius: 4,
+                    borderTopRightRadius: 4
+                  }}
+                >
+                  <Typography color='white' fontWeight={700} fontSize={14} sx={{ textTransform: 'capitalize' }}>
+                    {type}:{' '}
+                  </Typography>
+                </Box>
+
+                <Box sx={{ p: 1.5, px: 4 }}>
+                  {items.map(i => {
+                    return (
+                      <Typography key={i} variant='caption' color='white' className={fonts.className}>
+                        {i.text || i.fields}
+                      </Typography>
+                    )
+                  })}
+                </Box>
+              </>
+            }
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+              <Icon icon={icon} />
+            </Box>
+          </CustomTooltip>
+        )}
+      </>
+    )
   }
 
   const columns = [
@@ -182,7 +249,7 @@ const TableView = () => {
 
   const tableColumns = [
     {
-      flex: 0.1,
+      flex: 0.15,
       minWidth: 60,
       disableColumnMenu: true,
       type: 'string',
@@ -197,6 +264,7 @@ const TableView = () => {
               title={name}
               noWrap
               sx={{
+                pr: 4,
                 fontWeight: 400,
                 color: 'text.main',
                 textDecoration: 'none'
@@ -204,6 +272,12 @@ const TableView = () => {
             >
               {name}
             </Typography>
+            <Stack spacing={0} direction={'row'}>
+              {renderIconTooltip('partitioning', name)}
+              {renderIconTooltip('sortOrders', name)}
+              {renderIconTooltip('distribution', name)}
+              {renderIconTooltip('indexes', name)}
+            </Stack>
           </Box>
         )
       }

--- a/web/src/lib/store/metalakes/index.js
+++ b/web/src/lib/store/metalakes/index.js
@@ -605,7 +605,7 @@ export const getTableDetails = createAsyncThunk(
     const tableProps = [
       {
         type: 'partitioning',
-        icon: 'ant-design:partition-outlined',
+        icon: 'tabler:circle-letter-p-filled',
         items: partitioning.map(i => {
           let fields = i.fieldName || []
           let sub = ''
@@ -645,7 +645,7 @@ export const getTableDetails = createAsyncThunk(
       },
       {
         type: 'sortOrders',
-        icon: 'iconamoon:sorting-left-bold',
+        icon: 'mdi:letter-s-circle',
         items: sortOrders.map(i => {
           return {
             fields: i.sortTerm.fieldName,
@@ -674,7 +674,7 @@ export const getTableDetails = createAsyncThunk(
       },
       {
         type: 'indexes',
-        icon: 'mdi:key',
+        icon: 'mdi:letter-i-circle',
         items: indexes.map(i => {
           return {
             fields: i.fieldNames,

--- a/web/src/lib/store/metalakes/index.js
+++ b/web/src/lib/store/metalakes/index.js
@@ -605,7 +605,7 @@ export const getTableDetails = createAsyncThunk(
     const tableProps = [
       {
         type: 'partitioning',
-        icon: 'tabler:circle-letter-p-filled',
+        icon: 'ant-design:partition-outlined',
         items: partitioning.map(i => {
           let fields = i.fieldName || []
           let sub = ''
@@ -615,14 +615,14 @@ export const getTableDetails = createAsyncThunk(
             case 'bucket':
               sub = `[${i.numBuckets}]`
               fields = i.fieldNames
-              last = i.fieldNames.join(',')
+              last = i.fieldNames.map(v => v[0]).join(',')
               break
             case 'truncate':
               sub = `[${i.width}]`
               break
             case 'list':
               fields = i.fieldNames
-              last = i.fieldNames.join(',')
+              last = i.fieldNames.map(v => v[0]).join(',')
               break
             case 'function':
               sub = `[${i.funcName}]`
@@ -645,7 +645,7 @@ export const getTableDetails = createAsyncThunk(
       },
       {
         type: 'sortOrders',
-        icon: 'mdi:letter-s-circle',
+        icon: 'iconamoon:sorting-left-bold',
         items: sortOrders.map(i => {
           return {
             fields: i.sortTerm.fieldName,
@@ -674,7 +674,7 @@ export const getTableDetails = createAsyncThunk(
       },
       {
         type: 'indexes',
-        icon: 'mdi:letter-i-circle',
+        icon: 'mdi:key',
         items: indexes.map(i => {
           return {
             fields: i.fieldNames,

--- a/web/src/lib/store/metalakes/index.js
+++ b/web/src/lib/store/metalakes/index.js
@@ -959,6 +959,7 @@ export const appMetalakesSlice = createSlice({
       state.loadedNodes = []
 
       state.tableData = []
+      state.tableProps = []
       state.catalogs = []
       state.schemas = []
       state.tables = []

--- a/web/src/lib/store/metalakes/index.js
+++ b/web/src/lib/store/metalakes/index.js
@@ -600,6 +600,94 @@ export const getTableDetails = createAsyncThunk(
 
     const { table: resTable } = res
 
+    const { distribution, sortOrders = [], partitioning = [], indexes = [] } = resTable
+
+    const tableProps = [
+      {
+        type: 'partitioning',
+        icon: 'tabler:circle-letter-p-filled',
+        items: partitioning.map(i => {
+          let fields = i.fieldName || []
+          let sub = ''
+          let last = i.fieldName.join('.')
+
+          switch (i.strategy) {
+            case 'bucket':
+              sub = `[${i.numBuckets}]`
+              fields = i.fieldNames
+              last = i.fieldNames.join(',')
+              break
+            case 'truncate':
+              sub = `[${i.width}]`
+              break
+            case 'list':
+              fields = i.fieldNames
+              last = i.fieldNames.join(',')
+              break
+            case 'function':
+              sub = `[${i.funcName}]`
+              fields = i.funcArgs.map(v => v.fieldName)
+              last = fields.join(',')
+              break
+            default:
+              break
+          }
+
+          return {
+            strategy: i.strategy,
+            numBuckets: i.numBuckets,
+            width: i.width,
+            funcName: i.funcName,
+            fields,
+            text: `${i.strategy}${sub}(${last})`
+          }
+        })
+      },
+      {
+        type: 'sortOrders',
+        icon: 'mdi:letter-s-circle',
+        items: sortOrders.map(i => {
+          return {
+            fields: i.sortTerm.fieldName,
+            dir: i.direction,
+            no: i.nullOrdering,
+            text: `${i.sortTerm.fieldName[0]} ${i.direction} ${i.nullOrdering}`
+          }
+        })
+      },
+      {
+        type: 'distribution',
+        icon: 'tabler:circle-letter-d-filled',
+        items: distribution.funcArgs.map(i => {
+          return {
+            fields: i.fieldName,
+            number: distribution.number,
+            strategy: distribution.strategy,
+            text:
+              distribution.strategy === ''
+                ? ``
+                : `${distribution.strategy}${
+                    distribution.number === 0 ? '' : `[${distribution.number}]`
+                  }(${i.fieldName.join(',')})`
+          }
+        })
+      },
+      {
+        type: 'indexes',
+        icon: 'mdi:letter-i-circle',
+        items: indexes.map(i => {
+          return {
+            fields: i.fieldNames,
+            name: i.name,
+            indexType: i.indexType,
+            text: `${i.name}(${i.fieldNames.join(',')})`
+          }
+        })
+      }
+    ]
+
+    dispatch(setTableProps(tableProps))
+
     if (getState().metalakes.metalakeTree.length === 0) {
       dispatch(fetchCatalogs({ metalake }))
     }
@@ -818,6 +906,7 @@ export const appMetalakesSlice = createSlice({
     metalakes: [],
     filteredMetalakes: [],
     tableData: [],
+    tableProps: [],
     catalogs: [],
     schemas: [],
     tables: [],
@@ -897,6 +986,9 @@ export const appMetalakesSlice = createSlice({
     },
     removeCatalogFromTree(state, action) {
       state.metalakeTree = state.metalakeTree.filter(i => i.key !== action.payload)
+    },
+    setTableProps(state, action) {
+      state.tableProps = action.payload
     },
     resetMetalakeStore(state, action) {}
   },
@@ -1032,7 +1124,8 @@ export const {
   setExpanded,
   setExpandedNodes,
   addCatalogToTree,
-  removeCatalogFromTree
+  removeCatalogFromTree,
+  setTableProps
 } = appMetalakesSlice.actions
 
 export default appMetalakesSlice.reducer


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. add table properties displaying
  - partitioning
  - sortOrders
  - distribution
  - indexes
<img width="137" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/dd6d53b8-ce0e-4bd0-b982-7f50b2524db7">
<img width="131" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/c1a1ba64-e6c0-4503-a53e-4625eb3e3263">
<img width="126" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/cebf7c56-4d54-41a4-842c-93645f819c4a">
<img width="124" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/128ca3fd-6888-4650-b9f4-c3681690af75">

<img width="716" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/2e34e8d0-7a46-49f5-a2af-bdd40c97e3b9">
<img width="716" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/448bd796-bc3c-4cb7-9242-8dc86e5a480a">

3. modified fileset icon
<img width="328" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/6d94b33f-d875-4524-9839-a9b938743b11">

4. fix tree list refresh table
5. add fileset `type` and `storageLocation` displaying
<img width="714" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/2a29a093-4af2-4c4d-b393-70ebd6b605af">

6. fix login page logo icon error 9cc806574b49d211dd6b734bab9a01ce2ce0e944

### Why are the changes needed?

Fix: #2861
Fix: #2963
Fix: #2974

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A
