### PR TITLE
[#2955] refactor(catalogs): use managedStorage capability

### DIFF
--- a/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalog.java
+++ b/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalog.java
@@ -6,6 +6,7 @@ package com.datastrato.gravitino.catalog.hadoop;
 
 import com.datastrato.gravitino.connector.BaseCatalog;
 import com.datastrato.gravitino.connector.CatalogOperations;
+import com.datastrato.gravitino.connector.capability.Capability;
 import com.datastrato.gravitino.file.FilesetCatalog;
 import com.datastrato.gravitino.rel.SupportsSchemas;
 import java.util.Map;
@@ -26,6 +27,11 @@ public class HadoopCatalog extends BaseCatalog<HadoopCatalog> {
   protected CatalogOperations newOps(Map<String, String> config) {
     HadoopCatalogOperations ops = new HadoopCatalogOperations();
     return ops;
+  }
+
+  @Override
+  protected Capability newCapability() {
+    return new HadoopCatalogCapability();
   }
 
   @Override

--- a/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogCapability.java
+++ b/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogCapability.java
@@ -14,6 +14,7 @@ public class HadoopCatalogCapability implements Capability {
     if (Objects.requireNonNull(scope) == Scope.SCHEMA) {
       return CapabilityResult.SUPPORTED;
     }
-    return CapabilityResult.unsupported("Hadoop catalog does not support managed storage.");
+    return CapabilityResult.unsupported(
+        String.format("Hadoop catalog does not support managed storage for %s.", scope));
   }
 }

--- a/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogCapability.java
+++ b/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogCapability.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.catalog.hadoop;
+
+import com.datastrato.gravitino.connector.capability.Capability;
+import com.datastrato.gravitino.connector.capability.CapabilityResult;
+import java.util.Objects;
+
+public class HadoopCatalogCapability implements Capability {
+  @Override
+  public CapabilityResult managedStorage(Scope scope) {
+    if (Objects.requireNonNull(scope) == Scope.SCHEMA) {
+      return CapabilityResult.SUPPORTED;
+    }
+    return CapabilityResult.unsupported("Hadoop catalog does not support managed storage.");
+  }
+}

--- a/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogOperations.java
@@ -35,7 +35,6 @@ import com.datastrato.gravitino.rel.SupportsSchemas;
 import com.datastrato.gravitino.utils.PrincipalUtils;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import java.io.IOException;
 import java.time.Instant;
@@ -224,7 +223,7 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
             // managed fileset, Gravitino will get and store the location based on the
             // catalog/schema's location and store it to the store.
             .withStorageLocation(filesetPath.toString())
-            .withProperties(addManagedFlagToProperties(properties))
+            .withProperties(properties)
             .withAuditInfo(
                 AuditInfo.builder()
                     .withCreator(PrincipalUtils.getCurrentPrincipal().getName())
@@ -371,7 +370,7 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
             .withId(stringId.id())
             .withNamespace(ident.namespace())
             .withComment(comment)
-            .withProperties(addManagedFlagToProperties(properties))
+            .withProperties(properties)
             .withAuditInfo(
                 AuditInfo.builder()
                     .withCreator(PrincipalUtils.getCurrentPrincipal().getName())
@@ -513,10 +512,6 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
 
   @Override
   public void close() throws IOException {}
-
-  private Map<String, String> addManagedFlagToProperties(Map<String, String> properties) {
-    return ImmutableMap.<String, String>builder().putAll(properties).build();
-  }
 
   private SchemaEntity updateSchemaEntity(
       NameIdentifier ident, SchemaEntity schemaEntity, SchemaChange... changes) {

--- a/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogOperations.java
@@ -12,7 +12,6 @@ import com.datastrato.gravitino.GravitinoEnv;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.StringIdentifier;
-import com.datastrato.gravitino.connector.BasePropertiesMetadata;
 import com.datastrato.gravitino.connector.CatalogInfo;
 import com.datastrato.gravitino.connector.CatalogOperations;
 import com.datastrato.gravitino.connector.PropertiesMetadata;
@@ -516,10 +515,7 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
   public void close() throws IOException {}
 
   private Map<String, String> addManagedFlagToProperties(Map<String, String> properties) {
-    return ImmutableMap.<String, String>builder()
-        .putAll(properties)
-        .put(BasePropertiesMetadata.GRAVITINO_MANAGED_ENTITY, Boolean.TRUE.toString())
-        .build();
+    return ImmutableMap.<String, String>builder().putAll(properties).build();
   }
 
   private SchemaEntity updateSchemaEntity(

--- a/catalogs/catalog-hadoop/src/test/java/com/datastrato/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/test/java/com/datastrato/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
@@ -20,7 +20,6 @@ import com.datastrato.gravitino.EntityStoreFactory;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.StringIdentifier;
-import com.datastrato.gravitino.connector.BaseCatalogPropertiesMetadata;
 import com.datastrato.gravitino.exceptions.NoSuchFilesetException;
 import com.datastrato.gravitino.exceptions.NoSuchSchemaException;
 import com.datastrato.gravitino.exceptions.NonEmptySchemaException;
@@ -126,11 +125,6 @@ public class TestHadoopCatalogOperations {
     Schema schema = createSchema(name, comment, null, null);
     Assertions.assertEquals(name, schema.name());
     Assertions.assertEquals(comment, schema.comment());
-    Map<String, String> props = schema.properties();
-    Assertions.assertTrue(
-        props.containsKey(BaseCatalogPropertiesMetadata.GRAVITINO_MANAGED_ENTITY));
-    Assertions.assertEquals(
-        "true", props.get(BaseCatalogPropertiesMetadata.GRAVITINO_MANAGED_ENTITY));
 
     Throwable exception =
         Assertions.assertThrows(
@@ -205,10 +199,6 @@ public class TestHadoopCatalogOperations {
       Assertions.assertEquals(comment, schema1.comment());
 
       Map<String, String> props = schema1.properties();
-      Assertions.assertTrue(
-          props.containsKey(BaseCatalogPropertiesMetadata.GRAVITINO_MANAGED_ENTITY));
-      Assertions.assertEquals(
-          "true", props.get(BaseCatalogPropertiesMetadata.GRAVITINO_MANAGED_ENTITY));
       Assertions.assertTrue(props.containsKey(StringIdentifier.ID_KEY));
 
       Throwable exception =
@@ -251,10 +241,6 @@ public class TestHadoopCatalogOperations {
       Assertions.assertEquals(comment, schema1.comment());
 
       Map<String, String> props = schema1.properties();
-      Assertions.assertTrue(
-          props.containsKey(BaseCatalogPropertiesMetadata.GRAVITINO_MANAGED_ENTITY));
-      Assertions.assertEquals(
-          "true", props.get(BaseCatalogPropertiesMetadata.GRAVITINO_MANAGED_ENTITY));
       Assertions.assertTrue(props.containsKey(StringIdentifier.ID_KEY));
 
       String newKey = "k1";
@@ -301,10 +287,6 @@ public class TestHadoopCatalogOperations {
       Assertions.assertEquals(comment, schema1.comment());
 
       Map<String, String> props = schema1.properties();
-      Assertions.assertTrue(
-          props.containsKey(BaseCatalogPropertiesMetadata.GRAVITINO_MANAGED_ENTITY));
-      Assertions.assertEquals(
-          "true", props.get(BaseCatalogPropertiesMetadata.GRAVITINO_MANAGED_ENTITY));
       Assertions.assertTrue(props.containsKey(StringIdentifier.ID_KEY));
 
       ops.dropSchema(id, false);

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveCatalogOperations.java
@@ -68,7 +68,7 @@ class TestHiveCatalogOperations {
 
     Map<String, PropertyEntry<?>> propertyEntryMap =
         hiveCatalogOperations.catalogPropertiesMetadata().propertyEntries();
-    Assertions.assertEquals(12, propertyEntryMap.size());
+    Assertions.assertEquals(11, propertyEntryMap.size());
     Assertions.assertTrue(propertyEntryMap.containsKey(METASTORE_URIS));
     Assertions.assertTrue(propertyEntryMap.containsKey(Catalog.PROPERTY_PACKAGE));
     Assertions.assertTrue(propertyEntryMap.containsKey(BaseCatalog.CATALOG_OPERATION_IMPL));

--- a/catalogs/catalog-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalog.java
+++ b/catalogs/catalog-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalog.java
@@ -7,6 +7,7 @@ package com.datastrato.gravitino.catalog.kafka;
 
 import com.datastrato.gravitino.connector.BaseCatalog;
 import com.datastrato.gravitino.connector.CatalogOperations;
+import com.datastrato.gravitino.connector.capability.Capability;
 import com.datastrato.gravitino.messaging.TopicCatalog;
 import com.datastrato.gravitino.rel.SupportsSchemas;
 import java.util.Map;
@@ -23,6 +24,11 @@ public class KafkaCatalog extends BaseCatalog<KafkaCatalog> {
   protected CatalogOperations newOps(Map<String, String> config) {
     KafkaCatalogOperations ops = new KafkaCatalogOperations();
     return ops;
+  }
+
+  @Override
+  protected Capability newCapability() {
+    return new KafkaCatalogCapability();
   }
 
   @Override

--- a/catalogs/catalog-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogCapability.java
+++ b/catalogs/catalog-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogCapability.java
@@ -14,6 +14,7 @@ public class KafkaCatalogCapability implements Capability {
     if (Objects.requireNonNull(scope) == Scope.SCHEMA) {
       return CapabilityResult.SUPPORTED;
     }
-    return CapabilityResult.unsupported("Kafka catalog does not support managed storage.");
+    return CapabilityResult.unsupported(
+        String.format("Kafka catalog does not support managed storage for %s.", scope));
   }
 }

--- a/catalogs/catalog-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogCapability.java
+++ b/catalogs/catalog-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogCapability.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.catalog.kafka;
+
+import com.datastrato.gravitino.connector.capability.Capability;
+import com.datastrato.gravitino.connector.capability.CapabilityResult;
+import java.util.Objects;
+
+public class KafkaCatalogCapability implements Capability {
+  @Override
+  public CapabilityResult managedStorage(Scope scope) {
+    if (Objects.requireNonNull(scope) == Scope.SCHEMA) {
+      return CapabilityResult.SUPPORTED;
+    }
+    return CapabilityResult.unsupported("Kafka catalog does not support managed storage.");
+  }
+}

--- a/catalogs/catalog-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
+++ b/catalogs/catalog-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
@@ -18,7 +18,6 @@ import com.datastrato.gravitino.GravitinoEnv;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.StringIdentifier;
-import com.datastrato.gravitino.connector.BasePropertiesMetadata;
 import com.datastrato.gravitino.connector.CatalogInfo;
 import com.datastrato.gravitino.connector.CatalogOperations;
 import com.datastrato.gravitino.connector.PropertiesMetadata;
@@ -552,7 +551,6 @@ public class KafkaCatalogOperations implements CatalogOperations, SupportsSchema
     ImmutableMap<String, String> properties =
         ImmutableMap.<String, String>builder()
             .put(ID_KEY, StringIdentifier.fromId(uid).toString())
-            .put(BasePropertiesMetadata.GRAVITINO_MANAGED_ENTITY, Boolean.TRUE.toString())
             .build();
 
     SchemaEntity defaultSchema =

--- a/catalogs/catalog-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/TestKafkaCatalogOperations.java
+++ b/catalogs/catalog-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/TestKafkaCatalogOperations.java
@@ -25,7 +25,6 @@ import com.datastrato.gravitino.EntityStoreFactory;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.catalog.kafka.embedded.KafkaClusterEmbedded;
-import com.datastrato.gravitino.connector.BasePropertiesMetadata;
 import com.datastrato.gravitino.exceptions.NoSuchSchemaException;
 import com.datastrato.gravitino.exceptions.NoSuchTopicException;
 import com.datastrato.gravitino.exceptions.TopicAlreadyExistsException;
@@ -190,9 +189,6 @@ public class TestKafkaCatalogOperations extends KafkaClusterEmbedded {
     Assertions.assertEquals(
         "The default schema of Kafka catalog including all topics", schema.comment());
     Assertions.assertEquals(2, schema.properties().size());
-    Assertions.assertTrue(
-        schema.properties().containsKey(BasePropertiesMetadata.GRAVITINO_MANAGED_ENTITY));
-    Assertions.assertEquals("true", schema.properties().get("gravitino.managed.entity"));
   }
 
   @Test

--- a/catalogs/catalog-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/TestKafkaCatalogOperations.java
+++ b/catalogs/catalog-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/TestKafkaCatalogOperations.java
@@ -188,7 +188,7 @@ public class TestKafkaCatalogOperations extends KafkaClusterEmbedded {
     Assertions.assertEquals(DEFAULT_SCHEMA_NAME, schema.name());
     Assertions.assertEquals(
         "The default schema of Kafka catalog including all topics", schema.comment());
-    Assertions.assertEquals(2, schema.properties().size());
+    Assertions.assertEquals(1, schema.properties().size());
   }
 
   @Test

--- a/core/src/main/java/com/datastrato/gravitino/catalog/OperationDispatcher.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/OperationDispatcher.java
@@ -11,7 +11,6 @@ import com.datastrato.gravitino.HasIdentifier;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.StringIdentifier;
-import com.datastrato.gravitino.connector.BasePropertiesMetadata;
 import com.datastrato.gravitino.connector.HasPropertyMetadata;
 import com.datastrato.gravitino.connector.PropertiesMetadata;
 import com.datastrato.gravitino.connector.capability.Capability;
@@ -28,7 +27,6 @@ import com.google.common.collect.Maps;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -250,14 +248,11 @@ public abstract class OperationDispatcher {
     return NameIdentifier.of(allElems.get(0), allElems.get(1));
   }
 
-  boolean isManagedEntity(Map<String, String> properties) {
-    return Optional.ofNullable(properties)
-        .map(
-            p ->
-                p.getOrDefault(
-                        BasePropertiesMetadata.GRAVITINO_MANAGED_ENTITY, Boolean.FALSE.toString())
-                    .equals(Boolean.TRUE.toString()))
-        .orElse(false);
+  boolean isManagedEntity(NameIdentifier catalogIdent, Capability.Scope scope) {
+    return doWithCatalog(
+        catalogIdent,
+        c -> c.capabilities().managedStorage(scope).supported(),
+        IllegalArgumentException.class);
   }
 
   static final class FormattedErrorMessages {

--- a/core/src/main/java/com/datastrato/gravitino/catalog/SchemaOperationDispatcher.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/SchemaOperationDispatcher.java
@@ -13,6 +13,7 @@ import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.StringIdentifier;
 import com.datastrato.gravitino.connector.HasPropertyMetadata;
+import com.datastrato.gravitino.connector.capability.Capability;
 import com.datastrato.gravitino.exceptions.NoSuchCatalogException;
 import com.datastrato.gravitino.exceptions.NoSuchSchemaException;
 import com.datastrato.gravitino.exceptions.NonEmptySchemaException;
@@ -104,7 +105,7 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
             SchemaAlreadyExistsException.class);
 
     // If the Schema is maintained by the Gravitino's store, we don't have to store again.
-    boolean isManagedSchema = isManagedEntity(createdSchema.properties());
+    boolean isManagedSchema = isManagedEntity(catalogIdent, Capability.Scope.SCHEMA);
     if (isManagedSchema) {
       return EntityCombinedSchema.of(createdSchema)
           .withHiddenPropertiesSet(
@@ -169,7 +170,7 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
             NoSuchSchemaException.class);
 
     // If the Schema is maintained by the Gravitino's store, we don't have to load again.
-    boolean isManagedSchema = isManagedEntity(schema.properties());
+    boolean isManagedSchema = isManagedEntity(catalogIdentifier, Capability.Scope.SCHEMA);
     if (isManagedSchema) {
       return EntityCombinedSchema.of(schema)
           .withHiddenPropertiesSet(
@@ -237,7 +238,7 @@ public class SchemaOperationDispatcher extends OperationDispatcher implements Sc
             NoSuchSchemaException.class);
 
     // If the Schema is maintained by the Gravitino's store, we don't have to alter again.
-    boolean isManagedSchema = isManagedEntity(alteredSchema.properties());
+    boolean isManagedSchema = isManagedEntity(catalogIdent, Capability.Scope.SCHEMA);
     if (isManagedSchema) {
       return EntityCombinedSchema.of(alteredSchema)
           .withHiddenPropertiesSet(

--- a/core/src/main/java/com/datastrato/gravitino/connector/BasePropertiesMetadata.java
+++ b/core/src/main/java/com/datastrato/gravitino/connector/BasePropertiesMetadata.java
@@ -27,10 +27,6 @@ import java.util.Map;
 @Evolving
 public abstract class BasePropertiesMetadata implements PropertiesMetadata {
 
-  // "gravitino.managed.entity" is an internal and reserved property to indicate whether the
-  // entity is managed by Gravitino's own store or not.
-  public static final String GRAVITINO_MANAGED_ENTITY = "gravitino.managed.entity";
-
   private static final Map<String, PropertyEntry<?>> BASIC_PROPERTY_ENTRIES;
 
   private volatile Map<String, PropertyEntry<?>> propertyEntries;
@@ -42,11 +38,6 @@ public abstract class BasePropertiesMetadata implements PropertiesMetadata {
             PropertyEntry.stringReservedPropertyEntry(
                 ID_KEY,
                 "To differentiate the entities created directly by the underlying sources",
-                true),
-            PropertyEntry.booleanReservedPropertyEntry(
-                GRAVITINO_MANAGED_ENTITY,
-                "Whether the entity is managed by Gravitino's own store or not",
-                false,
                 true));
 
     BASIC_PROPERTY_ENTRIES = Maps.uniqueIndex(basicPropertyEntries, PropertyEntry::getName);

--- a/core/src/test/java/com/datastrato/gravitino/catalog/TestFilesetOperationDispatcher.java
+++ b/core/src/test/java/com/datastrato/gravitino/catalog/TestFilesetOperationDispatcher.java
@@ -5,7 +5,6 @@
 package com.datastrato.gravitino.catalog;
 
 import static com.datastrato.gravitino.StringIdentifier.ID_KEY;
-import static com.datastrato.gravitino.connector.BasePropertiesMetadata.GRAVITINO_MANAGED_ENTITY;
 
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
@@ -118,11 +117,10 @@ public class TestFilesetOperationDispatcher extends TestOperationDispatcher {
     testProperties(expectedProps, alteredFileset.properties());
 
     // Test immutable fileset properties
-    FilesetChange[] illegalChange =
-        new FilesetChange[] {FilesetChange.setProperty(GRAVITINO_MANAGED_ENTITY, "test")};
+    FilesetChange[] illegalChange = new FilesetChange[] {FilesetChange.setProperty(ID_KEY, "test")};
     testPropertyException(
         () -> filesetOperationDispatcher.alterFileset(filesetIdent1, illegalChange),
-        "Property gravitino.managed.entity is immutable or reserved, cannot be set");
+        "Property gravitino.identifier is immutable or reserved, cannot be set");
   }
 
   @Test

--- a/core/src/test/java/com/datastrato/gravitino/catalog/TestOperationDispatcher.java
+++ b/core/src/test/java/com/datastrato/gravitino/catalog/TestOperationDispatcher.java
@@ -5,7 +5,6 @@
 package com.datastrato.gravitino.catalog;
 
 import static com.datastrato.gravitino.TestFilesetPropertiesMetadata.TEST_FILESET_HIDDEN_KEY;
-import static com.datastrato.gravitino.connector.BasePropertiesMetadata.GRAVITINO_MANAGED_ENTITY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.reset;
@@ -119,7 +118,6 @@ public abstract class TestOperationDispatcher {
           Assertions.assertEquals(v, testProps.get(k));
         });
     Assertions.assertFalse(testProps.containsKey(StringIdentifier.ID_KEY));
-    Assertions.assertFalse(testProps.containsKey(GRAVITINO_MANAGED_ENTITY));
     Assertions.assertFalse(testProps.containsKey(TEST_FILESET_HIDDEN_KEY));
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

- remove property `GRAVITINO_MANAGED_ENTITY`
- add managedStorage capability for Hadoop and Kafka catalog

### Why are the changes needed?

Fix: #2955 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

existing tests
