### PR TITLE
[#2913] Improvement(catalog-hadoop) Return false if the schema is not dropped.

### DIFF
--- a/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogOperations.java
@@ -461,13 +461,13 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
       Path schemaPath = getSchemaPath(ident.name(), properties);
       // Nothing to delete if the schema path is not set.
       if (schemaPath == null) {
-        return true;
+        return false;
       }
 
       FileSystem fs = schemaPath.getFileSystem(hadoopConf);
       // Nothing to delete if the schema path does not exist.
       if (!fs.exists(schemaPath)) {
-        return true;
+        return false;
       }
 
       if (fs.listStatus(schemaPath).length > 0 && !cascade) {

--- a/catalogs/catalog-hadoop/src/test/java/com/datastrato/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/test/java/com/datastrato/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
@@ -327,6 +327,10 @@ public class TestHadoopCatalogOperations {
       // Test drop non-empty schema with cascade = true
       ops.dropSchema(id, true);
       Assertions.assertFalse(fs.exists(schemaPath));
+
+      // Test drop empty schema
+      Assertions.assertFalse(ops.dropSchema(id, true));
+      Assertions.assertFalse(ops.dropSchema(id, false));
     }
   }
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

When dropping the schema, if the schema is null or does not exist, then return false.


### Why are the changes needed?

a clear drop behavior of return value and exception thrown.

Fix: #2913 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

UT
