### PR TITLE
[#3078] feat(core): Use \\w instead of [a-zA-Z0-9_] in regexp

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/connector/capability/Capability.java
+++ b/core/src/main/java/com/datastrato/gravitino/connector/capability/Capability.java
@@ -94,7 +94,7 @@ public interface Capability {
      *
      * <p>$ - End of the string
      */
-    private static final String DEFAULT_NAME_PATTERN = "^[a-zA-Z0-9_][a-zA-Z0-9_/=-]{0,63}$";
+    private static final String DEFAULT_NAME_PATTERN = "^\\w[\\w/=-]{0,63}$";
 
     @Override
     public CapabilityResult columnNotNull() {

--- a/core/src/test/java/com/datastrato/gravitino/connector/capability/TestCapability.java
+++ b/core/src/test/java/com/datastrato/gravitino/connector/capability/TestCapability.java
@@ -18,6 +18,12 @@ public class TestCapability {
       CapabilityResult result = Capability.DEFAULT.specificationOnName(scope, "_name_123_/_=-");
       Assertions.assertTrue(result.supported());
 
+      result = Capability.DEFAULT.specificationOnName(scope, "name_123_/_=-");
+      Assertions.assertTrue(result.supported());
+
+      result = Capability.DEFAULT.specificationOnName(scope, "Name_123_/_=-");
+      Assertions.assertTrue(result.supported());
+
       // test for reserved name
       result = Capability.DEFAULT.specificationOnName(scope, SECURABLE_ENTITY_RESERVED_NAME);
       Assertions.assertFalse(result.supported());
@@ -41,6 +47,18 @@ public class TestCapability {
       Assertions.assertTrue(result.unsupportedMessage().contains("is illegal"));
 
       result = Capability.DEFAULT.specificationOnName(scope, "name_with_%");
+      Assertions.assertFalse(result.supported());
+      Assertions.assertTrue(result.unsupportedMessage().contains("is illegal"));
+
+      result = Capability.DEFAULT.specificationOnName(scope, "-name_start_with-");
+      Assertions.assertFalse(result.supported());
+      Assertions.assertTrue(result.unsupportedMessage().contains("is illegal"));
+
+      result = Capability.DEFAULT.specificationOnName(scope, "/name_start_with/");
+      Assertions.assertFalse(result.supported());
+      Assertions.assertTrue(result.unsupportedMessage().contains("is illegal"));
+
+      result = Capability.DEFAULT.specificationOnName(scope, "=name_start_with=");
       Assertions.assertFalse(result.supported());
       Assertions.assertTrue(result.unsupportedMessage().contains("is illegal"));
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use \\w instead of [a-zA-Z0-9_] in regexp in Capability.java

### Why are the changes needed?

Fix: #3078 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

ut
