### PR TITLE
[#3237] fix(IT): use simple catalog name in `TrinoContainer`

### DIFF
--- a/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/container/TrinoContainer.java
+++ b/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/container/TrinoContainer.java
@@ -117,16 +117,15 @@ public class TrinoContainer extends BaseContainer {
   }
 
   // Check tha Trino has synchronized the catalog from Gravitino
-  public boolean checkSyncCatalogFromGravitino(
-      int retryLimit, String metalakeName, String catalogName) {
+  public boolean checkSyncCatalogFromGravitino(int retryLimit, String catalogName) {
     int nRetry = 0;
     int sleepTime = 5000;
     while (nRetry++ < retryLimit) {
       ArrayList<ArrayList<String>> queryData =
-          executeQuerySQL(format("SHOW CATALOGS LIKE '%s.%s'", metalakeName, catalogName));
+          executeQuerySQL(format("SHOW CATALOGS LIKE '%s'", catalogName));
       for (ArrayList<String> record : queryData) {
         String columnValue = record.get(0);
-        if (columnValue.equals(String.format("%s.%s", metalakeName, catalogName))) {
+        if (columnValue.equals(catalogName)) {
           return true;
         }
       }

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoConnectorIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoConnectorIT.java
@@ -94,7 +94,9 @@ public class TrinoConnectorIT extends AbstractIT {
         System.getenv("GRAVITINO_ROOT_DIR") + "/trino-connector/build/libs",
         getGravitinoServerPort(),
         metalakeName);
-    containerSuite.getTrinoContainer().checkSyncCatalogFromGravitino(5, metalakeName, catalogName);
+    Assertions.assertTrue(
+        containerSuite.getTrinoContainer().checkSyncCatalogFromGravitino(5, catalogName),
+        "Can not synchronize calatogs from gravitino");
 
     createSchema();
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

use simple catalog name in `com.datastrato.gravitino.integration.test.container.TrinoContainer#checkSyncCatalogFromGravitino`, and verify it where it is called.

### Why are the changes needed?

Fix: #3237 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

ITs
