### PR TITLE
[#3057] fix(web): fix breadcrumbs text display styles and appbar layout

### DIFF
--- a/web/src/app/metalakes/metalake/MetalakeTree.js
+++ b/web/src/app/metalakes/metalake/MetalakeTree.js
@@ -237,10 +237,18 @@ const MetalakeTree = props => {
   }
 
   const renderNode = nodeData => {
+    const len = extractPlaceholder(nodeData.key).length
+    const maxWidth = 260 - (26 * 2 - 26 * (5 - len))
     if (nodeData.path) {
       return (
         <Typography
-          sx={{ color: theme => theme.palette.text.secondary }}
+          sx={{
+            color: theme => theme.palette.text.secondary,
+            whiteSpace: 'nowrap',
+            maxWidth,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis'
+          }}
           data-refer='tree-node'
           data-refer-node={nodeData.key}
         >

--- a/web/src/app/metalakes/metalake/rightContent/MetalakePath.js
+++ b/web/src/app/metalakes/metalake/rightContent/MetalakePath.js
@@ -12,11 +12,16 @@ import { Link as MUILink, Breadcrumbs, Typography, Tooltip, styled } from '@mui/
 
 import Icon from '@/components/Icon'
 
-const Text = styled(Typography)(({ theme }) => ({
-  maxWidth: '120px',
+const TextWrapper = styled(Typography)(({ theme }) => ({
+  mixWidth: '120px',
   overflow: 'hidden',
-  textOverflow: 'ellipsis'
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap'
 }))
+
+const Text = props => {
+  return <TextWrapper component='span' {...props} />
+}
 
 const MetalakePath = props => {
   const searchParams = useSearchParams()
@@ -47,10 +52,26 @@ const MetalakePath = props => {
   return (
     <Breadcrumbs
       sx={{
+        width: 'calc(100% - 48px)',
+        overflow: 'hidden',
         mt: 0,
         '& a': { display: 'flex', alignItems: 'center' },
+        '& ol': {
+          flexWrap: 'nowrap'
+        },
+        '& ol > li.MuiBreadcrumbs-li': {
+          overflow: 'hidden',
+          display: 'inline-flex',
+          '& > a': {
+            width: '100%',
+            '& > svg': {
+              minWidth: 20
+            }
+          }
+        },
         '& ol > li:last-of-type': {
-          color: theme => `${theme.palette.text.primary} !important`
+          color: theme => `${theme.palette.text.primary} !important`,
+          overflow: 'hidden'
         }
       }}
     >

--- a/web/src/app/metalakes/metalake/rightContent/RightContent.js
+++ b/web/src/app/metalakes/metalake/rightContent/RightContent.js
@@ -37,9 +37,9 @@ const RightContent = () => {
           borderBottom: theme => `1px solid ${theme.palette.divider}`
         }}
       >
-        <Box className={`twc-flex twc-items-center`}>
-          <Box className={`twc-flex twc-items-center twc-justify-between`}>
-            <Box className={`twc-flex twc-items-center`}>
+        <Box className={`twc-flex twc-items-center twc-flex-1 twc-overflow-hidden twc-mr-2`}>
+          <Box className={`twc-flex twc-items-center twc-justify-between twc-w-full`}>
+            <Box className={`twc-flex twc-items-center twc-w-full`}>
               <IconButton color='primary' component={Link} href='/metalakes' sx={{ mr: 2 }} data-refer='back-home-btn'>
                 <Icon icon='mdi:arrow-left' />
               </IconButton>
@@ -54,6 +54,7 @@ const RightContent = () => {
               variant='contained'
               startIcon={<Icon icon='mdi:plus-box' />}
               onClick={handleCreateCatalog}
+              sx={{ width: 200 }}
               data-refer='create-catalog-btn'
             >
               Create Catalog

--- a/web/src/app/rootLayout/AppBar.js
+++ b/web/src/app/rootLayout/AppBar.js
@@ -51,12 +51,18 @@ const AppBar = () => {
       elevation={6}
       position={'sticky'}
       className={
-        'layout-navbar-container twc-px-6 twc-items-center twc-justify-center twc-transition-[border-bottom] twc-ease-in-out twc-duration-200 twc-bg-customs-white'
+        'layout-navbar-container twc-items-center twc-justify-center twc-transition-[border-bottom] twc-ease-in-out twc-duration-200 twc-bg-customs-white'
       }
     >
       <Box className={'layout-navbar twc-w-full'}>
-        <Toolbar className={'navbar-content-container twc-mx-auto [@media(min-width:1440px)]:twc-max-w-[1440px]'}>
-          <Box className={'app-bar-content twc-w-full twc-flex twc-items-center twc-justify-between'}>
+        <Toolbar
+          className={'navbar-content-container twc-p-0 twc-mx-auto [@media(min-width:1440px)]:twc-max-w-[1440px]'}
+        >
+          <Box
+            className={
+              'app-bar-content twc-w-full twc-px-[1.5rem] sm:twc-px-6 twc-flex twc-items-center twc-justify-between'
+            }
+          >
             <Link href='/metalakes' className={'twc-flex twc-items-center twc-no-underline twc-mr-8'}>
               <Image
                 src={process.env.NEXT_PUBLIC_BASE_PATH + '/icons/gravitino.svg'}

--- a/web/src/app/rootLayout/AppBar.js
+++ b/web/src/app/rootLayout/AppBar.js
@@ -76,7 +76,7 @@ const AppBar = () => {
             <Box className={'app-bar-content-right twc-flex twc-items-center'}>
               <Stack direction='row' spacing={2} alignItems='center'>
                 {metalake ? (
-                  <FormControl fullWidth size='small'>
+                  <FormControl sx={{ maxWidth: 240 }} size='small'>
                     <InputLabel id='select-metalake'>Metalake</InputLabel>
                     <Select
                       labelId='select-metalake'
@@ -84,16 +84,28 @@ const AppBar = () => {
                       data-refer='select-metalake'
                       value={metalake}
                       label='Metalake'
+                      sx={{ width: '100%' }}
                     >
                       {metalakes.map(item => {
                         return (
                           <MenuItem
+                            title={item}
                             value={item}
                             key={item}
                             data-refer={'select-option-' + item}
+                            sx={{
+                              maxWidth: 240
+                            }}
                             onClick={() => router.push('/metalakes?metalake=' + item)}
                           >
-                            {item}
+                            <Box
+                              sx={{
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis'
+                              }}
+                            >
+                              {item}
+                            </Box>
                           </MenuItem>
                         )
                       })}

--- a/web/src/components/DetailsDrawer.js
+++ b/web/src/components/DetailsDrawer.js
@@ -105,7 +105,8 @@ const DetailsDrawer = props => {
                 'twc-py-2 twc-font-semibold twc-text-[1.2rem] twc-w-full twc-overflow-hidden twc-text-ellipsis'
               }
               sx={{
-                borderBottom: theme => `1px solid ${theme.palette.divider}`
+                borderBottom: theme => `1px solid ${theme.palette.divider}`,
+                whiteSpace: 'nowrap'
               }}
               data-refer='details-title'
             >


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix breadcrumbs text display styles.

### Why are the changes needed?

Fix: #3057 

### Does this PR introduce _any_ user-facing change?

<img width="713" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/c4869df7-2de7-4685-82db-8568595b3ba5">

<img width="716" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/c53f5516-8768-4574-a830-ab63b1da7f3c">

<img width="716" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/642f8aa4-8b28-40b3-b356-6898df5a27b0">

<img width="714" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/7b0f276a-e3f8-409b-be6f-024d56552107">

<img width="137" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/0da8c91f-d081-43b5-9f23-db99565acec8">

<img width="166" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/8406d0e7-4dc0-41ed-846f-465ddf1d5ebd">



### How was this patch tested?

local
