### PR TITLE
refactor(dev/docker/hive): shrink hive Docker image size by 420MB

### DIFF
--- a/catalogs/catalog-hadoop/build.gradle.kts
+++ b/catalogs/catalog-hadoop/build.gradle.kts
@@ -98,7 +98,7 @@ tasks.test {
     dependsOn(tasks.jar)
 
     doFirst {
-      environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "datastrato/gravitino-ci-hive:0.1.11")
+      environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "datastrato/gravitino-ci-hive:0.1.12")
     }
 
     val init = project.extra.get("initIntegrationTest") as (Test) -> Unit

--- a/catalogs/catalog-hive/build.gradle.kts
+++ b/catalogs/catalog-hive/build.gradle.kts
@@ -164,7 +164,7 @@ tasks.test {
     dependsOn(tasks.jar)
 
     doFirst {
-      environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "datastrato/gravitino-ci-hive:0.1.11")
+      environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "datastrato/gravitino-ci-hive:0.1.12")
     }
 
     val init = project.extra.get("initIntegrationTest") as (Test) -> Unit

--- a/catalogs/catalog-lakehouse-iceberg/build.gradle.kts
+++ b/catalogs/catalog-lakehouse-iceberg/build.gradle.kts
@@ -162,7 +162,7 @@ tasks.test {
     dependsOn(tasks.jar)
 
     doFirst {
-      environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "datastrato/gravitino-ci-hive:0.1.11")
+      environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "datastrato/gravitino-ci-hive:0.1.12")
     }
 
     val init = project.extra.get("initIntegrationTest") as (Test) -> Unit

--- a/dev/docker/build-docker.sh
+++ b/dev/docker/build-docker.sh
@@ -73,7 +73,7 @@ fi
 
 if [[ "${component_type}" == "hive" ]]; then
   . ${script_dir}/hive/hive-dependency.sh
-  build_args="--build-arg HADOOP_PACKAGE_NAME=${HADOOP_PACKAGE_NAME} --build-arg HIVE_PACKAGE_NAME=${HIVE_PACKAGE_NAME} --build-arg JDBC_DIVER_PACKAGE_NAME=${JDBC_DIVER_PACKAGE_NAME}"
+  build_args="--build-arg HADOOP_PACKAGE_NAME=${HADOOP_PACKAGE_NAME} --build-arg HIVE_PACKAGE_NAME=${HIVE_PACKAGE_NAME} --build-arg JDBC_DIVER_PACKAGE_NAME=${JDBC_DIVER_PACKAGE_NAME} --build-arg HADOOP_VERSION=${HADOOP_VERSION} --build-arg HIVE_VERSION=${HIVE_VERSION} --build-arg MYSQL_JDBC_DRIVER_VERSION=${MYSQL_JDBC_DRIVER_VERSION}"
 elif [[ "${component_type}" == "kerberos-hive" ]]; then
   . ${script_dir}/kerberos-hive/hive-dependency.sh
   build_args="--build-arg HADOOP_PACKAGE_NAME=${HADOOP_PACKAGE_NAME} --build-arg HIVE_PACKAGE_NAME=${HIVE_PACKAGE_NAME} --build-arg JDBC_DIVER_PACKAGE_NAME=${JDBC_DIVER_PACKAGE_NAME}"

--- a/dev/docker/hive/Dockerfile
+++ b/dev/docker/hive/Dockerfile
@@ -20,12 +20,10 @@ ENV HADOOP_HOME=/usr/local/hadoop
 RUN mkdir ${HADOOP_HOME}
 RUN tar -xz -C ${HADOOP_HOME} --strip-components 1 -f /tmp/packages/${HADOOP_PACKAGE_NAME} && rm -rf /tmp/packages/${HADOOP_PACKAGE_NAME}
 
-RUN ls -la ${HADOOP_HOME}
 # hive
 RUN mkdir ${HIVE_HOME}
 RUN tar -xz -C ${HIVE_HOME} --strip-components 1 -f /tmp/packages/${HIVE_PACKAGE_NAME} && rm -rf /tmp/packages/${HIVE_PACKAGE_NAME}
 
-RUN ls -la ${HIVE_HOME}/bin
 # add mysql jdbc driver
 RUN tar -xz -C ${HIVE_HOME}/lib --strip-components 1 -f /tmp/packages/${JDBC_DIVER_PACKAGE_NAME} && rm -rf /tmp/packages/${JDBC_DIVER_PACKAGE_NAME}
 

--- a/dev/docker/hive/Dockerfile
+++ b/dev/docker/hive/Dockerfile
@@ -3,13 +3,30 @@
 # This software is licensed under the Apache License version 2.
 #
 
-FROM ubuntu:16.04
-LABEL maintainer="support@datastrato.com"
+FROM ubuntu:16.04 AS packages
 
 ARG HADOOP_PACKAGE_NAME
 ARG HIVE_PACKAGE_NAME
 ARG JDBC_DIVER_PACKAGE_NAME
 ARG DEBIAN_FRONTEND=noninteractive
+
+COPY packages /tmp/packages
+
+ENV JAVA_HOME=/usr/local/jdk
+ENV HIVE_HOME=/usr/local/hive
+ENV HADOOP_HOME=/usr/local/hadoop
+
+# hadoop
+RUN mkdir ${HADOOP_HOME}
+RUN tar -xz -C ${HADOOP_HOME} --strip-components 1 -f /tmp/packages/${HADOOP_PACKAGE_NAME} && rm -rf /tmp/packages/${HADOOP_PACKAGE_NAME}
+# hive
+RUN mkdir ${HIVE_HOME}
+RUN tar -xz -C ${HIVE_HOME} --strip-components 1 -f /tmp/packages/${HIVE_PACKAGE_NAME} && rm -rf /tmp/packages/${HIVE_PACKAGE_NAME}
+# add mysql jdbc driver
+RUN tar -xz -C ${HIVE_HOME}/lib --strip-components 1 -f /tmp/packages/${JDBC_DIVER_PACKAGE_NAME} && rm -rf /tmp/packages/${JDBC_DIVER_PACKAGE_NAME}
+
+FROM ubuntu:16.04
+LABEL maintainer="support@datastrato.com"
 
 WORKDIR /
 
@@ -45,7 +62,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install --fix-missing -yq \
 RUN mkdir /root/.ssh
 RUN cat /dev/zero | ssh-keygen -q -N "" > /dev/null && cat /root/.ssh/id_rsa.pub > /root/.ssh/authorized_keys
 
-COPY packages /tmp/packages
+#COPY packages /tmp/packages
 
 ################################################################################
 # set environment variables
@@ -90,8 +107,12 @@ RUN echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> /etc/environment
 
 ################################################################################
 # install hadoop
-RUN mkdir ${HADOOP_HOME}
-RUN tar -xz -C ${HADOOP_HOME} --strip-components 1 -f /tmp/packages/${HADOOP_PACKAGE_NAME}
+#RUN mkdir ${HADOOP_HOME}
+COPY --from=packages /tmp/packages/${HADOOP_PACKAGE_NAME}/* ${HADOOP_HOME}/
+#RUN tar -xz -C ${HADOOP_HOME} --strip-components 1 -f /tmp/packages/${HADOOP_PACKAGE_NAME} && rm -rf /tmp/packages/${HADOOP_PACKAGE_NAME}
+#ADD packages/${HADOOP_PACKAGE_NAME} ${HADOOP_HOME}/
+
+RUN ls -la ${HADOOP_HOME}
 
 # replace configuration templates
 RUN rm -f ${HADOOP_CONF_DIR}/core-site.xml
@@ -110,8 +131,10 @@ RUN ${HADOOP_HOME}/bin/hdfs namenode -format -nonInteractive
 
 ################################################################################
 # install hive
-RUN mkdir ${HIVE_HOME}
-RUN tar -xz -C ${HIVE_HOME} --strip-components 1 -f /tmp/packages/${HIVE_PACKAGE_NAME}
+#RUN mkdir ${HIVE_HOME}
+COPY --from=packages /tmp/packages/${HIVE_PACKAGE_NAME}/* ${HIVE_HOME}/
+#RUN tar -xz -C ${HIVE_HOME} --strip-components 1 -f /tmp/packages/${HIVE_PACKAGE_NAME} && rm -rf /tmp/packages/${HIVE_PACKAGE_NAME}
+#ADD packages/${HIVE_PACKAGE_NAME} ${HIVE_HOME}/
 ADD hive-site.xml ${HIVE_HOME}/conf/hive-site.xml
 
 ################################################################################
@@ -119,7 +142,7 @@ ADD hive-site.xml ${HIVE_HOME}/conf/hive-site.xml
 ENV MYSQL_PWD=ds123
 RUN echo "mysql-server mysql-server/root_password password ${MYSQL_PWD}" | debconf-set-selections
 RUN echo "mysql-server mysql-server/root_password_again password ${MYSQL_PWD}" | debconf-set-selections
-RUN apt-get install -y mysql-server
+RUN apt-get install -y mysql-server && rm -rf /var/lib/apt/lists/*
 
 RUN chown -R mysql:mysql /var/lib/mysql
 RUN usermod -d /var/lib/mysql/ mysql
@@ -127,7 +150,9 @@ RUN sed -i "s/.*bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/mysql.conf.d/
 
 ################################################################################
 # add mysql jdbc driver
-RUN tar -xz -C ${HIVE_HOME}/lib --strip-components 1 -f /tmp/packages/${JDBC_DIVER_PACKAGE_NAME}
+COPY --from=packages /tmp/packages/${JDBC_DIVER_PACKAGE_NAME}/* ${HIVE_HOME}/lib/
+#RUN tar -xz -C ${HIVE_HOME}/lib --strip-components 1 -f /tmp/packages/${JDBC_DIVER_PACKAGE_NAME} && rm -rf /tmp/packages/${JDBC_DIVER_PACKAGE_NAME}
+# ADD packages/${JDBC_DIVER_PACKAGE_NAME} ${HIVE_HOME}/lib/
 
 ################################################################################
 # add users and groups
@@ -146,8 +171,8 @@ RUN chown -R datastrato:hadoop /home/datastrato
 
 ################################################################################
 # removed install packages and cache
-RUN rm -rf /tmp/packages
-RUN rm -rf /var/lib/apt/lists/*
+#RUN rm -rf /tmp/packages
+#RUN rm -rf /var/lib/apt/lists/*
 
 ################################################################################
 # expose port

--- a/dev/docker/hive/Dockerfile
+++ b/dev/docker/hive/Dockerfile
@@ -109,12 +109,7 @@ RUN echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> /etc/environment
 
 ################################################################################
 # install hadoop
-#RUN mkdir ${HADOOP_HOME}
 COPY --from=packages ${HADOOP_HOME} ${HADOOP_HOME}
-#RUN tar -xz -C ${HADOOP_HOME} --strip-components 1 -f /tmp/packages/${HADOOP_PACKAGE_NAME} && rm -rf /tmp/packages/${HADOOP_PACKAGE_NAME}
-#ADD packages/${HADOOP_PACKAGE_NAME} ${HADOOP_HOME}/
-
-RUN ls -la ${HADOOP_HOME}
 
 # replace configuration templates
 RUN rm -f ${HADOOP_CONF_DIR}/core-site.xml
@@ -133,11 +128,7 @@ RUN ${HADOOP_HOME}/bin/hdfs namenode -format -nonInteractive
 
 ################################################################################
 # install hive
-#RUN mkdir ${HIVE_HOME}
 COPY --from=packages ${HIVE_HOME} ${HIVE_HOME}
-RUN ls -la ${HIVE_HOME}/bin
-#RUN tar -xz -C ${HIVE_HOME} --strip-components 1 -f /tmp/packages/${HIVE_PACKAGE_NAME} && rm -rf /tmp/packages/${HIVE_PACKAGE_NAME}
-#ADD packages/${HIVE_PACKAGE_NAME} ${HIVE_HOME}/
 ADD hive-site.xml ${HIVE_HOME}/conf/hive-site.xml
 
 ################################################################################
@@ -150,13 +141,6 @@ RUN apt-get install -y mysql-server && rm -rf /var/lib/apt/lists/*
 RUN chown -R mysql:mysql /var/lib/mysql
 RUN usermod -d /var/lib/mysql/ mysql
 RUN sed -i "s/.*bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/mysql.conf.d/mysqld.cnf
-
-################################################################################
-# add mysql jdbc driver
-# FIXME: already copied at installation of HIVE_HOME ?
-#COPY --from=packages ${HIVE_HOME}/lib/* ${HIVE_HOME}/lib/
-#RUN tar -xz -C ${HIVE_HOME}/lib --strip-components 1 -f /tmp/packages/${JDBC_DIVER_PACKAGE_NAME} && rm -rf /tmp/packages/${JDBC_DIVER_PACKAGE_NAME}
-# ADD packages/${JDBC_DIVER_PACKAGE_NAME} ${HIVE_HOME}/lib/
 
 ################################################################################
 # add users and groups
@@ -172,11 +156,6 @@ RUN usermod -a -G mapred datastrato
 
 RUN mkdir /home/datastrato
 RUN chown -R datastrato:hadoop /home/datastrato
-
-################################################################################
-# removed install packages and cache
-#RUN rm -rf /tmp/packages
-#RUN rm -rf /var/lib/apt/lists/*
 
 ################################################################################
 # expose port

--- a/dev/docker/hive/Dockerfile
+++ b/dev/docker/hive/Dockerfile
@@ -6,9 +6,7 @@
 FROM ubuntu:16.04
 LABEL maintainer="support@datastrato.com"
 
-ARG HADOOP_PACKAGE_NAME
 ARG HADOOP_VERSION
-ARG HIVE_PACKAGE_NAME
 ARG HIVE_VERSION
 ARG JDBC_DIVER_PACKAGE_NAME
 ARG MYSQL_JDBC_DRIVER_VERSION
@@ -131,7 +129,6 @@ RUN sed -i "s/.*bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/mysql.conf.d/
 
 ################################################################################
 # add mysql jdbc driver
-#RUN tar -xz -C ${HIVE_HOME}/lib --strip-components 1 -f /tmp/packages/${JDBC_DIVER_PACKAGE_NAME}
 ADD packages/mysql-connector-java-${MYSQL_JDBC_DRIVER_VERSION}.tar.gz /opt/
 RUN ln -s /opt/mysql-connector-java-${MYSQL_JDBC_DRIVER_VERSION}/* ${HIVE_HOME}/lib
 

--- a/dev/docker/hive/Dockerfile
+++ b/dev/docker/hive/Dockerfile
@@ -19,9 +19,13 @@ ENV HADOOP_HOME=/usr/local/hadoop
 # hadoop
 RUN mkdir ${HADOOP_HOME}
 RUN tar -xz -C ${HADOOP_HOME} --strip-components 1 -f /tmp/packages/${HADOOP_PACKAGE_NAME} && rm -rf /tmp/packages/${HADOOP_PACKAGE_NAME}
+
+RUN ls -la ${HADOOP_HOME}
 # hive
 RUN mkdir ${HIVE_HOME}
 RUN tar -xz -C ${HIVE_HOME} --strip-components 1 -f /tmp/packages/${HIVE_PACKAGE_NAME} && rm -rf /tmp/packages/${HIVE_PACKAGE_NAME}
+
+RUN ls -la ${HIVE_HOME}/bin
 # add mysql jdbc driver
 RUN tar -xz -C ${HIVE_HOME}/lib --strip-components 1 -f /tmp/packages/${JDBC_DIVER_PACKAGE_NAME} && rm -rf /tmp/packages/${JDBC_DIVER_PACKAGE_NAME}
 
@@ -61,8 +65,6 @@ RUN apt-get update && apt-get upgrade -y && apt-get install --fix-missing -yq \
 ## setup ssh
 RUN mkdir /root/.ssh
 RUN cat /dev/zero | ssh-keygen -q -N "" > /dev/null && cat /root/.ssh/id_rsa.pub > /root/.ssh/authorized_keys
-
-#COPY packages /tmp/packages
 
 ################################################################################
 # set environment variables
@@ -108,7 +110,7 @@ RUN echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> /etc/environment
 ################################################################################
 # install hadoop
 #RUN mkdir ${HADOOP_HOME}
-COPY --from=packages /tmp/packages/${HADOOP_PACKAGE_NAME}/* ${HADOOP_HOME}/
+COPY --from=packages ${HADOOP_HOME} ${HADOOP_HOME}
 #RUN tar -xz -C ${HADOOP_HOME} --strip-components 1 -f /tmp/packages/${HADOOP_PACKAGE_NAME} && rm -rf /tmp/packages/${HADOOP_PACKAGE_NAME}
 #ADD packages/${HADOOP_PACKAGE_NAME} ${HADOOP_HOME}/
 
@@ -132,7 +134,8 @@ RUN ${HADOOP_HOME}/bin/hdfs namenode -format -nonInteractive
 ################################################################################
 # install hive
 #RUN mkdir ${HIVE_HOME}
-COPY --from=packages /tmp/packages/${HIVE_PACKAGE_NAME}/* ${HIVE_HOME}/
+COPY --from=packages ${HIVE_HOME} ${HIVE_HOME}
+RUN ls -la ${HIVE_HOME}/bin
 #RUN tar -xz -C ${HIVE_HOME} --strip-components 1 -f /tmp/packages/${HIVE_PACKAGE_NAME} && rm -rf /tmp/packages/${HIVE_PACKAGE_NAME}
 #ADD packages/${HIVE_PACKAGE_NAME} ${HIVE_HOME}/
 ADD hive-site.xml ${HIVE_HOME}/conf/hive-site.xml
@@ -150,7 +153,8 @@ RUN sed -i "s/.*bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/mysql.conf.d/
 
 ################################################################################
 # add mysql jdbc driver
-COPY --from=packages /tmp/packages/${JDBC_DIVER_PACKAGE_NAME}/* ${HIVE_HOME}/lib/
+# FIXME: already copied at installation of HIVE_HOME ?
+#COPY --from=packages ${HIVE_HOME}/lib/* ${HIVE_HOME}/lib/
 #RUN tar -xz -C ${HIVE_HOME}/lib --strip-components 1 -f /tmp/packages/${JDBC_DIVER_PACKAGE_NAME} && rm -rf /tmp/packages/${JDBC_DIVER_PACKAGE_NAME}
 # ADD packages/${JDBC_DIVER_PACKAGE_NAME} ${HIVE_HOME}/lib/
 

--- a/dev/docker/hive/Dockerfile
+++ b/dev/docker/hive/Dockerfile
@@ -108,7 +108,7 @@ ADD check-status.sh /tmp/check-status.sh
 # format HFS
 RUN ${HADOOP_HOME}/bin/hdfs namenode -format -nonInteractive
 
-#################################################################################
+################################################################################
 # install hive
 RUN mkdir ${HIVE_HOME}
 ADD packages/apache-hive-${HIVE_VERSION}-bin.tar.gz /opt/

--- a/dev/docker/hive/Dockerfile
+++ b/dev/docker/hive/Dockerfile
@@ -3,32 +3,13 @@
 # This software is licensed under the Apache License version 2.
 #
 
-FROM ubuntu:16.04 AS packages
+FROM ubuntu:16.04
+LABEL maintainer="support@datastrato.com"
 
 ARG HADOOP_PACKAGE_NAME
 ARG HIVE_PACKAGE_NAME
 ARG JDBC_DIVER_PACKAGE_NAME
 ARG DEBIAN_FRONTEND=noninteractive
-
-COPY packages /tmp/packages
-
-ENV JAVA_HOME=/usr/local/jdk
-ENV HIVE_HOME=/usr/local/hive
-ENV HADOOP_HOME=/usr/local/hadoop
-
-# hadoop
-RUN mkdir ${HADOOP_HOME}
-RUN tar -xz -C ${HADOOP_HOME} --strip-components 1 -f /tmp/packages/${HADOOP_PACKAGE_NAME} && rm -rf /tmp/packages/${HADOOP_PACKAGE_NAME}
-
-# hive
-RUN mkdir ${HIVE_HOME}
-RUN tar -xz -C ${HIVE_HOME} --strip-components 1 -f /tmp/packages/${HIVE_PACKAGE_NAME} && rm -rf /tmp/packages/${HIVE_PACKAGE_NAME}
-
-# add mysql jdbc driver
-RUN tar -xz -C ${HIVE_HOME}/lib --strip-components 1 -f /tmp/packages/${JDBC_DIVER_PACKAGE_NAME} && rm -rf /tmp/packages/${JDBC_DIVER_PACKAGE_NAME}
-
-FROM ubuntu:16.04
-LABEL maintainer="support@datastrato.com"
 
 WORKDIR /
 
@@ -63,6 +44,8 @@ RUN apt-get update && apt-get upgrade -y && apt-get install --fix-missing -yq \
 ## setup ssh
 RUN mkdir /root/.ssh
 RUN cat /dev/zero | ssh-keygen -q -N "" > /dev/null && cat /root/.ssh/id_rsa.pub > /root/.ssh/authorized_keys
+
+COPY packages /tmp/packages
 
 ################################################################################
 # set environment variables
@@ -107,7 +90,8 @@ RUN echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> /etc/environment
 
 ################################################################################
 # install hadoop
-COPY --from=packages ${HADOOP_HOME} ${HADOOP_HOME}
+RUN mkdir ${HADOOP_HOME}
+RUN tar -xz -C ${HADOOP_HOME} --strip-components 1 -f /tmp/packages/${HADOOP_PACKAGE_NAME}
 
 # replace configuration templates
 RUN rm -f ${HADOOP_CONF_DIR}/core-site.xml
@@ -126,7 +110,8 @@ RUN ${HADOOP_HOME}/bin/hdfs namenode -format -nonInteractive
 
 ################################################################################
 # install hive
-COPY --from=packages ${HIVE_HOME} ${HIVE_HOME}
+RUN mkdir ${HIVE_HOME}
+RUN tar -xz -C ${HIVE_HOME} --strip-components 1 -f /tmp/packages/${HIVE_PACKAGE_NAME}
 ADD hive-site.xml ${HIVE_HOME}/conf/hive-site.xml
 
 ################################################################################
@@ -134,11 +119,15 @@ ADD hive-site.xml ${HIVE_HOME}/conf/hive-site.xml
 ENV MYSQL_PWD=ds123
 RUN echo "mysql-server mysql-server/root_password password ${MYSQL_PWD}" | debconf-set-selections
 RUN echo "mysql-server mysql-server/root_password_again password ${MYSQL_PWD}" | debconf-set-selections
-RUN apt-get install -y mysql-server && rm -rf /var/lib/apt/lists/*
+RUN apt-get install -y mysql-server
 
 RUN chown -R mysql:mysql /var/lib/mysql
 RUN usermod -d /var/lib/mysql/ mysql
 RUN sed -i "s/.*bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/mysql.conf.d/mysqld.cnf
+
+################################################################################
+# add mysql jdbc driver
+RUN tar -xz -C ${HIVE_HOME}/lib --strip-components 1 -f /tmp/packages/${JDBC_DIVER_PACKAGE_NAME}
 
 ################################################################################
 # add users and groups
@@ -154,6 +143,11 @@ RUN usermod -a -G mapred datastrato
 
 RUN mkdir /home/datastrato
 RUN chown -R datastrato:hadoop /home/datastrato
+
+################################################################################
+# removed install packages and cache
+RUN rm -rf /tmp/packages
+RUN rm -rf /var/lib/apt/lists/*
 
 ################################################################################
 # expose port

--- a/dev/docker/hive/Dockerfile
+++ b/dev/docker/hive/Dockerfile
@@ -7,8 +7,11 @@ FROM ubuntu:16.04
 LABEL maintainer="support@datastrato.com"
 
 ARG HADOOP_PACKAGE_NAME
+ARG HADOOP_VERSION
 ARG HIVE_PACKAGE_NAME
+ARG HIVE_VERSION
 ARG JDBC_DIVER_PACKAGE_NAME
+ARG MYSQL_JDBC_DRIVER_VERSION
 ARG DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /
@@ -41,11 +44,9 @@ RUN apt-get update && apt-get upgrade -y && apt-get install --fix-missing -yq \
   openjdk-8-jdk
 
 #################################################################################
-## setup ssh
+# setup ssh
 RUN mkdir /root/.ssh
 RUN cat /dev/zero | ssh-keygen -q -N "" > /dev/null && cat /root/.ssh/id_rsa.pub > /root/.ssh/authorized_keys
-
-COPY packages /tmp/packages
 
 ################################################################################
 # set environment variables
@@ -91,7 +92,8 @@ RUN echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> /etc/environment
 ################################################################################
 # install hadoop
 RUN mkdir ${HADOOP_HOME}
-RUN tar -xz -C ${HADOOP_HOME} --strip-components 1 -f /tmp/packages/${HADOOP_PACKAGE_NAME}
+ADD packages/hadoop-${HADOOP_VERSION}.tar.gz /opt/
+RUN ln -s /opt/hadoop-${HADOOP_VERSION}/* ${HADOOP_HOME}
 
 # replace configuration templates
 RUN rm -f ${HADOOP_CONF_DIR}/core-site.xml
@@ -108,10 +110,12 @@ ADD check-status.sh /tmp/check-status.sh
 # format HFS
 RUN ${HADOOP_HOME}/bin/hdfs namenode -format -nonInteractive
 
-################################################################################
+#################################################################################
 # install hive
 RUN mkdir ${HIVE_HOME}
-RUN tar -xz -C ${HIVE_HOME} --strip-components 1 -f /tmp/packages/${HIVE_PACKAGE_NAME}
+ADD packages/apache-hive-${HIVE_VERSION}-bin.tar.gz /opt/
+RUN ln -s /opt/apache-hive-${HIVE_VERSION}-bin/* ${HIVE_HOME}
+
 ADD hive-site.xml ${HIVE_HOME}/conf/hive-site.xml
 
 ################################################################################
@@ -127,7 +131,9 @@ RUN sed -i "s/.*bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/mysql.conf.d/
 
 ################################################################################
 # add mysql jdbc driver
-RUN tar -xz -C ${HIVE_HOME}/lib --strip-components 1 -f /tmp/packages/${JDBC_DIVER_PACKAGE_NAME}
+#RUN tar -xz -C ${HIVE_HOME}/lib --strip-components 1 -f /tmp/packages/${JDBC_DIVER_PACKAGE_NAME}
+ADD packages/mysql-connector-java-${MYSQL_JDBC_DRIVER_VERSION}.tar.gz /opt/
+RUN ln -s /opt/mysql-connector-java-${MYSQL_JDBC_DRIVER_VERSION}/* ${HIVE_HOME}/lib
 
 ################################################################################
 # add users and groups

--- a/dev/docker/hive/start.sh
+++ b/dev/docker/hive/start.sh
@@ -34,5 +34,7 @@ ${HIVE_HOME}/bin/schematool -initSchema -dbType mysql
 ${HIVE_HOME}/bin/hive --service hiveserver2 > /dev/null 2>&1 &
 ${HIVE_HOME}/bin/hive --service metastore > /dev/null 2>&1 &
 
+echo "Hive started successfully."
+
 # persist the container
 tail -f /dev/null

--- a/docs/docker-image-details.md
+++ b/docs/docker-image-details.md
@@ -100,6 +100,9 @@ You can use this kind of image to test the catalog of Apache Hive.
 
 Changelog
 
+- gravitino-ci-hive:0.1.12
+  - Shrink hive Docker image size by 420MB
+
 - gravitino-ci-hive:0.1.11
   - Remove `yarn` from the startup script; Remove `yarn-site.xml` and `yarn-env.sh` files;
   - Change the value of `mapreduce.framework.name` from `yarn` to `local` in the `mapred-site.xml` file. 

--- a/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
+++ b/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
@@ -88,6 +88,7 @@ public class ContainerSuite implements Closeable {
           HiveContainer.Builder hiveBuilder =
               HiveContainer.builder()
                   .withHostName("gravitino-ci-hive")
+                  .withImage("unknowntpo/gravitino-ci-hive:shrink")
                   .withEnvVars(
                       ImmutableMap.<String, String>builder()
                           .put("HADOOP_USER_NAME", "datastrato")

--- a/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
+++ b/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
@@ -88,7 +88,7 @@ public class ContainerSuite implements Closeable {
           HiveContainer.Builder hiveBuilder =
               HiveContainer.builder()
                   .withHostName("gravitino-ci-hive")
-                  .withImage("unknowntpo/gravitino-ci-hive:shrink")
+                  .withImage("unknowntpo/gravitino-ci-hive:latest")
                   .withEnvVars(
                       ImmutableMap.<String, String>builder()
                           .put("HADOOP_USER_NAME", "datastrato")

--- a/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
+++ b/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
@@ -88,7 +88,6 @@ public class ContainerSuite implements Closeable {
           HiveContainer.Builder hiveBuilder =
               HiveContainer.builder()
                   .withHostName("gravitino-ci-hive")
-                  .withImage("unknowntpo/gravitino-ci-hive:latest")
                   .withEnvVars(
                       ImmutableMap.<String, String>builder()
                           .put("HADOOP_USER_NAME", "datastrato")

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -160,7 +160,7 @@ tasks.test {
 
     doFirst {
       // Gravitino CI Docker image
-      environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "datastrato/gravitino-ci-hive:0.1.11")
+      environment("GRAVITINO_CI_HIVE_DOCKER_IMAGE", "datastrato/gravitino-ci-hive:0.1.12")
       environment("GRAVITINO_CI_TRINO_DOCKER_IMAGE", "datastrato/gravitino-ci-trino:0.1.5")
       environment("GRAVITINO_CI_KAFKA_DOCKER_IMAGE", "apache/kafka:3.7.0")
       environment("GRAVITINO_CI_DORIS_DOCKER_IMAGE", "datastrato/gravitino-ci-doris:0.1.3")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use multi-stage build to reduce hive image size from 2.27GB to 1.83GB.

I use first stage to download archive file and unzip them, then in the final stage, copied them to destination directory.

### Why are the changes needed?

Fix: #3262 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit tests.


## TODO
- [ ] @mchades needs to push new image release to docker hub
- [ ] @unknowntpo should update changelog
