### PR TITLE
[#2917] fix: Use * instead of {0,} in regular expressions

### DIFF
--- a/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/utils/DorisUtils.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/utils/DorisUtils.java
@@ -32,7 +32,7 @@ public final class DorisUtils {
     String[] lines = createTableSql.split("\n");
 
     boolean isProperties = false;
-    final String sProperties = "\"(.*)\"\\s{0,}=\\s{0,}\"(.*)\",?";
+    final String sProperties = "\"(.*)\"\\s*=\\s*\"(.*)\",?";
     final Pattern patternProperties = Pattern.compile(sProperties);
 
     for (String line : lines) {

--- a/catalogs/catalog-jdbc-doris/src/test/java/com/datastrato/gravitino/catalog/doris/utils/TestDorisUtils.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/com/datastrato/gravitino/catalog/doris/utils/TestDorisUtils.java
@@ -59,5 +59,12 @@ public class TestDorisUtils {
     result = DorisUtils.extractPropertiesFromSql(createTableSql);
     Assertions.assertEquals("test_value1", result.get("test_property1"));
     Assertions.assertEquals("test_value2", result.get("test_property2"));
+
+    // test when properties has blank
+    createTableSql =
+        "CREATE DATABASE `test`\nPROPERTIES (\n\"property1\" = \"value1\",\n\"comment\"= \"comment\"\n)";
+    result = DorisUtils.extractPropertiesFromSql(createTableSql);
+    Assertions.assertEquals("value1", result.get("property1"));
+    Assertions.assertEquals("comment", result.get("comment"));
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use * instead of {0,} in regular expressions

### Why are the changes needed?

Fix: #2917

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

UT