### PR TITLE
[#3005] fix(web): fix table properties displaying format

### DIFF
--- a/web/src/app/metalakes/metalake/rightContent/tabsContent/TabsContent.js
+++ b/web/src/app/metalakes/metalake/rightContent/tabsContent/TabsContent.js
@@ -7,7 +7,7 @@
 
 import { Inconsolata } from 'next/font/google'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, Fragment } from 'react'
 
 import { styled, Box, Divider, List, ListItem, ListItemText, Stack, Tab, Typography } from '@mui/material'
 import Tooltip, { tooltipClasses } from '@mui/material/Tooltip'
@@ -163,10 +163,16 @@ const TabsContent = () => {
                             </Box>
 
                             <Box sx={{ p: 1.5, px: 4 }}>
-                              {item.items.map(i => {
+                              {item.items.map((it, idx) => {
                                 return (
-                                  <Typography key={i} variant='caption' color='white' className={fonts.className}>
-                                    {item.type === 'sortOrders' ? i.text : i.fields}
+                                  <Typography
+                                    key={idx}
+                                    variant='caption'
+                                    color='white'
+                                    className={fonts.className}
+                                    sx={{ display: 'flex', flexDirection: 'column' }}
+                                  >
+                                    {item.type === 'sortOrders' ? it.text : it.fields.join('.')}
                                   </Typography>
                                 )
                               })}
@@ -210,11 +216,16 @@ const TabsContent = () => {
                                   textOverflow: 'ellipsis'
                                 }}
                               >
-                                <Typography variant='caption' className={fonts.className}>
-                                  {item.type === 'sortOrders'
-                                    ? item.items.map(i => i.text)
-                                    : item.items.map(i => i.fields)}
-                                </Typography>
+                                {item.items.map((it, idx) => {
+                                  return (
+                                    <Fragment key={idx}>
+                                      <Typography variant='caption' className={fonts.className}>
+                                        {it.fields.join('.')}
+                                      </Typography>
+                                      {idx < item.items.length - 1 && <span>, </span>}
+                                    </Fragment>
+                                  )
+                                })}
                               </Box>
                             }
                           />

--- a/web/src/app/metalakes/metalake/rightContent/tabsContent/tableView/TableView.js
+++ b/web/src/app/metalakes/metalake/rightContent/tabsContent/tableView/TableView.js
@@ -111,10 +111,16 @@ const TableView = () => {
                 </Box>
 
                 <Box sx={{ p: 1.5, px: 4 }}>
-                  {items.map(i => {
+                  {items.map((it, idx) => {
                     return (
-                      <Typography key={i} variant='caption' color='white' className={fonts.className}>
-                        {i.text || i.fields}
+                      <Typography
+                        key={idx}
+                        variant='caption'
+                        color='white'
+                        className={fonts.className}
+                        sx={{ display: 'flex', flexDirection: 'column' }}
+                      >
+                        {it.text || it.fields}
                       </Typography>
                     )
                   })}

--- a/web/src/lib/store/metalakes/index.js
+++ b/web/src/lib/store/metalakes/index.js
@@ -609,7 +609,7 @@ export const getTableDetails = createAsyncThunk(
         items: partitioning.map(i => {
           let fields = i.fieldName || []
           let sub = ''
-          let last = i.fieldName.join('.')
+          let last = i.fieldName
 
           switch (i.strategy) {
             case 'bucket':
@@ -680,7 +680,7 @@ export const getTableDetails = createAsyncThunk(
             fields: i.fieldNames,
             name: i.name,
             indexType: i.indexType,
-            text: `${i.name}(${i.fieldNames.join(',')})`
+            text: `${i.name}(${i.fieldNames.join('.')})`
           }
         })
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

fix table properties displaying format
- partitioning:
    - <img width="329" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/009bd5a6-d886-488c-bc2b-4d8da7650622">
    - <img width="272" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/65f68435-699e-4769-b700-4f197c0ea522">
- indexes:
    - <img width="230" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/eb5bcfbc-6146-447e-b732-6e664796e622">
    - <img width="257" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/d61eefaa-8d0d-496c-89c6-ac59f4f288b8">
- distribution:
    - <img width="160" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/a0d457f5-b7b5-4588-9fca-475d1a94c4d1">
    - <img width="265" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/13ff5b28-1898-453c-a981-87263c4f6e0c">
- sortOrders:
    - <img width="180" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/a9b03e6b-4612-49f8-ac9c-924eaab4ebb3">
    - <img width="275" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/e41eda4f-188a-408c-a2aa-7b04ab48f8c0">

### Why are the changes needed?

Fix: #3005

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

local
