### PR TITLE
[#3035] fix(catalog-hive): catch Exception instead of Throwable

### DIFF
--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
@@ -218,8 +218,8 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
             () -> {
               try {
                 kerberosLoginUgi.checkTGTAndReloginFromKeytab();
-              } catch (Throwable throwable) {
-                LOG.error("Fail to refresh ugi token: ", throwable);
+              } catch (Exception e) {
+                LOG.error("Fail to refresh ugi token: ", e);
               }
             },
             checkInterval,

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveClientPool.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveClientPool.java
@@ -84,16 +84,16 @@ public class HiveClientPool extends ClientPoolImpl<IMetaStoreClient, TException>
       }
     } catch (MetaException e) {
       throw new RuntimeException("Failed to connect to Hive Metastore", e);
-    } catch (Throwable t) {
-      if (t.getMessage().contains("Another instance of Derby may have already booted")) {
+    } catch (Exception e) {
+      if (e.getMessage().contains("Another instance of Derby may have already booted")) {
         throw new RuntimeException(
             "Failed to start an embedded metastore because embedded "
                 + "Derby supports only one client at a time. To fix this, use a metastore that supports "
                 + "multiple clients.",
-            t);
+            e);
       }
 
-      throw new RuntimeException("Failed to connect to Hive Metastore", t);
+      throw new RuntimeException("Failed to connect to Hive Metastore", e);
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Catch Exception instead of Throwable in HiveCatalogOperations.java and HiveClientPool.java

### Why are the changes needed?

Fix: #3035 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

exist ut
