### PR TITLE
[#3089] fix:(jdbc-doris): Make class loaders of Doris Catalog can be GCed normally.

### DIFF
--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/MySQLProtocolCompatibleCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/MySQLProtocolCompatibleCatalogOperations.java
@@ -2,10 +2,9 @@
  * Copyright 2024 Datastrato Pvt Ltd.
  * This software is licensed under the Apache License version 2.
  */
-package com.datastrato.gravitino.catalog.mysql;
 
-import com.datastrato.gravitino.catalog.jdbc.JdbcCatalogOperations;
-import com.datastrato.gravitino.catalog.jdbc.JdbcTablePropertiesMetadata;
+package com.datastrato.gravitino.catalog.jdbc;
+
 import com.datastrato.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
 import com.datastrato.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
 import com.datastrato.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
@@ -16,10 +15,11 @@ import java.sql.DriverManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class MySQLCatalogOperations extends JdbcCatalogOperations {
-  private static final Logger LOG = LoggerFactory.getLogger(MySQLCatalogOperations.class);
+public class MySQLProtocolCompatibleCatalogOperations extends JdbcCatalogOperations {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(MySQLProtocolCompatibleCatalogOperations.class);
 
-  public MySQLCatalogOperations(
+  public MySQLProtocolCompatibleCatalogOperations(
       JdbcExceptionConverter exceptionConverter,
       JdbcTypeConverter jdbcTypeConverter,
       JdbcDatabaseOperations databaseOperation,

--- a/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/DorisCatalog.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/DorisCatalog.java
@@ -10,11 +10,14 @@ import com.datastrato.gravitino.catalog.doris.converter.DorisTypeConverter;
 import com.datastrato.gravitino.catalog.doris.operation.DorisDatabaseOperations;
 import com.datastrato.gravitino.catalog.doris.operation.DorisTableOperations;
 import com.datastrato.gravitino.catalog.jdbc.JdbcCatalog;
+import com.datastrato.gravitino.catalog.jdbc.MySQLProtocolCompatibleCatalogOperations;
 import com.datastrato.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
 import com.datastrato.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
 import com.datastrato.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
 import com.datastrato.gravitino.catalog.jdbc.operation.JdbcDatabaseOperations;
 import com.datastrato.gravitino.catalog.jdbc.operation.JdbcTableOperations;
+import com.datastrato.gravitino.connector.CatalogOperations;
+import java.util.Map;
 
 /** Implementation of a Doris catalog in Gravitino. */
 public class DorisCatalog extends JdbcCatalog {
@@ -22,6 +25,18 @@ public class DorisCatalog extends JdbcCatalog {
   @Override
   public String shortName() {
     return "jdbc-doris";
+  }
+
+  @Override
+  protected CatalogOperations newOps(Map<String, String> config) {
+    JdbcTypeConverter<String> jdbcTypeConverter = createJdbcTypeConverter();
+    return new MySQLProtocolCompatibleCatalogOperations(
+        createExceptionConverter(),
+        jdbcTypeConverter,
+        createJdbcDatabaseOperations(),
+        createJdbcTableOperations(),
+        createJdbcTablePropertiesMetadata(),
+        createJdbcColumnDefaultValueConverter());
   }
 
   @Override

--- a/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/MysqlCatalog.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/MysqlCatalog.java
@@ -6,6 +6,7 @@ package com.datastrato.gravitino.catalog.mysql;
 
 import com.datastrato.gravitino.catalog.jdbc.JdbcCatalog;
 import com.datastrato.gravitino.catalog.jdbc.JdbcTablePropertiesMetadata;
+import com.datastrato.gravitino.catalog.jdbc.MySQLProtocolCompatibleCatalogOperations;
 import com.datastrato.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
 import com.datastrato.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
 import com.datastrato.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
@@ -30,7 +31,7 @@ public class MysqlCatalog extends JdbcCatalog {
   @Override
   protected CatalogOperations newOps(Map<String, String> config) {
     JdbcTypeConverter<String> jdbcTypeConverter = createJdbcTypeConverter();
-    return new MySQLCatalogOperations(
+    return new MySQLProtocolCompatibleCatalogOperations(
         createExceptionConverter(),
         jdbcTypeConverter,
         createJdbcDatabaseOperations(),


### PR DESCRIPTION
### What changes were proposed in this pull request?

Introduce a common class `MySQLProtocolCompatibleCatalogOperations` so that any JDBC catalog that is compatible with MySQL protocol can use it. 

### Why are the changes needed?

It's a bug that need to fix

Fix: #3089 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Test locally.
