### PR TITLE
[#3042] [MINOR] fix(docs): Fix the authentication content format in gvfs docs

### DIFF
--- a/docs/how-to-use-gvfs.md
+++ b/docs/how-to-use-gvfs.md
@@ -234,9 +234,9 @@ Currently, Gravitino Virtual File System supports two kinds of authentication ty
 
 The type of `simple` is the default authentication type in Gravitino Virtual File System.
 
-### How to use simple authentication
+### How to use authentication
 
-#### Using `simple` authentication type
+#### Using `simple` authentication
 
 First, make sure that your Gravitino server is also configured to use the `simple` authentication mode.
 
@@ -260,7 +260,7 @@ Path filesetPath = new Path("gvfs://fileset/test_catalog/test_schema/test_filese
 FileSystem fs = filesetPath.getFileSystem(conf);
 ```
 
-#### Using OAuth authentication
+#### Using `OAuth` authentication
 
 If you want to use `oauth2` authentication for the Gravitino client in the Gravitino Virtual File System,
 please refer to this document to complete the configuration of the Gravitino server and the OAuth server: [Security](./security.md).


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the format of authentication content in gvfs docs.
![image](https://github.com/datastrato/gravitino/assets/26177232/217288ae-3bc5-4e5e-8dd9-ed0380041992)

### Why are the changes needed?

Fix: #3042 
