### PR TITLE
[MINOR]test: Increase the maximum wait time in Doris table operation test

### DIFF
--- a/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/operation/DorisTableOperations.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/operation/DorisTableOperations.java
@@ -292,6 +292,14 @@ public class DorisTableOperations extends JdbcTableOperations {
   @Override
   protected String generateAlterTableSql(
       String databaseName, String tableName, TableChange... changes) {
+    /*
+     * NOTICE:
+     * As described in the Doris documentation, the creation of Schema Change is an asynchronous process.
+     * If you load the table immediately after altering it, you might get the old schema.
+     * You can see in: https://doris.apache.org/docs/1.2/advanced/alter-table/schema-change/#create-job
+     * TODO: return state of the operation to user
+     * */
+
     // Not all operations require the original table information, so lazy loading is used here
     JdbcTable lazyLoadTable = null;
     TableChange.UpdateComment updateComment = null;

--- a/catalogs/catalog-jdbc-doris/src/test/java/com/datastrato/gravitino/catalog/doris/integration/test/DorisTableOperationsIT.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/com/datastrato/gravitino/catalog/doris/integration/test/DorisTableOperationsIT.java
@@ -40,7 +40,10 @@ public class DorisTableOperationsIT extends TestDorisAbstractIT {
 
   private static final String databaseName = GravitinoITUtils.genRandomName("doris_test_db");
 
-  private static final long MAX_WAIT = 5;
+  // Because the creation of Schema Change is an asynchronous process, we need wait for a while
+  // For more information, you can refer to the comment in
+  // DorisTableOperations.generateAlterTableSql().
+  private static final long MAX_WAIT = 30;
 
   private static final long WAIT_INTERVAL = 1;
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Increase the maximum wait time from 5 seconds to 30 seconds, which is set in schema alteration test for the Doris table operation

Avoid the instability of the GitHub CI flow.

### Why are the changes needed?

Github CI flow failed because table schema has not been done.

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Github CI