### PR TITLE
[#3081] improvement(core): Remove hack in BaseCatalog.java

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/connector/BaseCatalog.java
+++ b/core/src/main/java/com/datastrato/gravitino/connector/BaseCatalog.java
@@ -35,8 +35,10 @@ public abstract class BaseCatalog<T extends BaseCatalog>
     implements Catalog, CatalogProvider, HasPropertyMetadata {
   private static final Logger LOG = LoggerFactory.getLogger(BaseCatalog.class);
 
-  // A hack way to inject custom operation to Gravitino, the object you used is not stable, don't
-  // use it unless you know what you are doing.
+  // This variable is used as a key in properties of catalogs to inject custom operation to
+  // Gravitino.
+  // You can use your own object to replace the default catalog operation.
+  // The object you used is not stable, don't use it unless you know what you are doing.
   @VisibleForTesting public static final String CATALOG_OPERATION_IMPL = "ops-impl";
 
   private CatalogEntity entity;


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

Modify the description of `CATALOG_OPERATION_IMPL`, avoid the use of "hack"

### Why are the changes needed?

Fix: #3081 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?
  
No need to test
