### PR TITLE
[#2266] fix(partition): enable preassign partition when creating range and list partitioning table

### DIFF
--- a/api/src/main/java/com/datastrato/gravitino/rel/expressions/transforms/Transform.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/expressions/transforms/Transform.java
@@ -20,9 +20,12 @@
 
 package com.datastrato.gravitino.rel.expressions.transforms;
 
+import static com.datastrato.gravitino.rel.partitions.Partitions.EMPTY_PARTITIONS;
+
 import com.datastrato.gravitino.annotation.Evolving;
 import com.datastrato.gravitino.rel.expressions.Expression;
 import com.datastrato.gravitino.rel.expressions.NamedReference;
+import com.datastrato.gravitino.rel.partitions.Partition;
 import java.util.Objects;
 
 /**
@@ -40,11 +43,12 @@ public interface Transform extends Expression {
   Expression[] arguments();
 
   /**
-   * @return The preassigned partitions in the partitioning. Currently, only ListTransform and
-   *     RangeTransform need to deal with assignments
+   * @return The preassigned partitions in the partitioning. Currently, only {@link
+   *     Transforms.ListTransform} and {@link Transforms.RangeTransform} need to deal with
+   *     assignments
    */
-  default Expression[] assignments() {
-    return Expression.EMPTY_EXPRESSION;
+  default Partition[] assignments() {
+    return EMPTY_PARTITIONS;
   }
 
   @Override

--- a/api/src/main/java/com/datastrato/gravitino/rel/expressions/transforms/Transforms.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/expressions/transforms/Transforms.java
@@ -4,14 +4,11 @@
  */
 package com.datastrato.gravitino.rel.expressions.transforms;
 
-import static com.datastrato.gravitino.rel.partitions.Partitions.EMPTY_PARTITIONS;
-
 import com.datastrato.gravitino.rel.expressions.Expression;
 import com.datastrato.gravitino.rel.expressions.NamedReference;
 import com.datastrato.gravitino.rel.expressions.literals.Literal;
 import com.datastrato.gravitino.rel.expressions.literals.Literals;
 import com.datastrato.gravitino.rel.partitions.ListPartition;
-import com.datastrato.gravitino.rel.partitions.Partition;
 import com.datastrato.gravitino.rel.partitions.RangePartition;
 import com.google.common.collect.ObjectArrays;
 import java.util.Arrays;
@@ -171,8 +168,7 @@ public class Transforms {
    * @return The created transform
    */
   public static ListTransform list(String[]... fieldNames) {
-    return new ListTransform(
-        Arrays.stream(fieldNames).map(NamedReference::field).toArray(NamedReference[]::new));
+    return list(fieldNames, new ListPartition[0]);
   }
 
   /**

--- a/api/src/main/java/com/datastrato/gravitino/rel/expressions/transforms/Transforms.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/expressions/transforms/Transforms.java
@@ -4,10 +4,15 @@
  */
 package com.datastrato.gravitino.rel.expressions.transforms;
 
+import static com.datastrato.gravitino.rel.partitions.Partitions.EMPTY_PARTITIONS;
+
 import com.datastrato.gravitino.rel.expressions.Expression;
 import com.datastrato.gravitino.rel.expressions.NamedReference;
 import com.datastrato.gravitino.rel.expressions.literals.Literal;
 import com.datastrato.gravitino.rel.expressions.literals.Literals;
+import com.datastrato.gravitino.rel.partitions.ListPartition;
+import com.datastrato.gravitino.rel.partitions.Partition;
+import com.datastrato.gravitino.rel.partitions.RangePartition;
 import com.google.common.collect.ObjectArrays;
 import java.util.Arrays;
 import java.util.Objects;
@@ -171,13 +176,37 @@ public class Transforms {
   }
 
   /**
+   * Create a transform that includes multiple fields in a list with preassigned list partitions.
+   *
+   * @param fieldNames The field names to include in the list
+   * @param assignments The preassigned list partitions
+   * @return The created transform
+   */
+  public static ListTransform list(String[][] fieldNames, ListPartition[] assignments) {
+    return new ListTransform(
+        Arrays.stream(fieldNames).map(NamedReference::field).toArray(NamedReference[]::new),
+        assignments);
+  }
+
+  /**
    * Create a transform that returns the range of the input value.
    *
    * @param fieldName The field name to transform
    * @return The created transform
    */
   public static RangeTransform range(String[] fieldName) {
-    return new RangeTransform(NamedReference.field(fieldName));
+    return range(fieldName, new RangePartition[0]);
+  }
+
+  /**
+   * Create a transform that returns the range of the input value with preassigned range partitions.
+   *
+   * @param fieldName The field name to transform
+   * @param assignments The preassigned range partitions
+   * @return The created transform
+   */
+  public static RangeTransform range(String[] fieldName, RangePartition[] assignments) {
+    return new RangeTransform(NamedReference.field(fieldName), assignments);
   }
 
   /**
@@ -486,9 +515,16 @@ public class Transforms {
   public static final class ListTransform implements Transform {
 
     private final NamedReference[] fields;
+    private final ListPartition[] assignments;
 
     private ListTransform(NamedReference[] fields) {
       this.fields = fields;
+      this.assignments = new ListPartition[0];
+    }
+
+    private ListTransform(NamedReference[] fields, ListPartition[] assignments) {
+      this.fields = fields;
+      this.assignments = assignments;
     }
 
     /** @return The field names to include in the list. */
@@ -510,9 +546,8 @@ public class Transforms {
 
     /** @return The assignments to the transform. */
     @Override
-    public Expression[] assignments() {
-      // todo: resolve this
-      return Transform.super.assignments();
+    public ListPartition[] assignments() {
+      return assignments;
     }
 
     @Override
@@ -537,9 +572,16 @@ public class Transforms {
   public static final class RangeTransform implements Transform {
 
     private final NamedReference field;
+    private final RangePartition[] assignments;
 
     private RangeTransform(NamedReference field) {
       this.field = field;
+      this.assignments = new RangePartition[0];
+    }
+
+    private RangeTransform(NamedReference field, RangePartition[] assignments) {
+      this.field = field;
+      this.assignments = assignments;
     }
 
     /** @return The field name to transform. */
@@ -561,9 +603,8 @@ public class Transforms {
 
     /** @return The assignments to the transform. */
     @Override
-    public Expression[] assignments() {
-      // todo: resolve this
-      return Transform.super.assignments();
+    public RangePartition[] assignments() {
+      return assignments;
     }
 
     @Override

--- a/api/src/main/java/com/datastrato/gravitino/rel/partitions/Partitions.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/partitions/Partitions.java
@@ -12,6 +12,8 @@ import java.util.Objects;
 /** The helper class for partition expressions. */
 public class Partitions {
 
+  public static Partition[] EMPTY_PARTITIONS = new Partition[0];
+
   /**
    * Creates a range partition.
    *

--- a/api/src/main/java/com/datastrato/gravitino/rel/partitions/Partitions.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/partitions/Partitions.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 /** The helper class for partition expressions. */
 public class Partitions {
 
+  /** An empty array of partitions. */
   public static Partition[] EMPTY_PARTITIONS = new Partition[0];
 
   /**

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/ListPartitioningDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/ListPartitioningDTO.java
@@ -18,7 +18,7 @@ import lombok.EqualsAndHashCode;
 public final class ListPartitioningDTO implements Partitioning {
 
   /**
-   * Creates a new ListPartitioningDTO.
+   * Creates a new ListPartitioningDTO with no pre-assigned partitions.
    *
    * @param fieldNames The names of the fields to partition.
    * @return The new ListPartitioningDTO.
@@ -27,6 +27,13 @@ public final class ListPartitioningDTO implements Partitioning {
     return of(fieldNames, new ListPartitionDTO[0]);
   }
 
+  /**
+   * Creates a new ListPartitioningDTO.
+   *
+   * @param fieldNames The names of the fields to partition.
+   * @param assignments The pre-assigned list partitions.
+   * @return The new ListPartitioningDTO.
+   */
   public static ListPartitioningDTO of(String[][] fieldNames, ListPartitionDTO[] assignments) {
     return new ListPartitioningDTO(fieldNames, assignments);
   }

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/ListPartitioningDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/ListPartitioningDTO.java
@@ -7,6 +7,7 @@ package com.datastrato.gravitino.dto.rel.partitioning;
 import static com.datastrato.gravitino.dto.rel.PartitionUtils.validateFieldExistence;
 
 import com.datastrato.gravitino.dto.rel.ColumnDTO;
+import com.datastrato.gravitino.dto.rel.partitions.ListPartitionDTO;
 import com.datastrato.gravitino.rel.expressions.Expression;
 import com.datastrato.gravitino.rel.expressions.NamedReference;
 import java.util.Arrays;
@@ -23,18 +24,29 @@ public final class ListPartitioningDTO implements Partitioning {
    * @return The new ListPartitioningDTO.
    */
   public static ListPartitioningDTO of(String[][] fieldNames) {
-    return new ListPartitioningDTO(fieldNames);
+    return of(fieldNames, new ListPartitionDTO[0]);
+  }
+
+  public static ListPartitioningDTO of(String[][] fieldNames, ListPartitionDTO[] assignments) {
+    return new ListPartitioningDTO(fieldNames, assignments);
   }
 
   private final String[][] fieldNames;
+  private final ListPartitionDTO[] assignments;
 
-  private ListPartitioningDTO(String[][] fieldNames) {
+  private ListPartitioningDTO(String[][] fieldNames, ListPartitionDTO[] assignments) {
     this.fieldNames = fieldNames;
+    this.assignments = assignments;
   }
 
   /** @return The names of the fields to partition. */
   public String[][] fieldNames() {
     return fieldNames;
+  }
+
+  @Override
+  public ListPartitionDTO[] assignments() {
+    return assignments;
   }
 
   /** @return The strategy of the partitioning. */
@@ -64,35 +76,5 @@ public final class ListPartitioningDTO implements Partitioning {
   @Override
   public Expression[] arguments() {
     return Arrays.stream(fieldNames).map(NamedReference::field).toArray(Expression[]::new);
-  }
-
-  /** The builder for ListPartitioningDTO. */
-  public static class Builder {
-    private String[][] fieldNames;
-
-    /**
-     * Set the field names for the builder.
-     *
-     * @param fieldNames The names of the fields to partition.
-     * @return The builder.
-     */
-    public Builder withFieldNames(String[][] fieldNames) {
-      this.fieldNames = fieldNames;
-      return this;
-    }
-
-    /**
-     * Builds the ListPartitioningDTO.
-     *
-     * @return The ListPartitioningDTO.
-     */
-    public ListPartitioningDTO build() {
-      return new ListPartitioningDTO(fieldNames);
-    }
-  }
-
-  /** @return the builder for creating a new instance of ListPartitioningDTO. */
-  public static Builder builder() {
-    return new Builder();
   }
 }

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/RangePartitioningDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/RangePartitioningDTO.java
@@ -17,7 +17,7 @@ import lombok.EqualsAndHashCode;
 public final class RangePartitioningDTO implements Partitioning {
 
   /**
-   * Creates a new RangePartitioningDTO.
+   * Creates a new RangePartitioningDTO with no pre-assigned partitions.
    *
    * @param fieldName The name of the field to partition.
    * @return The new RangePartitioningDTO.
@@ -26,6 +26,13 @@ public final class RangePartitioningDTO implements Partitioning {
     return of(fieldName, new RangePartitionDTO[0]);
   }
 
+  /**
+   * Creates a new RangePartitioningDTO.
+   *
+   * @param fieldName The name of the field to partition.
+   * @param assignments The pre-assigned range partitions.
+   * @return The new RangePartitioningDTO.
+   */
   public static RangePartitioningDTO of(String[] fieldName, RangePartitionDTO[] assignments) {
     return new RangePartitioningDTO(fieldName, assignments);
   }

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/RangePartitioningDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/RangePartitioningDTO.java
@@ -8,6 +8,7 @@ import static com.datastrato.gravitino.dto.rel.PartitionUtils.validateFieldExist
 import static com.datastrato.gravitino.rel.expressions.NamedReference.field;
 
 import com.datastrato.gravitino.dto.rel.ColumnDTO;
+import com.datastrato.gravitino.dto.rel.partitions.RangePartitionDTO;
 import com.datastrato.gravitino.rel.expressions.Expression;
 import lombok.EqualsAndHashCode;
 
@@ -22,13 +23,19 @@ public final class RangePartitioningDTO implements Partitioning {
    * @return The new RangePartitioningDTO.
    */
   public static RangePartitioningDTO of(String[] fieldName) {
-    return new RangePartitioningDTO(fieldName);
+    return of(fieldName, new RangePartitionDTO[0]);
+  }
+
+  public static RangePartitioningDTO of(String[] fieldName, RangePartitionDTO[] assignments) {
+    return new RangePartitioningDTO(fieldName, assignments);
   }
 
   private final String[] fieldName;
+  private final RangePartitionDTO[] assignments;
 
-  private RangePartitioningDTO(String[] fieldName) {
+  private RangePartitioningDTO(String[] fieldName, RangePartitionDTO[] assignments) {
     this.fieldName = fieldName;
+    this.assignments = assignments;
   }
 
   /** @return The name of the field to partition. */
@@ -40,6 +47,11 @@ public final class RangePartitioningDTO implements Partitioning {
   @Override
   public String name() {
     return strategy().name().toLowerCase();
+  }
+
+  @Override
+  public RangePartitionDTO[] assignments() {
+    return assignments;
   }
 
   /** @return The arguments of the partitioning. */
@@ -63,35 +75,5 @@ public final class RangePartitioningDTO implements Partitioning {
   @Override
   public void validate(ColumnDTO[] columns) throws IllegalArgumentException {
     validateFieldExistence(columns, fieldName);
-  }
-
-  /** The builder for the RangePartitioningDTO. */
-  public static class Builder {
-    private String[] fieldName;
-
-    /**
-     * Set the field name for the builder.
-     *
-     * @param fieldName The name of the field to partition.
-     * @return The builder.
-     */
-    public Builder withFieldName(String[] fieldName) {
-      this.fieldName = fieldName;
-      return this;
-    }
-
-    /**
-     * Builds the RangePartitioningDTO.
-     *
-     * @return The new RangePartitioningDTO.
-     */
-    public RangePartitioningDTO build() {
-      return new RangePartitioningDTO(fieldName);
-    }
-  }
-
-  /** @return the builder for creating a new instance of RangePartitioningDTO. */
-  public static Builder builder() {
-    return new Builder();
   }
 }

--- a/common/src/main/java/com/datastrato/gravitino/json/JsonUtils.java
+++ b/common/src/main/java/com/datastrato/gravitino/json/JsonUtils.java
@@ -1103,7 +1103,15 @@ public class JsonUtils {
               node);
           List<ListPartitionDTO> assignments = Lists.newArrayList();
           node.get(ASSIGNMENTS_NAME)
-              .forEach(assignment -> assignments.add((ListPartitionDTO) readPartition(assignment)));
+              .forEach(
+                  assignment -> {
+                    PartitionDTO partitionDTO = readPartition(assignment);
+                    Preconditions.checkArgument(
+                        partitionDTO instanceof ListPartitionDTO,
+                        "Cannot parse list partitioning from non-list assignment: %s",
+                        assignment);
+                    assignments.add((ListPartitionDTO) partitionDTO);
+                  });
           return ListPartitioningDTO.of(
               listFields.toArray(new String[0][0]), assignments.toArray(new ListPartitionDTO[0]));
 
@@ -1120,8 +1128,14 @@ public class JsonUtils {
           List<RangePartitionDTO> rangeAssignments = Lists.newArrayList();
           node.get(ASSIGNMENTS_NAME)
               .forEach(
-                  assignment ->
-                      rangeAssignments.add((RangePartitionDTO) readPartition(assignment)));
+                  assignment -> {
+                    PartitionDTO partitionDTO = readPartition(assignment);
+                    Preconditions.checkArgument(
+                        partitionDTO instanceof RangePartitionDTO,
+                        "Cannot parse range partitioning from non-range assignment: %s",
+                        assignment);
+                    rangeAssignments.add((RangePartitionDTO) partitionDTO);
+                  });
           return RangePartitioningDTO.of(
               fields, rangeAssignments.toArray(new RangePartitionDTO[0]));
 

--- a/common/src/main/java/com/datastrato/gravitino/json/JsonUtils.java
+++ b/common/src/main/java/com/datastrato/gravitino/json/JsonUtils.java
@@ -80,6 +80,7 @@ public class JsonUtils {
   private static final String STRATEGY = "strategy";
   private static final String FIELD_NAME = "fieldName";
   private static final String FIELD_NAMES = "fieldNames";
+  private static final String ASSIGNMENTS_NAME = "assignments";
   private static final String NUM_BUCKETS = "numBuckets";
   private static final String WIDTH = "width";
   private static final String FUNCTION_NAME = "funcName";
@@ -427,6 +428,127 @@ public class JsonUtils {
         throw new IOException("Unknown function argument type: " + arg.argType());
     }
     gen.writeEndObject();
+  }
+
+  private static void writePartition(PartitionDTO value, JsonGenerator gen) throws IOException {
+    gen.writeStartObject();
+    gen.writeStringField(PARTITION_TYPE, value.type().name().toLowerCase());
+    gen.writeStringField(PARTITION_NAME, value.name());
+    switch (value.type()) {
+      case IDENTITY:
+        IdentityPartitionDTO identityPartitionDTO = (IdentityPartitionDTO) value;
+        gen.writeFieldName(FIELD_NAMES);
+        gen.writeObject(identityPartitionDTO.fieldNames());
+        gen.writeArrayFieldStart(IDENTITY_PARTITION_VALUES);
+        for (LiteralDTO literal : identityPartitionDTO.values()) {
+          writeFunctionArg(literal, gen);
+        }
+        gen.writeEndArray();
+        break;
+      case LIST:
+        ListPartitionDTO listPartitionDTO = (ListPartitionDTO) value;
+        gen.writeArrayFieldStart(LIST_PARTITION_LISTS);
+        for (LiteralDTO[] literals : listPartitionDTO.lists()) {
+          gen.writeStartArray();
+          for (LiteralDTO literal : literals) {
+            writeFunctionArg(literal, gen);
+          }
+          gen.writeEndArray();
+        }
+        gen.writeEndArray();
+        break;
+      case RANGE:
+        RangePartitionDTO rangePartitionDTO = (RangePartitionDTO) value;
+        gen.writeFieldName(RANGE_PARTITION_UPPER);
+        writeFunctionArg(rangePartitionDTO.upper(), gen);
+        gen.writeFieldName(RANGE_PARTITION_LOWER);
+        writeFunctionArg(rangePartitionDTO.lower(), gen);
+        break;
+      default:
+        throw new IOException("Unknown partition type: " + value.type());
+    }
+    gen.writeObjectField(PARTITION_PROPERTIES, value.properties());
+    gen.writeEndObject();
+  }
+
+  private static PartitionDTO readPartition(JsonNode node) {
+    Preconditions.checkArgument(
+        node != null && !node.isNull() && node.isObject(),
+        "Partition must be a valid JSON object, but found: %s",
+        node);
+    Preconditions.checkArgument(
+        node.has(PARTITION_TYPE), "Partition must have a type field, but found: %s", node);
+    String type = getString(PARTITION_TYPE, node);
+    switch (PartitionDTO.Type.valueOf(type.toUpperCase())) {
+      case IDENTITY:
+        Preconditions.checkArgument(
+            node.has(FIELD_NAMES) && node.get(FIELD_NAMES).isArray(),
+            "Identity partition must have array of fieldNames, but found: %s",
+            node);
+        Preconditions.checkArgument(
+            node.has(IDENTITY_PARTITION_VALUES) && node.get(IDENTITY_PARTITION_VALUES).isArray(),
+            "Identity partition must have array of values, but found: %s",
+            node);
+
+        List<String[]> fieldNames = Lists.newArrayList();
+        node.get(FIELD_NAMES).forEach(field -> fieldNames.add(getStringArray((ArrayNode) field)));
+        List<LiteralDTO> values = Lists.newArrayList();
+        node.get(IDENTITY_PARTITION_VALUES)
+            .forEach(value -> values.add((LiteralDTO) readFunctionArg(value)));
+        return IdentityPartitionDTO.builder()
+            .withName(getStringOrNull(PARTITION_NAME, node))
+            .withFieldNames(fieldNames.toArray(new String[0][0]))
+            .withValues(values.toArray(new LiteralDTO[0]))
+            .withProperties(getStringMapOrNull(PARTITION_PROPERTIES, node))
+            .build();
+
+      case LIST:
+        Preconditions.checkArgument(
+            node.has(PARTITION_NAME), "List partition must have name, but found: %s", node);
+        Preconditions.checkArgument(
+            node.has(LIST_PARTITION_LISTS) && node.get(LIST_PARTITION_LISTS).isArray(),
+            "List partition must have array of lists, but found: %s",
+            node);
+
+        List<LiteralDTO[]> lists = Lists.newArrayList();
+        node.get(LIST_PARTITION_LISTS)
+            .forEach(
+                list -> {
+                  List<LiteralDTO> literals = Lists.newArrayList();
+                  list.forEach(literal -> literals.add((LiteralDTO) readFunctionArg(literal)));
+                  lists.add(literals.toArray(new LiteralDTO[0]));
+                });
+
+        return ListPartitionDTO.builder()
+            .withName(getStringOrNull(PARTITION_NAME, node))
+            .withLists(lists.toArray(new LiteralDTO[0][0]))
+            .withProperties(getStringMapOrNull(PARTITION_PROPERTIES, node))
+            .build();
+
+      case RANGE:
+        Preconditions.checkArgument(
+            node.has(PARTITION_NAME), "Range partition must have name, but found: %s", node);
+        Preconditions.checkArgument(
+            node.has(RANGE_PARTITION_UPPER),
+            "Range partition must have upper, but found: %s",
+            node);
+        Preconditions.checkArgument(
+            node.has(RANGE_PARTITION_LOWER),
+            "Range partition must have lower, but found: %s",
+            node);
+
+        LiteralDTO upper = (LiteralDTO) readFunctionArg(node.get(RANGE_PARTITION_UPPER));
+        LiteralDTO lower = (LiteralDTO) readFunctionArg(node.get(RANGE_PARTITION_LOWER));
+        return RangePartitionDTO.builder()
+            .withName(getStringOrNull(PARTITION_NAME, node))
+            .withUpper(upper)
+            .withLower(lower)
+            .withProperties(getStringMapOrNull(PARTITION_PROPERTIES, node))
+            .build();
+
+      default:
+        throw new IllegalArgumentException("Unknown partition type: " + type);
+    }
   }
 
   /**
@@ -896,11 +1018,21 @@ public class JsonUtils {
           ListPartitioningDTO listPartitioningDTO = (ListPartitioningDTO) value;
           gen.writeFieldName(FIELD_NAMES);
           gen.writeObject(listPartitioningDTO.fieldNames());
+          gen.writeArrayFieldStart(ASSIGNMENTS_NAME);
+          for (ListPartitionDTO listPartitionDTO : listPartitioningDTO.assignments()) {
+            writePartition(listPartitionDTO, gen);
+          }
+          gen.writeEndArray();
           break;
         case RANGE:
           RangePartitioningDTO rangePartitioningDTO = (RangePartitioningDTO) value;
           gen.writeFieldName(FIELD_NAME);
           gen.writeObject(rangePartitioningDTO.fieldName());
+          gen.writeArrayFieldStart(ASSIGNMENTS_NAME);
+          for (PartitionDTO rangePartitionDTO : rangePartitioningDTO.assignments()) {
+            writePartition(rangePartitionDTO, gen);
+          }
+          gen.writeEndArray();
           break;
         case FUNCTION:
           FunctionPartitioningDTO funcExpression = (FunctionPartitioningDTO) value;
@@ -933,29 +1065,66 @@ public class JsonUtils {
       switch (Partitioning.Strategy.getByName(strategy)) {
         case IDENTITY:
           return IdentityPartitioningDTO.of(getStringList(FIELD_NAME, node).toArray(new String[0]));
+
         case YEAR:
           return YearPartitioningDTO.of(getStringList(FIELD_NAME, node).toArray(new String[0]));
+
         case MONTH:
           return MonthPartitioningDTO.of(getStringList(FIELD_NAME, node).toArray(new String[0]));
+
         case DAY:
           return DayPartitioningDTO.of(getStringList(FIELD_NAME, node).toArray(new String[0]));
+
         case HOUR:
           return HourPartitioningDTO.of(getStringList(FIELD_NAME, node).toArray(new String[0]));
+
         case BUCKET:
           int numBuckets = getInt(NUM_BUCKETS, node);
           List<String[]> fieldNames = Lists.newArrayList();
           node.get(FIELD_NAMES).forEach(field -> fieldNames.add(getStringArray((ArrayNode) field)));
           return BucketPartitioningDTO.of(numBuckets, fieldNames.toArray(new String[0][0]));
+
         case TRUNCATE:
           int width = getInt(WIDTH, node);
           return TruncatePartitioningDTO.of(
               width, getStringList(FIELD_NAME, node).toArray(new String[0]));
+
         case LIST:
           List<String[]> listFields = Lists.newArrayList();
           node.get(FIELD_NAMES).forEach(field -> listFields.add(getStringArray((ArrayNode) field)));
-          return ListPartitioningDTO.of(listFields.toArray(new String[0][0]));
+
+          if (!node.hasNonNull(ASSIGNMENTS_NAME)) {
+            return ListPartitioningDTO.of(listFields.toArray(new String[0][0]));
+          }
+
+          Preconditions.checkArgument(
+              node.get(ASSIGNMENTS_NAME).isArray(),
+              "Cannot parse list partitioning from non-array assignments: %s",
+              node);
+          List<ListPartitionDTO> assignments = Lists.newArrayList();
+          node.get(ASSIGNMENTS_NAME)
+              .forEach(assignment -> assignments.add((ListPartitionDTO) readPartition(assignment)));
+          return ListPartitioningDTO.of(
+              listFields.toArray(new String[0][0]), assignments.toArray(new ListPartitionDTO[0]));
+
         case RANGE:
-          return RangePartitioningDTO.of(getStringList(FIELD_NAME, node).toArray(new String[0]));
+          String[] fields = getStringList(FIELD_NAME, node).toArray(new String[0]);
+          if (!node.hasNonNull(ASSIGNMENTS_NAME)) {
+            return RangePartitioningDTO.of(fields);
+          }
+
+          Preconditions.checkArgument(
+              node.get(ASSIGNMENTS_NAME).isArray(),
+              "Cannot parse range partitioning from non-array assignments: %s",
+              node);
+          List<RangePartitionDTO> rangeAssignments = Lists.newArrayList();
+          node.get(ASSIGNMENTS_NAME)
+              .forEach(
+                  assignment ->
+                      rangeAssignments.add((RangePartitionDTO) readPartition(assignment)));
+          return RangePartitioningDTO.of(
+              fields, rangeAssignments.toArray(new RangePartitionDTO[0]));
+
         case FUNCTION:
           String functionName = getString(FUNCTION_NAME, node);
           Preconditions.checkArgument(
@@ -965,6 +1134,7 @@ public class JsonUtils {
           List<FunctionArg> args = Lists.newArrayList();
           node.get(FUNCTION_ARGS).forEach(arg -> args.add(readFunctionArg(arg)));
           return FunctionPartitioningDTO.of(functionName, args.toArray(FunctionArg.EMPTY_ARGS));
+
         default:
           throw new IOException("Unknown partitioning strategy: " + strategy);
       }
@@ -1082,44 +1252,7 @@ public class JsonUtils {
     @Override
     public void serialize(PartitionDTO value, JsonGenerator gen, SerializerProvider serializers)
         throws IOException {
-      gen.writeStartObject();
-      gen.writeStringField(PARTITION_TYPE, value.type().name().toLowerCase());
-      gen.writeStringField(PARTITION_NAME, value.name());
-      switch (value.type()) {
-        case IDENTITY:
-          IdentityPartitionDTO identityPartitionDTO = (IdentityPartitionDTO) value;
-          gen.writeFieldName(FIELD_NAMES);
-          gen.writeObject(identityPartitionDTO.fieldNames());
-          gen.writeArrayFieldStart(IDENTITY_PARTITION_VALUES);
-          for (LiteralDTO literal : identityPartitionDTO.values()) {
-            writeFunctionArg(literal, gen);
-          }
-          gen.writeEndArray();
-          break;
-        case LIST:
-          ListPartitionDTO listPartitionDTO = (ListPartitionDTO) value;
-          gen.writeArrayFieldStart(LIST_PARTITION_LISTS);
-          for (LiteralDTO[] literals : listPartitionDTO.lists()) {
-            gen.writeStartArray();
-            for (LiteralDTO literal : literals) {
-              writeFunctionArg(literal, gen);
-            }
-            gen.writeEndArray();
-          }
-          gen.writeEndArray();
-          break;
-        case RANGE:
-          RangePartitionDTO rangePartitionDTO = (RangePartitionDTO) value;
-          gen.writeFieldName(RANGE_PARTITION_UPPER);
-          writeFunctionArg(rangePartitionDTO.upper(), gen);
-          gen.writeFieldName(RANGE_PARTITION_LOWER);
-          writeFunctionArg(rangePartitionDTO.lower(), gen);
-          break;
-        default:
-          throw new IOException("Unknown partition type: " + value.type());
-      }
-      gen.writeObjectField(PARTITION_PROPERTIES, value.properties());
-      gen.writeEndObject();
+      writePartition(value, gen);
     }
   }
 
@@ -1128,83 +1261,7 @@ public class JsonUtils {
     @Override
     public PartitionDTO deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
       JsonNode node = p.getCodec().readTree(p);
-      Preconditions.checkArgument(
-          node != null && !node.isNull() && node.isObject(),
-          "Partition must be a valid JSON object, but found: %s",
-          node);
-      Preconditions.checkArgument(
-          node.has(PARTITION_TYPE), "Partition must have a type field, but found: %s", node);
-      String type = getString(PARTITION_TYPE, node);
-      switch (PartitionDTO.Type.valueOf(type.toUpperCase())) {
-        case IDENTITY:
-          Preconditions.checkArgument(
-              node.has(FIELD_NAMES) && node.get(FIELD_NAMES).isArray(),
-              "Identity partition must have array of fieldNames, but found: %s",
-              node);
-          Preconditions.checkArgument(
-              node.has(IDENTITY_PARTITION_VALUES) && node.get(IDENTITY_PARTITION_VALUES).isArray(),
-              "Identity partition must have array of values, but found: %s",
-              node);
-
-          List<String[]> fieldNames = Lists.newArrayList();
-          node.get(FIELD_NAMES).forEach(field -> fieldNames.add(getStringArray((ArrayNode) field)));
-          List<LiteralDTO> values = Lists.newArrayList();
-          node.get(IDENTITY_PARTITION_VALUES)
-              .forEach(value -> values.add((LiteralDTO) readFunctionArg(value)));
-          return IdentityPartitionDTO.builder()
-              .withName(getStringOrNull(PARTITION_NAME, node))
-              .withFieldNames(fieldNames.toArray(new String[0][0]))
-              .withValues(values.toArray(new LiteralDTO[0]))
-              .withProperties(getStringMapOrNull(PARTITION_PROPERTIES, node))
-              .build();
-
-        case LIST:
-          Preconditions.checkArgument(
-              node.has(PARTITION_NAME), "List partition must have name, but found: %s", node);
-          Preconditions.checkArgument(
-              node.has(LIST_PARTITION_LISTS) && node.get(LIST_PARTITION_LISTS).isArray(),
-              "List partition must have array of lists, but found: %s",
-              node);
-
-          List<LiteralDTO[]> lists = Lists.newArrayList();
-          node.get(LIST_PARTITION_LISTS)
-              .forEach(
-                  list -> {
-                    List<LiteralDTO> literals = Lists.newArrayList();
-                    list.forEach(literal -> literals.add((LiteralDTO) readFunctionArg(literal)));
-                    lists.add(literals.toArray(new LiteralDTO[0]));
-                  });
-
-          return ListPartitionDTO.builder()
-              .withName(getStringOrNull(PARTITION_NAME, node))
-              .withLists(lists.toArray(new LiteralDTO[0][0]))
-              .withProperties(getStringMapOrNull(PARTITION_PROPERTIES, node))
-              .build();
-
-        case RANGE:
-          Preconditions.checkArgument(
-              node.has(PARTITION_NAME), "Range partition must have name, but found: %s", node);
-          Preconditions.checkArgument(
-              node.has(RANGE_PARTITION_UPPER),
-              "Range partition must have upper, but found: %s",
-              node);
-          Preconditions.checkArgument(
-              node.has(RANGE_PARTITION_LOWER),
-              "Range partition must have lower, but found: %s",
-              node);
-
-          LiteralDTO upper = (LiteralDTO) readFunctionArg(node.get(RANGE_PARTITION_UPPER));
-          LiteralDTO lower = (LiteralDTO) readFunctionArg(node.get(RANGE_PARTITION_LOWER));
-          return RangePartitionDTO.builder()
-              .withName(getStringOrNull(PARTITION_NAME, node))
-              .withUpper(upper)
-              .withLower(lower)
-              .withProperties(getStringMapOrNull(PARTITION_PROPERTIES, node))
-              .build();
-
-        default:
-          throw new IOException("Unknown partition type: " + type);
-      }
+      return readPartition(node);
     }
   }
 

--- a/common/src/test/java/com/datastrato/gravitino/json/TestDTOJsonSerDe.java
+++ b/common/src/test/java/com/datastrato/gravitino/json/TestDTOJsonSerDe.java
@@ -25,6 +25,8 @@ import com.datastrato.gravitino.dto.rel.partitioning.Partitioning;
 import com.datastrato.gravitino.dto.rel.partitioning.RangePartitioningDTO;
 import com.datastrato.gravitino.dto.rel.partitioning.TruncatePartitioningDTO;
 import com.datastrato.gravitino.dto.rel.partitioning.YearPartitioningDTO;
+import com.datastrato.gravitino.dto.rel.partitions.ListPartitionDTO;
+import com.datastrato.gravitino.dto.rel.partitions.RangePartitionDTO;
 import com.datastrato.gravitino.rel.Column;
 import com.datastrato.gravitino.rel.types.Type;
 import com.datastrato.gravitino.rel.types.Types;
@@ -312,24 +314,67 @@ public class TestDTOJsonSerDe {
     Partitioning yearPart = YearPartitioningDTO.of(field1);
 
     // construct list partition
-    // TODO: support assign partition value
-    // String[][] p1Value = {{"2023-04-01", "San Francisco"}, {"2023-04-01", "San Francisco"}};
-    // String[][] p2Value = {{"2023-04-01", "Houston"}, {"2023-04-01", "Dallas"}};
-    Partitioning listPart =
-        ListPartitioningDTO.builder()
-            .withFieldNames(new String[][] {field1, field2})
-            // .withAssignment("p202304_California", p1Value)
-            // .withAssignment("p202304_Texas", p2Value)
+    LiteralDTO[][] pCaliforniaValue = {
+      {
+        LiteralDTO.builder().withValue("2023-04-01").withDataType(Types.DateType.get()).build(),
+        LiteralDTO.builder().withValue("San Francisco").withDataType(Types.StringType.get()).build()
+      },
+      {
+        LiteralDTO.builder().withValue("2023-04-01").withDataType(Types.DateType.get()).build(),
+        LiteralDTO.builder().withValue("San Diego").withDataType(Types.StringType.get()).build()
+      }
+    };
+    ListPartitionDTO pCalifornia =
+        ListPartitionDTO.builder()
+            .withName("p202304_California")
+            .withLists(pCaliforniaValue)
             .build();
+
+    LiteralDTO[][] pTexasValue = {
+      {
+        LiteralDTO.builder().withValue("2023-04-01").withDataType(Types.DateType.get()).build(),
+        LiteralDTO.builder().withValue("Houston").withDataType(Types.StringType.get()).build()
+      },
+      {
+        LiteralDTO.builder().withValue("2023-04-01").withDataType(Types.DateType.get()).build(),
+        LiteralDTO.builder().withValue("Dallas").withDataType(Types.StringType.get()).build()
+      }
+    };
+    ListPartitionDTO pTexas =
+        ListPartitionDTO.builder().withName("p202304_Texas").withLists(pTexasValue).build();
+
+    Partitioning listPart =
+        ListPartitioningDTO.of(
+            new String[][] {field1, field2}, new ListPartitionDTO[] {pCalifornia, pTexas});
 
     // construct range partition
     // TODO: support assign partition value
-    Partitioning rangePart =
-        RangePartitioningDTO.builder()
-            .withFieldName(field1)
-            // .withRange("p20230101", "2023-01-01T00:00:00", "2023-01-02T00:00:00")
-            // .withRange("p20230102", "2023-01-01T00:00:00", null)
+    RangePartitionDTO p20230101 =
+        RangePartitionDTO.builder()
+            .withName("p20230101")
+            .withUpper(
+                LiteralDTO.builder()
+                    .withValue("2023-01-01")
+                    .withDataType(Types.DateType.get())
+                    .build())
+            .withLower(
+                LiteralDTO.builder()
+                    .withValue("2023-01-01")
+                    .withDataType(Types.DateType.get())
+                    .build())
             .build();
+    RangePartitionDTO p20230102 =
+        RangePartitionDTO.builder()
+            .withName("p20230102")
+            .withUpper(
+                LiteralDTO.builder()
+                    .withValue("2023-01-02")
+                    .withDataType(Types.DateType.get())
+                    .build())
+            .withLower(LiteralDTO.NULL)
+            .build();
+    Partitioning rangePart =
+        RangePartitioningDTO.of(field1, new RangePartitionDTO[] {p20230101, p20230102});
 
     // construct function partitioning, toYYYYMM(toDate(ts, ‘Asia/Shanghai’))
     FunctionArg arg1 = FieldReferenceDTO.of(field1);

--- a/common/src/test/java/com/datastrato/gravitino/json/TestDTOJsonSerDe.java
+++ b/common/src/test/java/com/datastrato/gravitino/json/TestDTOJsonSerDe.java
@@ -405,6 +405,8 @@ public class TestDTOJsonSerDe {
             .configure(EnumFeature.WRITE_ENUMS_TO_LOWERCASE, true)
             .build()
             .writeValueAsString(partitioning);
+    System.out.println("lmh");
+    System.out.printf("partitioning: %s\n", serJson);
     Partitioning[] desPartitioning =
         JsonUtils.objectMapper().readValue(serJson, Partitioning[].class);
 

--- a/common/src/test/java/com/datastrato/gravitino/json/TestDTOJsonSerDe.java
+++ b/common/src/test/java/com/datastrato/gravitino/json/TestDTOJsonSerDe.java
@@ -348,7 +348,6 @@ public class TestDTOJsonSerDe {
             new String[][] {field1, field2}, new ListPartitionDTO[] {pCalifornia, pTexas});
 
     // construct range partition
-    // TODO: support assign partition value
     RangePartitionDTO p20230101 =
         RangePartitionDTO.builder()
             .withName("p20230101")

--- a/docs/open-api/partitioning.yaml
+++ b/docs/open-api/partitioning.yaml
@@ -144,6 +144,11 @@ components:
             - "list"
         fieldNames:
           $ref: "./tables.yaml#/components/schemas/FieldNames"
+        assignments:
+          type: array
+          description: The pre-assigned list partitions
+          items:
+            $ref: "./partitions.yaml#/components/schemas/ListPartition"
 
     RangePartitioning:
       type: object
@@ -157,6 +162,11 @@ components:
             - "range"
         fieldName:
           $ref: "./tables.yaml#/components/schemas/FieldName"
+        assignments:
+          type: array
+          description: The pre-assigned range partitions
+          items:
+            $ref: "./partitions.yaml#/components/schemas/RangePartition"
 
     FunctionPartitioning:
       type: object


### PR DESCRIPTION
### What changes were proposed in this pull request?

enable pre-assign partition when creating range and list partitioning table

### Why are the changes needed?

Fix: #2266 

### Does this PR introduce _any_ user-facing change?

yes, enable pre-assign partition when creating range and list partitioning table

### How was this patch tested?

tests modified
