### PR TITLE
[#3083] improve(web): update regular expression of metalake and catalog name

### DIFF
--- a/web/src/app/metalakes/CreateMetalakeDialog.js
+++ b/web/src/app/metalakes/CreateMetalakeDialog.js
@@ -45,7 +45,7 @@ const schema = yup.object().shape({
     .required()
     .matches(
       nameRegex,
-      'This field must start with a letter or underscore, and can only contain letters, numbers, and underscores'
+      'This field must start with a letter or underscore, and can only contain letters, numbers, dashes, and underscores'
     )
 })
 

--- a/web/src/app/metalakes/metalake/rightContent/CreateCatalogDialog.js
+++ b/web/src/app/metalakes/metalake/rightContent/CreateCatalogDialog.js
@@ -54,7 +54,7 @@ const schema = yup.object().shape({
     .required()
     .matches(
       nameRegex,
-      'This field must start with a letter or underscore, and can only contain letters, numbers, and underscores'
+      'This field must start with a letter or underscore, and can only contain letters, numbers, dashes, and underscores'
     ),
   type: yup.mixed().oneOf(['relational', 'fileset', 'messaging']).required(),
   provider: yup.string().when('type', (type, schema) => {

--- a/web/src/lib/utils/regex.js
+++ b/web/src/lib/utils/regex.js
@@ -3,6 +3,6 @@
  * This software is licensed under the Apache License version 2.
  */
 
-export const nameRegex = /^[a-zA-Z_][a-zA-Z0-9_]*$/
+export const nameRegex = /^[a-zA-Z_-][a-zA-Z0-9_-]*$/
 
 export const keyRegex = /^[a-zA-Z_][a-zA-Z0-9-_.]*$/


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support for the use of dashes in naming metalake and catalog by web UI.
<img width="716" alt="image" src="https://github.com/datastrato/gravitino/assets/9210625/fe1b0d78-32b6-491e-83bb-e512831454d1">


### Why are the changes needed?
The dashes is a relatively common usage in naming.

Fix: #3083

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
Manually Test
