### PR TITLE
[#3139] fix(core): Fix NPE issue during creating catalog when properties are not specified

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/CatalogManager.java
@@ -316,8 +316,9 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
     }
 
     // load catalog-related configuration from catalog-specific configuration file
-    Map<String, String> catalogSpecificConfig = loadCatalogSpecificConfig(properties, provider);
-    Map<String, String> mergedConfig = mergeConf(properties, catalogSpecificConfig);
+    Map<String, String> newProperties = Optional.ofNullable(properties).orElse(Maps.newHashMap());
+    Map<String, String> catalogSpecificConfig = loadCatalogSpecificConfig(newProperties, provider);
+    Map<String, String> mergedConfig = mergeConf(newProperties, catalogSpecificConfig);
 
     long uid = idGenerator.nextId();
     StringIdentifier stringId = StringIdentifier.fromId(uid);

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/client/CatalogIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/client/CatalogIT.java
@@ -93,6 +93,26 @@ public class CatalogIT extends AbstractIT {
   }
 
   @Test
+  public void testCreateCatalogWithoutProperties() {
+    String catalogName = GravitinoITUtils.genRandomName("catalog");
+    NameIdentifier catalogIdent = NameIdentifier.of(metalakeName, catalogName);
+    Assertions.assertFalse(metalake.catalogExists(catalogIdent));
+
+    Catalog catalog =
+        metalake.createCatalog(
+            catalogIdent, Catalog.Type.FILESET, "hadoop", "catalog comment", null);
+    Assertions.assertTrue(metalake.catalogExists(catalogIdent));
+
+    Assertions.assertEquals(catalogName, catalog.name());
+    Assertions.assertEquals(Catalog.Type.FILESET, catalog.type());
+    Assertions.assertEquals("hadoop", catalog.provider());
+    Assertions.assertEquals("catalog comment", catalog.comment());
+    Assertions.assertTrue(catalog.properties().isEmpty());
+
+    metalake.dropCatalog(catalogIdent);
+  }
+
+  @Test
   public void testListCatalogsInfo() {
     String relCatalogName = GravitinoITUtils.genRandomName("rel_catalog_");
     NameIdentifier relCatalogIdent = NameIdentifier.of(metalakeName, relCatalogName);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Check if properties is null before use it.

### Why are the changes needed?

Without this Gravitino will throw NPE.

Fix: #3139 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

IT added.