### PR TITLE
[#3002] fix(jdbc-mysql): Fix MySQL list tables bugs.

### DIFF
--- a/catalogs/catalog-jdbc-common/src/test/java/com/datastrato/gravitino/catalog/jdbc/operation/SqliteTableOperations.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/com/datastrato/gravitino/catalog/jdbc/operation/SqliteTableOperations.java
@@ -109,7 +109,7 @@ public class SqliteTableOperations extends JdbcTableOperations {
   public List<String> listTables(String databaseName) throws NoSuchSchemaException {
     try (Connection connection = getConnection(databaseName)) {
       final List<String> names = Lists.newArrayList();
-      try (ResultSet tables = getTables(connection)) {
+      try (ResultSet tables = getTables(connection, databaseName)) {
         // tables.getString("TABLE_SCHEM") is always null.
         while (tables.next()) {
           names.add(tables.getString("TABLE_NAME"));

--- a/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/operation/DorisTableOperations.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/operation/DorisTableOperations.java
@@ -52,7 +52,7 @@ public class DorisTableOperations extends JdbcTableOperations {
     final List<String> names = Lists.newArrayList();
 
     try (Connection connection = getConnection(databaseName);
-        ResultSet tables = getTables(connection)) {
+        ResultSet tables = getTables(connection, databaseName)) {
       while (tables.next()) {
         if (Objects.equals(tables.getString("TABLE_CAT"), databaseName)) {
           names.add(tables.getString("TABLE_NAME"));

--- a/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlTableOperations.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/operation/MysqlTableOperations.java
@@ -58,13 +58,20 @@ public class MysqlTableOperations extends JdbcTableOperations {
     final List<String> names = Lists.newArrayList();
 
     try (Connection connection = getConnection(databaseName);
-        ResultSet tables = getTables(connection)) {
+        ResultSet tables = getTables(connection, databaseName)) {
+      long total = 0;
       while (tables.next()) {
-        if (Objects.equals(tables.getString("TABLE_CAT"), databaseName)) {
+        String dbNameFromResult = tables.getString("TABLE_CAT");
+        if (Objects.equals(dbNameFromResult, databaseName)) {
           names.add(tables.getString("TABLE_NAME"));
         }
+        total++;
       }
-      LOG.info("Finished listing tables size {} for database name {} ", names.size(), databaseName);
+      LOG.info(
+          "Finished listing tables size {} for database name {}, total scan = {}",
+          names.size(),
+          databaseName,
+          total);
       return names;
     } catch (final SQLException se) {
       throw this.exceptionMapper.toGravitinoException(se);

--- a/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/MysqlTableOperationsIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/MysqlTableOperationsIT.java
@@ -774,7 +774,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
   }
 
   @Test
-  void testListTable() {
+  void testListMySQLTable() {
     String[] dbNames = new String[] {"db1", "db2"};
     String[] tableNames = new String[] {"table1", "table2", "table3"};
     for (String dbName : dbNames) {

--- a/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/MysqlTableOperationsIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/MysqlTableOperationsIT.java
@@ -23,6 +23,7 @@ import com.datastrato.gravitino.rel.types.Types;
 import com.datastrato.gravitino.utils.RandomNameUtils;
 import java.sql.Connection;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -774,7 +775,7 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
   }
 
   @Test
-  void testListMySQLTable() {
+  void testListMySQLTable() throws SQLException {
     String[] dbNames = new String[] {"db1", "db2"};
     String[] tableNames = new String[] {"table1", "table2", "table3"};
     for (String dbName : dbNames) {
@@ -810,8 +811,6 @@ public class MysqlTableOperationsIT extends TestMysqlAbstractIT {
           tables.add(resultSet.getString("TABLE_NAME"));
         }
         Assertions.assertEquals(Arrays.asList(tableNames), tables);
-      } catch (Exception e) {
-        throw new RuntimeException(e);
       }
     }
   }

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlTableOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/operation/PostgreSqlTableOperations.java
@@ -675,7 +675,7 @@ public class PostgreSqlTableOperations extends JdbcTableOperations {
   }
 
   @Override
-  protected Connection getConnection(String schema) throws SQLException {
+  public Connection getConnection(String schema) throws SQLException {
     Connection connection = dataSource.getConnection();
     connection.setCatalog(database);
     connection.setSchema(schema);

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/PostgreSqlTableOperationsIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/PostgreSqlTableOperationsIT.java
@@ -626,7 +626,7 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
   }
 
   @Test
-  void testListPostgreSQLTable() {
+  void testListPostgreSQLTable() throws SQLException {
     String[] dbNames = new String[] {"db1", "db2"};
     String[] tableNames = new String[] {"table1", "table2", "table3"};
     for (String dbName : dbNames) {
@@ -662,8 +662,6 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
           tables.add(resultSet.getString("TABLE_NAME"));
         }
         Assertions.assertEquals(Arrays.asList(tableNames), tables);
-      } catch (Exception e) {
-        throw new RuntimeException(e);
       }
     }
   }

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/PostgreSqlTableOperationsIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/PostgreSqlTableOperationsIT.java
@@ -24,8 +24,10 @@ import com.datastrato.gravitino.rel.types.Type;
 import com.datastrato.gravitino.rel.types.Types;
 import com.datastrato.gravitino.utils.RandomNameUtils;
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -621,5 +623,48 @@ public class PostgreSqlTableOperationsIT extends TestPostgreSqlAbstractIT {
         StringUtils.contains(
             gravitinoRuntimeException.getMessage(),
             "column \"no_exist_1\" named in key does not exist"));
+  }
+
+  @Test
+  void testListPostgreSQLTable() {
+    String[] dbNames = new String[] {"db1", "db2"};
+    String[] tableNames = new String[] {"table1", "table2", "table3"};
+    for (String dbName : dbNames) {
+      DATABASE_OPERATIONS.create(dbName, null, null);
+    }
+
+    for (String dbName : dbNames) {
+      for (String tableName : tableNames) {
+        TABLE_OPERATIONS.create(
+            dbName,
+            tableName,
+            new JdbcColumn[] {
+              JdbcColumn.builder()
+                  .withName("col_1")
+                  .withType(Types.DecimalType.of(10, 2))
+                  .withComment("test_decimal")
+                  .withNullable(false)
+                  .build()
+            },
+            "test_comment",
+            null,
+            null,
+            Distributions.NONE,
+            Indexes.EMPTY_INDEXES);
+      }
+    }
+
+    for (String dbName : dbNames) {
+      try (Connection connection = TABLE_OPERATIONS.getConnection(dbName);
+          ResultSet resultSet = TABLE_OPERATIONS.getTables(connection, dbName)) {
+        List<String> tables = new ArrayList<>();
+        while (resultSet.next()) {
+          tables.add(resultSet.getString("TABLE_NAME"));
+        }
+        Assertions.assertEquals(Arrays.asList(tableNames), tables);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
   }
 }

--- a/server/src/main/resources/project.properties
+++ b/server/src/main/resources/project.properties
@@ -1,0 +1,7 @@
+#
+# Copyright 2023 Datastrato Pvt Ltd.
+# This software is licensed under the Apache License version 2.
+#
+project.version=0.5.0-SNAPSHOT
+compile.date=23/04/2024 17:39:38
+git.commit.id=ebdf514eee9fe450ef79dcb1bf22c4454f75b40a

--- a/server/src/main/resources/project.properties
+++ b/server/src/main/resources/project.properties
@@ -1,7 +1,0 @@
-#
-# Copyright 2023 Datastrato Pvt Ltd.
-# This software is licensed under the Apache License version 2.
-#
-project.version=0.5.0-SNAPSHOT
-compile.date=23/04/2024 17:39:38
-git.commit.id=ebdf514eee9fe450ef79dcb1bf22c4454f75b40a


### PR DESCRIPTION
### What changes were proposed in this pull request?

Set the connection database to the database passed by the method when getting the JDBC connection. 

### Why are the changes needed?

`connection.getSchema()` is null for MySQL and thus will cause the problem that list operation will get all tables in the MySQL instance NOT a specific database. 

Fix: #3002

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

New UT was added.
