### PR TITLE
[#3030] fix(test): adjust the order of assertion parameters

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
@@ -251,7 +251,7 @@ public class CatalogsPageTest extends AbstractWebIT {
   @Order(7)
   public void testRefreshPage() {
     driver.navigate().refresh();
-    Assertions.assertEquals(driver.getTitle(), WEB_TITLE);
+    Assertions.assertEquals(WEB_TITLE, driver.getTitle());
     Assertions.assertTrue(catalogsPage.verifyRefreshPage());
     List<String> catalogsNames =
         Arrays.asList(

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/MetalakePageTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/MetalakePageTest.java
@@ -125,7 +125,7 @@ public class MetalakePageTest extends AbstractWebIT {
   public void testRefreshPage() {
     driver.navigate().refresh();
 
-    Assertions.assertEquals(driver.getTitle(), WEB_TITLE);
+    Assertions.assertEquals(WEB_TITLE, driver.getTitle());
     Assertions.assertTrue(metalakePage.verifyRefreshPage());
   }
 

--- a/spark-connector/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/hive/TestHivePropertiesConverter.java
+++ b/spark-connector/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/hive/TestHivePropertiesConverter.java
@@ -25,7 +25,7 @@ public class TestHivePropertiesConverter {
         hivePropertiesConverter.toGravitinoTableProperties(
             ImmutableMap.of(HivePropertiesConstants.SPARK_HIVE_STORED_AS, "PARQUET"));
     Assertions.assertEquals(
-        hiveProperties.get(HivePropertiesConstants.GRAVITINO_HIVE_FORMAT), "PARQUET");
+        "PARQUET", hiveProperties.get(HivePropertiesConstants.GRAVITINO_HIVE_FORMAT));
     Assertions.assertThrowsExactly(
         NotSupportedException.class,
         () ->
@@ -84,8 +84,8 @@ public class TestHivePropertiesConverter {
         hivePropertiesConverter.toGravitinoTableProperties(
             ImmutableMap.of(HivePropertiesConstants.SPARK_HIVE_EXTERNAL, "true"));
     Assertions.assertEquals(
-        hiveProperties.get(HivePropertiesConstants.GRAVITINO_HIVE_TABLE_TYPE),
-        HivePropertiesConstants.GRAVITINO_HIVE_EXTERNAL_TABLE);
+        HivePropertiesConstants.GRAVITINO_HIVE_EXTERNAL_TABLE,
+        hiveProperties.get(HivePropertiesConstants.GRAVITINO_HIVE_TABLE_TYPE));
 
     hiveProperties =
         hivePropertiesConverter.toSparkTableProperties(


### PR DESCRIPTION
### What changes were proposed in this pull request?

assertion arguments should be in the in correct order: expected value, actual value

### Why are the changes needed?

Fix: #3030 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

exist ut