### PR TITLE
[#3056] fix(catalog-hadoop): fix improper character class in regex

### DIFF
--- a/clients/filesystem-hadoop3/src/main/java/com/datastrato/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
+++ b/clients/filesystem-hadoop3/src/main/java/com/datastrato/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
@@ -57,7 +57,7 @@ public class GravitinoVirtualFileSystem extends FileSystem {
   //     gvfs://fileset/fileset_catalog/fileset_schema/fileset1/file.txt
   //     /fileset_catalog/fileset_schema/fileset1/sub_dir/
   private static final Pattern IDENTIFIER_PATTERN =
-      Pattern.compile("^(?:gvfs://fileset)?/([^/]+)/([^/]+)/([^/]+)(?:[/[^/]+]*)$");
+      Pattern.compile("^(?:gvfs://fileset)?/([^/]+)/([^/]+)/([^/]+)(?:/[^/]+)*/?$");
 
   @Override
   public void initialize(URI name, Configuration configuration) throws IOException {

--- a/clients/filesystem-hadoop3/src/test/java/com/datastrato/gravitino/filesystem/hadoop/TestGvfsBase.java
+++ b/clients/filesystem-hadoop3/src/test/java/com/datastrato/gravitino/filesystem/hadoop/TestGvfsBase.java
@@ -558,6 +558,12 @@ public class TestGvfsBase extends GravitinoMockServerBase {
       assertThrows(
           IllegalArgumentException.class,
           () -> fs.extractIdentifier(new URI("/catalog1/schema1/")));
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> fs.extractIdentifier(new URI("gvfs://fileset/catalog1/schema1/fileset1//")));
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> fs.extractIdentifier(new URI("/catalog1/schema1/fileset1/dir//")));
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

(Please outline the changes and how this PR fixes the issue.)

### Why are the changes needed?
"gvfs://fileset/catalog1/schema1/fileset1//" should not pass the test but it passed.

Fix: #3056
### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
Add UT
