### PR TITLE
[#3059] fix(spark-connector):  Failed to run spark sql with spark-connector-runtime.jar

### DIFF
--- a/spark-connector/spark-connector-runtime/build.gradle.kts
+++ b/spark-connector/spark-connector-runtime/build.gradle.kts
@@ -28,7 +28,7 @@ tasks.withType<ShadowJar>(ShadowJar::class.java) {
   // Relocate dependencies to avoid conflicts
   relocate("com.google", "com.datastrato.gravitino.shaded.com.google")
   relocate("google", "com.datastrato.gravitino.shaded.google")
-  relocate("org.apache", "com.datastrato.gravitino.shaded.org.apache")
+  relocate("org.apache.hc", "com.datastrato.gravitino.shaded.org.apache.hc")
 }
 
 tasks.jar {


### PR DESCRIPTION

### What changes were proposed in this pull request?
shade apache hc only

### Why are the changes needed?
if shading `org.apache`, spark package will be shaded to `com/datastrato/gravitino/shaded/org/apache/spark`, but spark package is not build in spark-connector, leading ClassNotFound exception

Fix: #3059 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
build spark connector jar and run with spark
