### PR TITLE
[#3058] fix(web): fix value displaying and enhance the styles

### DIFF
--- a/web/src/app/metalakes/metalake/rightContent/tabsContent/TabsContent.js
+++ b/web/src/app/metalakes/metalake/rightContent/tabsContent/TabsContent.js
@@ -165,15 +165,46 @@ const TabsContent = () => {
                             <Box sx={{ p: 1.5, px: 4 }}>
                               {item.items.map((it, idx) => {
                                 return (
-                                  <Typography
-                                    key={idx}
-                                    variant='caption'
-                                    color='white'
-                                    className={fonts.className}
-                                    sx={{ display: 'flex', flexDirection: 'column' }}
-                                  >
-                                    {item.type === 'sortOrders' ? it.text : it.fields.join('.')}
-                                  </Typography>
+                                  <Fragment key={idx}>
+                                    <Typography
+                                      variant='caption'
+                                      color='white'
+                                      className={fonts.className}
+                                      sx={{ display: 'flex', flexDirection: 'column' }}
+                                    >
+                                      {item.type === 'sortOrders'
+                                        ? it.text
+                                        : it.fields.map((v, vi) => {
+                                            return (
+                                              <Fragment key={vi}>
+                                                <Box component={'span'} sx={{}}>
+                                                  {Array.isArray(v) ? v.join('.') : v}
+                                                </Box>
+                                                {vi < it.fields.length - 1 && (
+                                                  <Box
+                                                    component={'span'}
+                                                    sx={{
+                                                      display: 'block',
+                                                      my: 1,
+                                                      borderTop: theme => `1px solid ${theme.palette.grey[800]}`
+                                                    }}
+                                                  ></Box>
+                                                )}
+                                              </Fragment>
+                                            )
+                                          })}
+                                    </Typography>
+                                    {idx < item.items.length - 1 && (
+                                      <Box
+                                        component={'span'}
+                                        sx={{
+                                          display: 'block',
+                                          my: 1,
+                                          borderTop: theme => `1px solid ${theme.palette.grey[800]}`
+                                        }}
+                                      ></Box>
+                                    )}
+                                  </Fragment>
                                 )
                               })}
                             </Box>
@@ -220,7 +251,7 @@ const TabsContent = () => {
                                   return (
                                     <Fragment key={idx}>
                                       <Typography variant='caption' className={fonts.className}>
-                                        {it.fields.join('.')}
+                                        {it.fields.map(v => (Array.isArray(v) ? v.join('.') : v)).join(',')}
                                       </Typography>
                                       {idx < item.items.length - 1 && <span>, </span>}
                                     </Fragment>

--- a/web/src/app/metalakes/metalake/rightContent/tabsContent/TabsContent.js
+++ b/web/src/app/metalakes/metalake/rightContent/tabsContent/TabsContent.js
@@ -13,6 +13,8 @@ import { styled, Box, Divider, List, ListItem, ListItemText, Stack, Tab, Typogra
 import Tooltip, { tooltipClasses } from '@mui/material/Tooltip'
 import { TabContext, TabList, TabPanel } from '@mui/lab'
 
+import clsx from 'clsx'
+
 import { useAppSelector } from '@/lib/hooks/useStore'
 
 import { useSearchParams } from 'next/navigation'
@@ -253,7 +255,9 @@ const TabsContent = () => {
                                       <Typography variant='caption' className={fonts.className}>
                                         {it.fields.map(v => (Array.isArray(v) ? v.join('.') : v)).join(',')}
                                       </Typography>
-                                      {idx < item.items.length - 1 && <span>, </span>}
+                                      {idx < item.items.length - 1 && (
+                                        <span className={clsx(fonts.className, 'twc-text-[12px]')}>,</span>
+                                      )}
                                     </Fragment>
                                   )
                                 })}

--- a/web/src/app/metalakes/metalake/rightContent/tabsContent/tableView/TableView.js
+++ b/web/src/app/metalakes/metalake/rightContent/tabsContent/tableView/TableView.js
@@ -7,7 +7,7 @@
 
 import { Inconsolata } from 'next/font/google'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, Fragment } from 'react'
 
 import Link from 'next/link'
 
@@ -113,15 +113,26 @@ const TableView = () => {
                 <Box sx={{ p: 1.5, px: 4 }}>
                   {items.map((it, idx) => {
                     return (
-                      <Typography
-                        key={idx}
-                        variant='caption'
-                        color='white'
-                        className={fonts.className}
-                        sx={{ display: 'flex', flexDirection: 'column' }}
-                      >
-                        {it.text || it.fields}
-                      </Typography>
+                      <Fragment key={idx}>
+                        <Typography
+                          variant='caption'
+                          color='white'
+                          className={fonts.className}
+                          sx={{ display: 'flex', flexDirection: 'column' }}
+                        >
+                          {it.text || it.fields}
+                        </Typography>
+                        {idx < items.length - 1 && (
+                          <Box
+                            component={'span'}
+                            sx={{
+                              display: 'block',
+                              my: 1,
+                              borderTop: theme => `1px solid ${theme.palette.grey[800]}`
+                            }}
+                          ></Box>
+                        )}
+                      </Fragment>
                     )
                   })}
                 </Box>

--- a/web/src/lib/store/metalakes/index.js
+++ b/web/src/lib/store/metalakes/index.js
@@ -672,7 +672,7 @@ export const getTableDetails = createAsyncThunk(
             fields: i.fieldNames,
             name: i.name,
             indexType: i.indexType,
-            text: `${i.name}(${i.fieldNames.join('.')})`
+            text: `${i.name}(${i.fieldNames.map(v => v.join('.')).join(',')})`
           }
         })
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix value displaying and enhance the styles.

### Why are the changes needed?

Fix: #3058

### Does this PR introduce _any_ user-facing change?

`[['id', 'b'], ['name'], ['d', 'e'], ['f'], ['g']]`

header:
<img width="129" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/5206bd0c-a3d6-487c-a623-52d91b2429cf">
column:
<img width="219" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/da060e00-a472-4df5-98f7-8b4feda51ea8">


others:

<img width="157" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/364ff92d-8472-4c5e-ace0-30e709f84c5c">

<img width="196" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/a0dc67f4-1b2f-4481-945c-b0bc773e0735">

<img width="148" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/02463cf3-8e7c-40c5-a73a-a2dbea8392ce">

<img width="182" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/e9578950-7686-4b70-9216-14b987d88181">

<img width="175" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/eb62d830-d6a5-4eea-817b-adaded5c04ae">

<img width="217" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/933a4554-3e5f-4b04-b04f-2d0e84e4a734">


### How was this patch tested?

local
