### PR TITLE
[#3072] fix(spark-connector):  fix local run SparkIcebergCatalogIT failed for non-utc timezone

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkEnvIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkEnvIT.java
@@ -147,6 +147,7 @@ public abstract class SparkEnvIT extends SparkUtilIT {
             .config(GravitinoSparkConfig.GRAVITINO_METALAKE, metalakeName)
             .config("hive.exec.dynamic.partition.mode", "nonstrict")
             .config("spark.sql.warehouse.dir", warehouse)
+            .config("spark.sql.session.timeZone", TIME_ZONE_UTC)
             .enableHiveSupport()
             .getOrCreate();
   }

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/iceberg/SparkIcebergCatalogIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/iceberg/SparkIcebergCatalogIT.java
@@ -188,12 +188,12 @@ public class SparkIcebergCatalogIT extends SparkCommonIT {
 
               String insertData =
                   String.format(
-                      "INSERT into %s values(2,'a',cast('2024-01-01 12:00:00.0' as timestamp));",
+                      "INSERT into %s values(2,'a',cast('2024-01-01 12:00:00' as timestamp));",
                       tableName);
               sql(insertData);
               List<String> queryResult = getTableData(tableName);
               Assertions.assertEquals(1, queryResult.size());
-              Assertions.assertEquals("2,a,2024-01-01 12:00:00.0", queryResult.get(0));
+              Assertions.assertEquals("2,a,2024-01-01 12:00:00", queryResult.get(0));
               String partitionExpression = partitionPaths.get(func);
               Path partitionPath = new Path(getTableLocation(tableInfo), partitionExpression);
               checkDirExists(partitionPath);

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/spark/SparkUtilIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/spark/SparkUtilIT.java
@@ -21,10 +21,13 @@ package com.datastrato.gravitino.integration.test.util.spark;
 
 import com.datastrato.gravitino.integration.test.util.AbstractIT;
 import com.datastrato.gravitino.spark.connector.table.SparkBaseTable;
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.spark.sql.AnalysisException;
@@ -45,6 +48,8 @@ import org.junit.jupiter.api.Assertions;
 public abstract class SparkUtilIT extends AbstractIT {
 
   protected abstract SparkSession getSparkSession();
+
+  protected final String TIME_ZONE_UTC = "UTC";
 
   protected Set<String> getCatalogs() {
     return convertToStringSet(sql("SHOW CATALOGS"), 0);
@@ -89,21 +94,27 @@ public abstract class SparkUtilIT extends AbstractIT {
     return getQueryData(getSelectAllSql(tableName));
   }
 
+  private String sparkObjectToString(Object item) {
+    if (item instanceof Object[]) {
+      return Arrays.stream((Object[]) item)
+          .map(i -> sparkObjectToString(i))
+          .collect(Collectors.joining(","));
+    } else if (item instanceof Timestamp) {
+      Timestamp timestamp = (Timestamp) item;
+      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+      sdf.setTimeZone(TimeZone.getTimeZone(TIME_ZONE_UTC));
+      return sdf.format(timestamp);
+    } else {
+      return item.toString();
+    }
+  }
+
   protected List<String> getQueryData(String querySql) {
     return sql(querySql).stream()
         .map(
             line ->
                 Arrays.stream(line)
-                    .map(
-                        item -> {
-                          if (item instanceof Object[]) {
-                            return Arrays.stream((Object[]) item)
-                                .map(Object::toString)
-                                .collect(Collectors.joining(","));
-                          } else {
-                            return item.toString();
-                          }
-                        })
+                    .map(item -> sparkObjectToString(item))
                     .collect(Collectors.joining(",")))
         .collect(Collectors.toList());
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
configurate spark time zone to UTC

### Why are the changes needed?
if not specifying timezone, Iceberg partition path varies for different time zone in local machine.

Fix: #3072 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
test in local machine
