### PR TITLE
[#3163] Refactor(spark-connector): Refactor Spark-connector IT to support more iceberg catalog backends

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkEnvIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/SparkEnvIT.java
@@ -12,9 +12,7 @@ import com.datastrato.gravitino.integration.test.container.ContainerSuite;
 import com.datastrato.gravitino.integration.test.container.HiveContainer;
 import com.datastrato.gravitino.integration.test.util.spark.SparkUtilIT;
 import com.datastrato.gravitino.spark.connector.GravitinoSparkConfig;
-import com.datastrato.gravitino.spark.connector.iceberg.IcebergPropertiesConstants;
 import com.datastrato.gravitino.spark.connector.plugin.GravitinoSparkPlugin;
-import com.google.common.collect.Maps;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
@@ -32,17 +30,19 @@ public abstract class SparkEnvIT extends SparkUtilIT {
   private static final Logger LOG = LoggerFactory.getLogger(SparkEnvIT.class);
   private static final ContainerSuite containerSuite = ContainerSuite.getInstance();
 
+  protected String hiveMetastoreUri = "thrift://127.0.0.1:9083";
+  protected String warehouse;
   protected FileSystem hdfs;
-  private final String metalakeName = "test";
 
+  private final String metalakeName = "test";
   private SparkSession sparkSession;
-  private String hiveMetastoreUri = "thrift://127.0.0.1:9083";
   private String gravitinoUri = "http://127.0.0.1:8090";
-  private String warehouse;
 
   protected abstract String getCatalogName();
 
   protected abstract String getProvider();
+
+  protected abstract Map<String, String> getCatalogConfigs();
 
   @Override
   protected SparkSession getSparkSession() {
@@ -80,19 +80,7 @@ public abstract class SparkEnvIT extends SparkUtilIT {
   private void initMetalakeAndCatalogs() {
     client.createMetalake(NameIdentifier.of(metalakeName), "", Collections.emptyMap());
     GravitinoMetalake metalake = client.loadMetalake(NameIdentifier.of(metalakeName));
-    Map<String, String> properties = Maps.newHashMap();
-    switch (getProvider()) {
-      case "hive":
-        properties.put(GravitinoSparkConfig.GRAVITINO_HIVE_METASTORE_URI, hiveMetastoreUri);
-        break;
-      case "lakehouse-iceberg":
-        properties.put(IcebergPropertiesConstants.GRAVITINO_ICEBERG_CATALOG_BACKEND, "hive");
-        properties.put(IcebergPropertiesConstants.GRAVITINO_ICEBERG_CATALOG_WAREHOUSE, warehouse);
-        properties.put(IcebergPropertiesConstants.GRAVITINO_ICEBERG_CATALOG_URI, hiveMetastoreUri);
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported provider: " + getProvider());
-    }
+    Map<String, String> properties = getCatalogConfigs();
     metalake.createCatalog(
         NameIdentifier.of(metalakeName, getCatalogName()),
         Catalog.Type.RELATIONAL,

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/hive/SparkHiveCatalogIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/hive/SparkHiveCatalogIT.java
@@ -8,11 +8,14 @@ import com.datastrato.gravitino.integration.test.spark.SparkCommonIT;
 import com.datastrato.gravitino.integration.test.util.spark.SparkTableInfo;
 import com.datastrato.gravitino.integration.test.util.spark.SparkTableInfo.SparkColumnInfo;
 import com.datastrato.gravitino.integration.test.util.spark.SparkTableInfoChecker;
+import com.datastrato.gravitino.spark.connector.GravitinoSparkConfig;
 import com.datastrato.gravitino.spark.connector.hive.HivePropertiesConstants;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.types.DataTypes;
@@ -33,6 +36,13 @@ public class SparkHiveCatalogIT extends SparkCommonIT {
   @Override
   protected String getProvider() {
     return "hive";
+  }
+
+  @Override
+  protected Map<String, String> getCatalogConfigs() {
+    Map<String, String> catalogProperties = Maps.newHashMap();
+    catalogProperties.put(GravitinoSparkConfig.GRAVITINO_HIVE_METASTORE_URI, hiveMetastoreUri);
+    return catalogProperties;
   }
 
   @Override

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/iceberg/SparkIcebergCatalogHiveBackendIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/iceberg/SparkIcebergCatalogHiveBackendIT.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.integration.test.spark.iceberg;
+
+import com.datastrato.gravitino.spark.connector.iceberg.IcebergPropertiesConstants;
+import com.google.common.collect.Maps;
+import java.util.Map;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInstance;
+
+@Tag("gravitino-docker-it")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class SparkIcebergCatalogHiveBackendIT extends SparkIcebergCatalogIT {
+
+  @Override
+  protected Map<String, String> getCatalogConfigs() {
+    Map<String, String> catalogProperties = Maps.newHashMap();
+    catalogProperties.put(IcebergPropertiesConstants.GRAVITINO_ICEBERG_CATALOG_BACKEND, "hive");
+    catalogProperties.put(
+        IcebergPropertiesConstants.GRAVITINO_ICEBERG_CATALOG_WAREHOUSE, warehouse);
+    catalogProperties.put(
+        IcebergPropertiesConstants.GRAVITINO_ICEBERG_CATALOG_URI, hiveMetastoreUri);
+    return catalogProperties;
+  }
+}

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/iceberg/SparkIcebergCatalogIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/iceberg/SparkIcebergCatalogIT.java
@@ -23,13 +23,9 @@ import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.functions.UnboundFunction;
 import org.apache.spark.sql.types.DataTypes;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 
-@Tag("gravitino-docker-it")
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class SparkIcebergCatalogIT extends SparkCommonIT {
+public abstract class SparkIcebergCatalogIT extends SparkCommonIT {
 
   @Override
   protected String getCatalogName() {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Refactor Spark-connector IT.


### Why are the changes needed?
to support more iceberg catalog backends, such as testing hive, jdbc, rest catalog backends.

Fix: https://github.com/datastrato/gravitino/issues/3163

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing ITs.
