### PR TITLE
[#3051] fix(kafka-catalog): Make the catalog creation failure exception more accurate

### DIFF
--- a/catalogs/catalog-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
+++ b/catalogs/catalog-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
@@ -66,7 +66,9 @@ import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.apache.kafka.clients.admin.NewPartitions;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.errors.InvalidReplicationFactorException;
@@ -132,8 +134,15 @@ public class KafkaCatalogOperations implements CatalogOperations, SupportsSchema
         AdminClientConfig.CLIENT_ID_CONFIG,
         String.format(CLIENT_ID_TEMPLATE, config.get(ID_KEY), info.namespace(), info.name()));
 
+    try {
+      adminClient = AdminClient.create(adminClientConfig);
+    } catch (KafkaException e) {
+      if (e.getCause() instanceof ConfigException) {
+        throw new IllegalArgumentException(
+            "Invalid configuration for Kafka AdminClient: " + e.getCause().getMessage(), e);
+      }
+    }
     createDefaultSchemaIfNecessary();
-    adminClient = AdminClient.create(adminClientConfig);
   }
 
   @Override

--- a/catalogs/catalog-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
+++ b/catalogs/catalog-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
@@ -141,6 +141,7 @@ public class KafkaCatalogOperations implements CatalogOperations, SupportsSchema
         throw new IllegalArgumentException(
             "Invalid configuration for Kafka AdminClient: " + e.getCause().getMessage(), e);
       }
+      throw new RuntimeException("Failed to create Kafka AdminClient", e);
     }
     createDefaultSchemaIfNecessary();
   }

--- a/catalogs/catalog-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/integration/test/CatalogKafkaIT.java
+++ b/catalogs/catalog-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/integration/test/CatalogKafkaIT.java
@@ -146,6 +146,35 @@ public class CatalogKafkaIT extends AbstractIT {
   }
 
   @Test
+  public void testCatalogException() {
+    String catalogName = GravitinoITUtils.genRandomName("test-catalog");
+    Exception exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                metalake.createCatalog(
+                    NameIdentifier.of(METALAKE_NAME, catalogName),
+                    Catalog.Type.MESSAGING,
+                    PROVIDER,
+                    "comment",
+                    ImmutableMap.of(BOOTSTRAP_SERVERS, "2")));
+    Assertions.assertTrue(exception.getMessage().contains("Invalid url in bootstrap.servers: 2"));
+
+    exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                metalake.createCatalog(
+                    NameIdentifier.of(METALAKE_NAME, catalogName),
+                    Catalog.Type.MESSAGING,
+                    PROVIDER,
+                    "comment",
+                    ImmutableMap.of("abc", "2")));
+    Assertions.assertTrue(
+        exception.getMessage().contains("Missing configuration: bootstrap.servers"));
+  }
+
+  @Test
   public void testDefaultSchema() {
     NameIdentifier[] schemas =
         catalog.asSchemas().listSchemas(Namespace.ofSchema(METALAKE_NAME, CATALOG_NAME));

--- a/core/src/main/java/com/datastrato/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/CatalogManager.java
@@ -347,6 +347,9 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
     } catch (Exception e3) {
       catalogCache.invalidate(ident);
       LOG.error("Failed to create catalog {}", ident, e3);
+      if (e3 instanceof RuntimeException) {
+        throw (RuntimeException) e3;
+      }
       throw new RuntimeException(e3);
     } finally {
       if (!createSuccess) {

--- a/core/src/main/java/com/datastrato/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/CatalogManager.java
@@ -354,7 +354,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
     } finally {
       if (!createSuccess) {
         try {
-          store.delete(ident, EntityType.CATALOG);
+          store.delete(ident, EntityType.CATALOG, true);
         } catch (IOException e4) {
           LOG.error("Failed to clean up catalog {}", ident, e4);
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?

- postpone default schema creation after admin client
- reduced exception nesting

### Why are the changes needed?

Fix: #3015 

### Does this PR introduce _any_ user-facing change?

yes, when the Kafka catalog creation fails, use the correct error message

### How was this patch tested?

IT added
