### PR TITLE
[#3037][#3086] improve(catalog-hadoop): Improve regexp in GravitinoVirtualFileSystem.java

### DIFF
--- a/clients/filesystem-hadoop3/src/main/java/com/datastrato/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
+++ b/clients/filesystem-hadoop3/src/main/java/com/datastrato/gravitino/filesystem/hadoop/GravitinoVirtualFileSystem.java
@@ -57,7 +57,7 @@ public class GravitinoVirtualFileSystem extends FileSystem {
   //     gvfs://fileset/fileset_catalog/fileset_schema/fileset1/file.txt
   //     /fileset_catalog/fileset_schema/fileset1/sub_dir/
   private static final Pattern IDENTIFIER_PATTERN =
-      Pattern.compile("^(?:gvfs://fileset)?/([^/]+)/([^/]+)/([^/]+)(?:/[^/]+)*/?$");
+      Pattern.compile("^(?:gvfs://fileset)?/([^/]+)/([^/]+)/([^/]+)(?>/[^/]+)*/?$");
 
   @Override
   public void initialize(URI name, Configuration configuration) throws IOException {

--- a/clients/filesystem-hadoop3/src/test/java/com/datastrato/gravitino/filesystem/hadoop/TestGvfsBase.java
+++ b/clients/filesystem-hadoop3/src/test/java/com/datastrato/gravitino/filesystem/hadoop/TestGvfsBase.java
@@ -549,6 +549,18 @@ public class TestGvfsBase extends GravitinoMockServerBase {
       assertEquals(
           NameIdentifier.ofFileset(metalakeName, "catalog1", "schema1", "fileset1"), identifier10);
 
+      StringBuilder longUri = new StringBuilder("gvfs://fileset/catalog1/schema1/fileset1");
+      for (int i = 0; i < 1500; i++) {
+        longUri.append("/dir");
+      }
+      NameIdentifier identifier11 = fs.extractIdentifier(new URI(longUri.toString()));
+      assertEquals(
+          NameIdentifier.ofFileset(metalakeName, "catalog1", "schema1", "fileset1"), identifier11);
+
+      NameIdentifier identifier12 = fs.extractIdentifier(new URI(longUri.delete(0, 14).toString()));
+      assertEquals(
+          NameIdentifier.ofFileset(metalakeName, "catalog1", "schema1", "fileset1"), identifier12);
+
       assertThrows(
           IllegalArgumentException.class,
           () -> fs.extractIdentifier(new URI("gvfs://fileset/catalog1/")));


### PR DESCRIPTION
### What changes were proposed in this pull request?

replace the non-capturing group `?:` with independent, non-capturing group (atomic group) `?>` to eliminate backtracking.

### Why are the changes needed?

To prevent stack overflow

Fix: #3037 
Fix: #3086 

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
Add UT