### PR TITLE
[#3207] fix(test): Trigger integration test with changes in module `integration-test-common`

### DIFF
--- a/.github/workflows/backend-integration-test.yml
+++ b/.github/workflows/backend-integration-test.yml
@@ -36,6 +36,7 @@ jobs:
               - dev/**
               - gradle/**
               - integration-test/**
+              - integration-test-common/**
               - meta/**
               - server/**
               - server-common/**

--- a/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/MiniGravitino.java
+++ b/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/MiniGravitino.java
@@ -41,6 +41,10 @@ import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * MiniGravitino is a mini Gravitino server for integration tests. It starts a Gravitino server in
+ * the same JVM process.
+ */
 public class MiniGravitino {
   private static final Logger LOG = LoggerFactory.getLogger(MiniGravitino.class);
   private MiniGravitinoContext context;


### PR DESCRIPTION
### What changes were proposed in this pull request?

Trigger integration test when there is a change in module `integration-test-common`. 

### Why are the changes needed?

We should start the integration test if there are changes in module `integration-test-common`.  however, CI https://github.com/datastrato/gravitino/actions/runs/8872110159/job/24356012525?pr=3197 of PR https://github.com/datastrato/gravitino/pull/3197 can't start the CI pipeline.

Fixed: #3207 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

CI passed.
