### PR TITLE
[#3161] fix(jdbc-pg): Fix getting PostgreSQL jdbc driver error

### DIFF
--- a/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/PostgreSQLCatalogOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/PostgreSQLCatalogOperations.java
@@ -38,7 +38,7 @@ public class PostgreSQLCatalogOperations extends JdbcCatalogOperations {
     try {
       // Unload the PostgreSQL driver, only Unload the driver if it is loaded by
       // IsolatedClassLoader.
-      Driver pgDriver = DriverManager.getDriver("jdbc:postgresql://dummy_address:dummy_port/");
+      Driver pgDriver = DriverManager.getDriver("jdbc:postgresql://dummy_address:12345/");
       deregisterDriver(pgDriver);
     } catch (Exception e) {
       LOG.warn("Failed to deregister PostgreSQL driver", e);

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
@@ -46,6 +46,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.sql.DriverManager;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -1497,5 +1498,14 @@ public class CatalogPostgreSqlIT extends AbstractIT {
         properties,
         Indexes.EMPTY_INDEXES,
         table);
+  }
+
+  @Test
+  void testGetPGDriver() {
+    Assertions.assertDoesNotThrow(
+        () -> DriverManager.getDriver("jdbc:postgresql://dummy_address:12345/"));
+    Assertions.assertThrows(
+        Exception.class,
+        () -> DriverManager.getDriver("jdbc:postgresql://dummy_address:dummy_port/"));
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change the dummy port to a real valid port.

### Why are the changes needed?

PostgreSQL is different from MySQL and is more strict about obtaining JDBC drivers. We need to provide a real port or we can't the driver. 

Fix: #3161 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

IT.
