### PR TITLE
[#2115] fix(jdbc-catalog):  Can't create a table in database with the same name prefix.

### DIFF
--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/operation/JdbcTableOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/operation/JdbcTableOperations.java
@@ -124,32 +124,44 @@ public abstract class JdbcTableOperations implements TableOperation {
     }
   }
 
+  /**
+   * Get table information from the result set and attach it to the table builder, If the table is
+   * not found, it will throw a NoSuchTableException.
+   *
+   * @param tablesResult The result set of the table
+   * @return The builder of the table to be returned
+   */
+  protected JdbcTable.Builder getTableBuilder(
+      ResultSet tablesResult, String databaseName, String tableName) throws SQLException {
+    boolean found = false;
+    JdbcTable.Builder builder = null;
+    while (tablesResult.next() && !found) {
+      if (Objects.equals(tablesResult.getString("TABLE_NAME"), tableName)) {
+        builder = getBasicJdbcTableInfo(tablesResult);
+        found = true;
+      }
+    }
+
+    if (!found) {
+      throw new NoSuchTableException("Table %s does not exist in %s.", tableName, databaseName);
+    }
+
+    return builder;
+  }
+
   @Override
   public JdbcTable load(String databaseName, String tableName) throws NoSuchTableException {
-    // We should handle case sensitivity and wild card issue in some catalog tables, take a MySQL
-    // table for example.
+    // We should handle case sensitivity and wild card issue in some catalog tables, take MySQL
+    // tables, for example.
     // 1. MySQL will get table 'a_b' and 'A_B' when we query 'a_b' in a case-insensitive charset
     // like utf8mb4.
     // 2. MySQL treats 'a_b' as a wildcard, matching any table name that begins with 'a', followed
     // by any character, and ending with 'b'.
     try (Connection connection = getConnection(databaseName)) {
-      // 1.Get table information
-      ResultSet table = getTable(connection, databaseName, tableName);
-      // The result of tables may be more than one due to the reason above, so we need to check the
-      // result
-      JdbcTable.Builder jdbcTableBuilder = JdbcTable.builder();
-      boolean found = false;
-      // Handle case-sensitive issues.
-      while (table.next() && !found) {
-        if (Objects.equals(table.getString("TABLE_NAME"), tableName)) {
-          jdbcTableBuilder = getBasicJdbcTableInfo(table);
-          found = true;
-        }
-      }
-
-      if (!found) {
-        throw new NoSuchTableException("Table %s does not exist in %s.", tableName, databaseName);
-      }
+      // 1. Get table information, The result of tables may be more than one due to the reason
+      // above, so we need to check the result.
+      ResultSet tables = getTable(connection, databaseName, tableName);
+      JdbcTable.Builder jdbcTableBuilder = getTableBuilder(tables, databaseName, tableName);
 
       // 2.Get column information
       List<JdbcColumn> jdbcColumns = new ArrayList<>();


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add check logic about schema name when loading table meta from driver. 

### Why are the changes needed?

Some drivers , such as PG drivers, contain schema name information, we need to filter it. Some drivers like MySQL don't like it, we do not need to check it. 
check it. 

Fix: #2115 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Add ITs: `testCreateSameTableInDifferentSchema`
