### PR TITLE
[#2970]fix(UI): disabled update the location property of fileset catalog

### DIFF
--- a/web/src/app/metalakes/metalake/rightContent/CreateCatalogDialog.js
+++ b/web/src/app/metalakes/metalake/rightContent/CreateCatalogDialog.js
@@ -386,7 +386,8 @@ const CreateCatalogDialog = props => {
         if (findPropIndex === -1) {
           let propItem = {
             key: item,
-            value: properties[item]
+            value: properties[item],
+            disabled: data.type === 'fileset' && item === 'location' && type === 'update'
           }
           propsItems.push(propItem)
         }
@@ -552,7 +553,7 @@ const CreateCatalogDialog = props => {
                                   name='key'
                                   label='Key'
                                   value={item.key}
-                                  disabled={item.required}
+                                  disabled={item.required || item.disabled}
                                   onChange={event => handleFormChange({ index, event })}
                                   error={item.hasDuplicateKey}
                                   data-refer={`props-key-${index}`}
@@ -591,7 +592,7 @@ const CreateCatalogDialog = props => {
                                 )}
                               </Box>
 
-                              {!item.required ? (
+                              {!(item.required || item.disabled) ? (
                                 <Box sx={{ minWidth: 40 }}>
                                   <IconButton onClick={() => removeFields(index)}>
                                     <Icon icon='mdi:minus-circle-outline' />


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
Disabled update  the "location" property item for fileset catalog
<img width="765" alt="image" src="https://github.com/datastrato/gravitino/assets/9210625/1a5cf4f8-e659-4893-aa46-c74cbd35cacd">


### Why are the changes needed?
The "location" property of fileset catalog is immutable or reserved

Fix: #2970

### Does this PR introduce _any_ user-facing change?
Edit a fileset catalog and open the dialog

### How was this patch tested?
local e2e test
<img width="359" alt="image" src="https://github.com/datastrato/gravitino/assets/9210625/02e8afcf-4ed0-432d-87a2-1e3e952f647d">
