### PR TITLE
[#3158] fix(doc): correct iceberg rest catalog service verify url

### DIFF
--- a/docs/iceberg-rest-service.md
+++ b/docs/iceberg-rest-service.md
@@ -127,11 +127,13 @@ To start the service:
 ./bin/gravitino.sh start
 ```
 
-To find out whether the service has started:
+To verify whether the service has started:
 
 ```shell
-curl  http://127.0.0.1:9001/iceberg/application.wadl
+curl  http://127.0.0.1:9001/iceberg/v1/config
 ```
+
+Normally you will see the output like `{"defaults":{},"overrides":{}}%`.
 
 ## Exploring the Gravitino and Apache Iceberg REST catalog service with Apache Spark
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
using `http://127.0.0.1:9001/iceberg/v1/config` to. verify the avaibility of Iceberg service.

### Why are the changes needed?
The original verify URL is not accessible in some environment.

Fix: #3158 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
just document
