### PR TITLE
[#3163] Refactor(spark-connector): Refactor Spark-connector IT to support more iceberg catalog backends

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkEnvIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkEnvIT.java
@@ -12,9 +12,7 @@ import com.datastrato.gravitino.integration.test.container.ContainerSuite;
 import com.datastrato.gravitino.integration.test.container.HiveContainer;
 import com.datastrato.gravitino.integration.test.util.spark.SparkUtilIT;
 import com.datastrato.gravitino.spark.connector.GravitinoSparkConfig;
-import com.datastrato.gravitino.spark.connector.iceberg.IcebergPropertiesConstants;
 import com.datastrato.gravitino.spark.connector.plugin.GravitinoSparkPlugin;
-import com.google.common.collect.Maps;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
@@ -32,17 +30,19 @@ public abstract class SparkEnvIT extends SparkUtilIT {
   private static final Logger LOG = LoggerFactory.getLogger(SparkEnvIT.class);
   private static final ContainerSuite containerSuite = ContainerSuite.getInstance();
 
+  protected String hiveMetastoreUri = "thrift://127.0.0.1:9083";
+  protected String warehouse;
   protected FileSystem hdfs;
-  private final String metalakeName = "test";
 
+  private final String metalakeName = "test";
   private SparkSession sparkSession;
-  private String hiveMetastoreUri = "thrift://127.0.0.1:9083";
   private String gravitinoUri = "http://127.0.0.1:8090";
-  private String warehouse;
 
   protected abstract String getCatalogName();
 
   protected abstract String getProvider();
+
+  protected abstract Map<String, String> getCatalogConfigs();
 
   @Override
   protected SparkSession getSparkSession() {
@@ -80,19 +80,7 @@ public abstract class SparkEnvIT extends SparkUtilIT {
   private void initMetalakeAndCatalogs() {
     client.createMetalake(NameIdentifier.of(metalakeName), "", Collections.emptyMap());
     GravitinoMetalake metalake = client.loadMetalake(NameIdentifier.of(metalakeName));
-    Map<String, String> properties = Maps.newHashMap();
-    switch (getProvider()) {
-      case "hive":
-        properties.put(GravitinoSparkConfig.GRAVITINO_HIVE_METASTORE_URI, hiveMetastoreUri);
-        break;
-      case "lakehouse-iceberg":
-        properties.put(IcebergPropertiesConstants.GRAVITINO_ICEBERG_CATALOG_BACKEND, "hive");
-        properties.put(IcebergPropertiesConstants.GRAVITINO_ICEBERG_CATALOG_WAREHOUSE, warehouse);
-        properties.put(IcebergPropertiesConstants.GRAVITINO_ICEBERG_CATALOG_URI, hiveMetastoreUri);
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported provider: " + getProvider());
-    }
+    Map<String, String> properties = getCatalogConfigs();
     metalake.createCatalog(
         NameIdentifier.of(metalakeName, getCatalogName()),
         Catalog.Type.RELATIONAL,

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/hive/SparkHiveCatalogIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/hive/SparkHiveCatalogIT.java
@@ -8,11 +8,14 @@ import com.datastrato.gravitino.integration.test.spark.SparkCommonIT;
 import com.datastrato.gravitino.integration.test.util.spark.SparkTableInfo;
 import com.datastrato.gravitino.integration.test.util.spark.SparkTableInfo.SparkColumnInfo;
 import com.datastrato.gravitino.integration.test.util.spark.SparkTableInfoChecker;
+import com.datastrato.gravitino.spark.connector.GravitinoSparkConfig;
 import com.datastrato.gravitino.spark.connector.hive.HivePropertiesConstants;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.types.DataTypes;
@@ -33,6 +36,13 @@ public class SparkHiveCatalogIT extends SparkCommonIT {
   @Override
   protected String getProvider() {
     return "hive";
+  }
+
+  @Override
+  protected Map<String, String> getCatalogConfigs() {
+    Map<String, String> catalogProperties = Maps.newHashMap();
+    catalogProperties.put(GravitinoSparkConfig.GRAVITINO_HIVE_METASTORE_URI, hiveMetastoreUri);
+    return catalogProperties;
   }
 
   @Override

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/iceberg/SparkIcebergCatalogHiveBackendIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/iceberg/SparkIcebergCatalogHiveBackendIT.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.integration.test.spark.iceberg;
+
+import com.datastrato.gravitino.spark.connector.iceberg.IcebergPropertiesConstants;
+import com.google.common.collect.Maps;
+import java.util.Map;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInstance;
+
+@Tag("gravitino-docker-it")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class SparkIcebergCatalogHiveBackendIT extends SparkIcebergCatalogIT {
+
+  @Override
+  protected Map<String, String> getCatalogConfigs() {
+    Map<String, String> catalogProperties = Maps.newHashMap();
+    catalogProperties.put(IcebergPropertiesConstants.GRAVITINO_ICEBERG_CATALOG_BACKEND, "hive");
+    catalogProperties.put(
+        IcebergPropertiesConstants.GRAVITINO_ICEBERG_CATALOG_WAREHOUSE, warehouse);
+    catalogProperties.put(
+        IcebergPropertiesConstants.GRAVITINO_ICEBERG_CATALOG_URI, hiveMetastoreUri);
+    return catalogProperties;
+  }
+}

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/iceberg/SparkIcebergCatalogIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/iceberg/SparkIcebergCatalogIT.java
@@ -5,31 +5,37 @@
 package com.datastrato.gravitino.integration.test.spark.iceberg;
 
 import com.datastrato.gravitino.integration.test.spark.SparkCommonIT;
+import com.datastrato.gravitino.integration.test.util.spark.SparkMetadataColumnInfo;
 import com.datastrato.gravitino.integration.test.util.spark.SparkTableInfo;
 import com.datastrato.gravitino.integration.test.util.spark.SparkTableInfoChecker;
 import com.google.common.collect.ImmutableList;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchFunctionException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.catalyst.expressions.Literal;
 import org.apache.spark.sql.connector.catalog.CatalogPlugin;
 import org.apache.spark.sql.connector.catalog.FunctionCatalog;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.functions.UnboundFunction;
 import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 
-@Tag("gravitino-docker-it")
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class SparkIcebergCatalogIT extends SparkCommonIT {
+public abstract class SparkIcebergCatalogIT extends SparkCommonIT {
 
   @Override
   protected String getCatalogName() {
@@ -200,6 +206,186 @@ public class SparkIcebergCatalogIT extends SparkCommonIT {
             });
   }
 
+  @Test
+  void testIcebergMetadataColumns() throws NoSuchTableException {
+    testMetadataColumns();
+    testSpecAndPartitionMetadataColumns();
+    testPositionMetadataColumn();
+    testPartitionMetadataColumnWithUnPartitionedTable();
+    testFileMetadataColumn();
+    testDeleteMetadataColumn();
+  }
+
+  private void testMetadataColumns() {
+    String tableName = "test_metadata_columns";
+    dropTableIfExists(tableName);
+    String createTableSQL = getCreateSimpleTableString(tableName);
+    createTableSQL = createTableSQL + " PARTITIONED BY (name);";
+    sql(createTableSQL);
+
+    SparkTableInfo tableInfo = getTableInfo(tableName);
+
+    SparkMetadataColumnInfo[] metadataColumns = getIcebergMetadataColumns();
+    SparkTableInfoChecker checker =
+        SparkTableInfoChecker.create()
+            .withName(tableName)
+            .withColumns(getSimpleTableColumn())
+            .withMetadataColumns(metadataColumns);
+    checker.check(tableInfo);
+  }
+
+  private void testSpecAndPartitionMetadataColumns() {
+    String tableName = "test_spec_partition";
+    dropTableIfExists(tableName);
+    String createTableSQL = getCreateSimpleTableString(tableName);
+    createTableSQL = createTableSQL + " PARTITIONED BY (name);";
+    sql(createTableSQL);
+
+    SparkTableInfo tableInfo = getTableInfo(tableName);
+
+    SparkMetadataColumnInfo[] metadataColumns = getIcebergMetadataColumns();
+    SparkTableInfoChecker checker =
+        SparkTableInfoChecker.create()
+            .withName(tableName)
+            .withColumns(getSimpleTableColumn())
+            .withMetadataColumns(metadataColumns);
+    checker.check(tableInfo);
+
+    String insertData = String.format("INSERT into %s values(2,'a', 1);", tableName);
+    sql(insertData);
+
+    String expectedMetadata = "0,a";
+    String getMetadataSQL =
+        String.format("SELECT _spec_id, _partition FROM %s ORDER BY _spec_id", tableName);
+    List<String> queryResult = getTableMetadata(getMetadataSQL);
+    Assertions.assertEquals(1, queryResult.size());
+    Assertions.assertEquals(expectedMetadata, queryResult.get(0));
+  }
+
+  private void testPositionMetadataColumn() throws NoSuchTableException {
+    String tableName = "test_position_metadata_column";
+    dropTableIfExists(tableName);
+    String createTableSQL = getCreateSimpleTableString(tableName);
+    createTableSQL = createTableSQL + " PARTITIONED BY (name);";
+    sql(createTableSQL);
+
+    SparkTableInfo tableInfo = getTableInfo(tableName);
+
+    SparkMetadataColumnInfo[] metadataColumns = getIcebergMetadataColumns();
+    SparkTableInfoChecker checker =
+        SparkTableInfoChecker.create()
+            .withName(tableName)
+            .withColumns(getSimpleTableColumn())
+            .withMetadataColumns(metadataColumns);
+    checker.check(tableInfo);
+
+    List<Integer> ids = new ArrayList<>();
+    for (int id = 0; id < 200; id++) {
+      ids.add(id);
+    }
+    Dataset<Row> df =
+        getSparkSession()
+            .createDataset(ids, Encoders.INT())
+            .withColumnRenamed("value", "id")
+            .withColumn("name", new Column(Literal.create("a", DataTypes.StringType)))
+            .withColumn("age", new Column(Literal.create(1, DataTypes.IntegerType)));
+    df.coalesce(1).writeTo(tableName).append();
+
+    Assertions.assertEquals(200, getSparkSession().table(tableName).count());
+
+    String getMetadataSQL = String.format("SELECT _pos FROM %s", tableName);
+    List<String> expectedRows = ids.stream().map(String::valueOf).collect(Collectors.toList());
+    List<String> queryResult = getTableMetadata(getMetadataSQL);
+    Assertions.assertEquals(expectedRows.size(), queryResult.size());
+    Assertions.assertArrayEquals(expectedRows.toArray(), queryResult.toArray());
+  }
+
+  private void testPartitionMetadataColumnWithUnPartitionedTable() {
+    String tableName = "test_position_metadata_column_in_unpartitioned_table";
+    dropTableIfExists(tableName);
+    String createTableSQL = getCreateSimpleTableString(tableName);
+    sql(createTableSQL);
+
+    SparkTableInfo tableInfo = getTableInfo(tableName);
+
+    SparkMetadataColumnInfo[] metadataColumns = getIcebergMetadataColumns();
+    metadataColumns[1] =
+        new SparkMetadataColumnInfo(
+            "_partition", DataTypes.createStructType(new StructField[] {}), true);
+    SparkTableInfoChecker checker =
+        SparkTableInfoChecker.create()
+            .withName(tableName)
+            .withColumns(getSimpleTableColumn())
+            .withMetadataColumns(metadataColumns);
+    checker.check(tableInfo);
+
+    String insertData = String.format("INSERT into %s values(2,'a', 1);", tableName);
+    sql(insertData);
+
+    String getMetadataSQL = String.format("SELECT _partition FROM %s", tableName);
+    Assertions.assertEquals(1, getSparkSession().sql(getMetadataSQL).count());
+    Row row = getSparkSession().sql(getMetadataSQL).collectAsList().get(0);
+    Assertions.assertNotNull(row);
+    Assertions.assertNull(row.get(0));
+  }
+
+  private void testFileMetadataColumn() {
+    String tableName = "test_file_metadata_column";
+    dropTableIfExists(tableName);
+    String createTableSQL = getCreateSimpleTableString(tableName);
+    createTableSQL = createTableSQL + " PARTITIONED BY (name);";
+    sql(createTableSQL);
+
+    SparkTableInfo tableInfo = getTableInfo(tableName);
+
+    SparkMetadataColumnInfo[] metadataColumns = getIcebergMetadataColumns();
+    SparkTableInfoChecker checker =
+        SparkTableInfoChecker.create()
+            .withName(tableName)
+            .withColumns(getSimpleTableColumn())
+            .withMetadataColumns(metadataColumns);
+    checker.check(tableInfo);
+
+    String insertData = String.format("INSERT into %s values(2,'a', 1);", tableName);
+    sql(insertData);
+
+    String getMetadataSQL = String.format("SELECT _file FROM %s", tableName);
+    List<String> queryResult = getTableMetadata(getMetadataSQL);
+    Assertions.assertEquals(1, queryResult.size());
+    Assertions.assertTrue(queryResult.get(0).contains(tableName));
+  }
+
+  private void testDeleteMetadataColumn() {
+    String tableName = "test_delete_metadata_column";
+    dropTableIfExists(tableName);
+    String createTableSQL = getCreateSimpleTableString(tableName);
+    createTableSQL = createTableSQL + " PARTITIONED BY (name);";
+    sql(createTableSQL);
+
+    SparkTableInfo tableInfo = getTableInfo(tableName);
+
+    SparkMetadataColumnInfo[] metadataColumns = getIcebergMetadataColumns();
+    SparkTableInfoChecker checker =
+        SparkTableInfoChecker.create()
+            .withName(tableName)
+            .withColumns(getSimpleTableColumn())
+            .withMetadataColumns(metadataColumns);
+    checker.check(tableInfo);
+
+    String insertData = String.format("INSERT into %s values(2,'a', 1);", tableName);
+    sql(insertData);
+
+    String getMetadataSQL = String.format("SELECT _deleted FROM %s", tableName);
+    List<String> queryResult = getTableMetadata(getMetadataSQL);
+    Assertions.assertEquals(1, queryResult.size());
+    Assertions.assertEquals("false", queryResult.get(0));
+
+    sql(getDeleteSql(tableName, "1 = 1"));
+
+    List<String> queryResult1 = getTableMetadata(getMetadataSQL);
+    Assertions.assertEquals(0, queryResult1.size());
+  }
+
   private List<SparkTableInfo.SparkColumnInfo> getIcebergSimpleTableColumn() {
     return Arrays.asList(
         SparkTableInfo.SparkColumnInfo.of("id", DataTypes.IntegerType, "id comment"),
@@ -215,5 +401,19 @@ public class SparkIcebergCatalogIT extends SparkCommonIT {
     return String.format(
         "CREATE TABLE %s (id INT COMMENT 'id comment', name STRING COMMENT '', ts TIMESTAMP)",
         tableName);
+  }
+
+  private SparkMetadataColumnInfo[] getIcebergMetadataColumns() {
+    return new SparkMetadataColumnInfo[] {
+      new SparkMetadataColumnInfo("_spec_id", DataTypes.IntegerType, false),
+      new SparkMetadataColumnInfo(
+          "_partition",
+          DataTypes.createStructType(
+              new StructField[] {DataTypes.createStructField("name", DataTypes.StringType, true)}),
+          true),
+      new SparkMetadataColumnInfo("_file", DataTypes.StringType, false),
+      new SparkMetadataColumnInfo("_pos", DataTypes.LongType, false),
+      new SparkMetadataColumnInfo("_deleted", DataTypes.BooleanType, false)
+    };
   }
 }

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/spark/SparkMetadataColumnInfo.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/spark/SparkMetadataColumnInfo.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright 2024 Datastrato Pvt Ltd.
+ *  This software is licensed under the Apache License version 2.
+ */
+
+package com.datastrato.gravitino.integration.test.util.spark;
+
+import org.apache.spark.sql.connector.catalog.MetadataColumn;
+import org.apache.spark.sql.types.DataType;
+
+public class SparkMetadataColumnInfo implements MetadataColumn {
+  private final String name;
+  private final DataType dataType;
+  private final boolean isNullable;
+
+  public SparkMetadataColumnInfo(String name, DataType dataType, boolean isNullable) {
+    this.name = name;
+    this.dataType = dataType;
+    this.isNullable = isNullable;
+  }
+
+  public String name() {
+    return this.name;
+  }
+
+  public DataType dataType() {
+    return this.dataType;
+  }
+
+  public boolean isNullable() {
+    return this.isNullable;
+  }
+}

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/spark/SparkTableInfoChecker.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/spark/SparkTableInfoChecker.java
@@ -37,6 +37,7 @@ public class SparkTableInfoChecker {
     BUCKET,
     COMMENT,
     TABLE_PROPERTY,
+    METADATA_COLUMN
   }
 
   public SparkTableInfoChecker withName(String name) {
@@ -135,6 +136,12 @@ public class SparkTableInfoChecker {
     return this;
   }
 
+  public SparkTableInfoChecker withMetadataColumns(SparkMetadataColumnInfo[] metadataColumns) {
+    this.expectedTableInfo.setMetadataColumns(metadataColumns);
+    this.checkFields.add(CheckField.METADATA_COLUMN);
+    return this;
+  }
+
   public void check(SparkTableInfo realTableInfo) {
     checkFields.stream()
         .forEach(
@@ -155,6 +162,22 @@ public class SparkTableInfoChecker {
                   break;
                 case BUCKET:
                   Assertions.assertEquals(expectedTableInfo.getBucket(), realTableInfo.getBucket());
+                  break;
+                case METADATA_COLUMN:
+                  Assertions.assertEquals(
+                      expectedTableInfo.getMetadataColumns().length,
+                      realTableInfo.getMetadataColumns().length);
+                  for (int i = 0; i < expectedTableInfo.getMetadataColumns().length; i++) {
+                    Assertions.assertEquals(
+                        expectedTableInfo.getMetadataColumns()[i].name(),
+                        realTableInfo.getMetadataColumns()[i].name());
+                    Assertions.assertEquals(
+                        expectedTableInfo.getMetadataColumns()[i].dataType(),
+                        realTableInfo.getMetadataColumns()[i].dataType());
+                    Assertions.assertEquals(
+                        expectedTableInfo.getMetadataColumns()[i].isNullable(),
+                        realTableInfo.getMetadataColumns()[i].isNullable());
+                  }
                   break;
                 case COMMENT:
                   Assertions.assertEquals(

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/spark/SparkUtilIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/spark/SparkUtilIT.java
@@ -119,6 +119,11 @@ public abstract class SparkUtilIT extends AbstractIT {
         .collect(Collectors.toList());
   }
 
+  // columns data are joined by ','
+  protected List<String> getTableMetadata(String getTableMetadataSql) {
+    return getQueryData(getTableMetadataSql);
+  }
+
   // Create SparkTableInfo from SparkBaseTable retrieved from LogicalPlan.
   protected SparkTableInfo getTableInfo(String tableName) {
     Dataset ds = getSparkSession().sql("DESC TABLE EXTENDED " + tableName);

--- a/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/iceberg/SparkIcebergTable.java
+++ b/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/iceberg/SparkIcebergTable.java
@@ -10,11 +10,14 @@ import com.datastrato.gravitino.spark.connector.PropertiesConverter;
 import com.datastrato.gravitino.spark.connector.SparkTransformConverter;
 import com.datastrato.gravitino.spark.connector.table.SparkBaseTable;
 import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.MetadataColumn;
 import org.apache.spark.sql.connector.catalog.SupportsDelete;
+import org.apache.spark.sql.connector.catalog.SupportsMetadataColumns;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.sources.Filter;
 
-public class SparkIcebergTable extends SparkBaseTable implements SupportsDelete {
+public class SparkIcebergTable extends SparkBaseTable
+    implements SupportsDelete, SupportsMetadataColumns {
 
   public SparkIcebergTable(
       Identifier identifier,
@@ -38,5 +41,10 @@ public class SparkIcebergTable extends SparkBaseTable implements SupportsDelete 
   @Override
   public void deleteWhere(Filter[] filters) {
     ((SupportsDelete) getSparkTable()).deleteWhere(filters);
+  }
+
+  @Override
+  public MetadataColumn[] metadataColumns() {
+    return ((SupportsMetadataColumns) getSparkTable()).metadataColumns();
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Refactor Spark-connector IT.

### Why are the changes needed?
to support more iceberg catalog backends, such as testing hive, jdbc, rest catalog backends.

Fix: https://github.com/datastrato/gravitino/issues/3163

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
Existing ITs.