### PR TITLE
[#2696] fix(core): list catalog info handle hidden properties

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/CatalogManager.java
@@ -23,6 +23,7 @@ import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.StringIdentifier;
 import com.datastrato.gravitino.connector.BaseCatalog;
+import com.datastrato.gravitino.connector.CatalogOperations;
 import com.datastrato.gravitino.connector.HasPropertyMetadata;
 import com.datastrato.gravitino.connector.PropertiesMetadata;
 import com.datastrato.gravitino.connector.PropertyEntry;
@@ -589,18 +590,23 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
     Map<String, String> conf = entity.getProperties();
     String provider = entity.getProvider();
 
-    IsolatedClassLoader classLoader = createClassLoader(provider, conf);
-    BaseCatalog<?> catalog = createBaseCatalog(classLoader, entity);
-
-    return classLoader.withClassLoader(
-        cl -> {
-          PropertiesMetadata catalogPropertiesMetadata = catalog.ops().catalogPropertiesMetadata();
-          return catalogPropertiesMetadata.propertyEntries().values().stream()
-              .filter(PropertyEntry::isHidden)
-              .map(PropertyEntry::getName)
-              .collect(Collectors.toSet());
-        },
-        RuntimeException.class);
+    try (IsolatedClassLoader classLoader = createClassLoader(provider, conf)) {
+      BaseCatalog<?> catalog = createBaseCatalog(classLoader, entity);
+      return classLoader.withClassLoader(
+          cl -> {
+            try (CatalogOperations ops = catalog.ops()) {
+              PropertiesMetadata catalogPropertiesMetadata = ops.catalogPropertiesMetadata();
+              return catalogPropertiesMetadata.propertyEntries().values().stream()
+                  .filter(PropertyEntry::isHidden)
+                  .map(PropertyEntry::getName)
+                  .collect(Collectors.toSet());
+            } catch (Exception e) {
+              LOG.error("Failed to get hidden property names", e);
+              throw e;
+            }
+          },
+          RuntimeException.class);
+    }
   }
 
   private BaseCatalog<?> createBaseCatalog(IsolatedClassLoader classLoader, CatalogEntity entity) {

--- a/core/src/main/java/com/datastrato/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/CatalogManager.java
@@ -24,6 +24,8 @@ import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.StringIdentifier;
 import com.datastrato.gravitino.connector.BaseCatalog;
 import com.datastrato.gravitino.connector.HasPropertyMetadata;
+import com.datastrato.gravitino.connector.PropertiesMetadata;
+import com.datastrato.gravitino.connector.PropertyEntry;
 import com.datastrato.gravitino.connector.capability.Capability;
 import com.datastrato.gravitino.exceptions.CatalogAlreadyExistsException;
 import com.datastrato.gravitino.exceptions.NoSuchCatalogException;
@@ -48,6 +50,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Multimaps;
 import com.google.common.collect.Streams;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.Closeable;
@@ -63,6 +66,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.ServiceLoader;
+import java.util.Set;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -251,8 +255,17 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
     checkMetalakeExists(metalakeIdent);
 
     try {
-      return store.list(namespace, CatalogEntity.class, EntityType.CATALOG).stream()
-          .map(CatalogEntity::toCatalogInfo)
+      List<CatalogEntity> catalogEntities =
+          store.list(namespace, CatalogEntity.class, EntityType.CATALOG);
+
+      // Using provider as key to avoid loading the same type catalog instance multiple times
+      Map<String, Set<String>> hiddenProps = new HashMap<>();
+      Multimaps.index(catalogEntities, CatalogEntity::getProvider)
+          .asMap()
+          .forEach((p, e) -> hiddenProps.put(p, getHiddenPropertyNames(e.iterator().next())));
+
+      return catalogEntities.stream()
+          .map(e -> e.toCatalogInfoWithoutHiddenProps(hiddenProps.get(e.getProvider())))
           .toArray(Catalog[]::new);
     } catch (IOException ioe) {
       LOG.error("Failed to list catalogs in metalake {}", metalakeIdent, ioe);
@@ -547,21 +560,8 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
     Map<String, String> conf = entity.getProperties();
     String provider = entity.getProvider();
 
-    IsolatedClassLoader classLoader;
-    if (config.get(Configs.CATALOG_LOAD_ISOLATED)) {
-      String pkgPath = buildPkgPath(conf, provider);
-      String confPath = buildConfPath(conf, provider);
-      classLoader = IsolatedClassLoader.buildClassLoader(Lists.newArrayList(pkgPath, confPath));
-    } else {
-      // This will use the current class loader, it is mainly used for test.
-      classLoader =
-          new IsolatedClassLoader(
-              Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-    }
-
-    // Load Catalog class instance
-    BaseCatalog<?> catalog = createCatalogInstance(classLoader, provider);
-    catalog.withCatalogConf(conf).withCatalogEntity(entity);
+    IsolatedClassLoader classLoader = createClassLoader(provider, conf);
+    BaseCatalog<?> catalog = createBaseCatalog(classLoader, entity);
 
     CatalogWrapper wrapper = new CatalogWrapper(catalog, classLoader);
     // Validate catalog properties and initialize the config
@@ -583,6 +583,43 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
         IllegalArgumentException.class);
 
     return wrapper;
+  }
+
+  private Set<String> getHiddenPropertyNames(CatalogEntity entity) {
+    Map<String, String> conf = entity.getProperties();
+    String provider = entity.getProvider();
+
+    IsolatedClassLoader classLoader = createClassLoader(provider, conf);
+    BaseCatalog<?> catalog = createBaseCatalog(classLoader, entity);
+
+    return classLoader.withClassLoader(
+        cl -> {
+          PropertiesMetadata catalogPropertiesMetadata = catalog.ops().catalogPropertiesMetadata();
+          return catalogPropertiesMetadata.propertyEntries().values().stream()
+              .filter(PropertyEntry::isHidden)
+              .map(PropertyEntry::getName)
+              .collect(Collectors.toSet());
+        },
+        RuntimeException.class);
+  }
+
+  private BaseCatalog<?> createBaseCatalog(IsolatedClassLoader classLoader, CatalogEntity entity) {
+    // Load Catalog class instance
+    BaseCatalog<?> catalog = createCatalogInstance(classLoader, entity.getProvider());
+    catalog.withCatalogConf(entity.getProperties()).withCatalogEntity(entity);
+    return catalog;
+  }
+
+  private IsolatedClassLoader createClassLoader(String provider, Map<String, String> conf) {
+    if (config.get(Configs.CATALOG_LOAD_ISOLATED)) {
+      String pkgPath = buildPkgPath(conf, provider);
+      String confPath = buildConfPath(conf, provider);
+      return IsolatedClassLoader.buildClassLoader(Lists.newArrayList(pkgPath, confPath));
+    } else {
+      // This will use the current class loader, it is mainly used for test.
+      return new IsolatedClassLoader(
+          Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+    }
   }
 
   private BaseCatalog<?> createCatalogInstance(IsolatedClassLoader classLoader, String provider) {

--- a/core/src/main/java/com/datastrato/gravitino/meta/CatalogEntity.java
+++ b/core/src/main/java/com/datastrato/gravitino/meta/CatalogEntity.java
@@ -16,6 +16,7 @@ import com.google.common.base.Objects;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.ToString;
@@ -121,6 +122,14 @@ public class CatalogEntity implements Entity, Auditable, HasIdentifier {
   /** Convert the catalog entity to a {@link CatalogInfo} instance. */
   public CatalogInfo toCatalogInfo() {
     return new CatalogInfo(id, name, type, provider, comment, properties, auditInfo, namespace);
+  }
+
+  public CatalogInfo toCatalogInfoWithoutHiddenProps(Set<String> hiddenKeys) {
+    Map<String, String> filteredProperties =
+        properties == null ? new HashMap<>() : new HashMap<>(properties);
+    filteredProperties.keySet().removeAll(hiddenKeys);
+    return new CatalogInfo(
+        id, name, type, provider, comment, filteredProperties, auditInfo, namespace);
   }
 
   /** Builder class for creating instances of {@link CatalogEntity}. */

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/client/CatalogIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/client/CatalogIT.java
@@ -16,6 +16,7 @@ import com.google.common.collect.Maps;
 import java.io.File;
 import java.util.Collections;
 import java.util.Map;
+import org.apache.commons.lang.ArrayUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -123,9 +124,8 @@ public class CatalogIT extends AbstractIT {
         assertCatalogEquals(fileCatalog, catalog);
       }
     }
-    // TODO: uncomment this after fixing hidden properties
-    // Assertions.assertTrue(ArrayUtils.contains(catalogs, relCatalog));
-    // Assertions.assertTrue(ArrayUtils.contains(catalogs, fileCatalog));
+    Assertions.assertTrue(ArrayUtils.contains(catalogs, relCatalog));
+    Assertions.assertTrue(ArrayUtils.contains(catalogs, fileCatalog));
   }
 
   private void assertCatalogEquals(Catalog catalog1, Catalog catalog2) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Filter out hidden properties before returning the result in `listCatalogInfo`.

### Why are the changes needed?

Fix: #2696 

### Does this PR introduce _any_ user-facing change?

yes, hidden properties will not show in result of `listCatalogInfo`

### How was this patch tested?

tests added
