### PR TITLE
[#3275] improvement(jdbc-doris): Filter system database like `information_schema` for Doris catalog.

### DIFF
--- a/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/operation/DorisDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/operation/DorisDatabaseOperations.java
@@ -10,6 +10,7 @@ import com.datastrato.gravitino.catalog.jdbc.operation.JdbcDatabaseOperations;
 import com.datastrato.gravitino.exceptions.NoSuchSchemaException;
 import com.datastrato.gravitino.exceptions.NoSuchTableException;
 import com.datastrato.gravitino.meta.AuditInfo;
+import com.google.common.collect.ImmutableSet;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -18,11 +19,15 @@ import java.sql.Statement;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 
 /** Database operations for Doris. */
 public class DorisDatabaseOperations extends JdbcDatabaseOperations {
   public static final String COMMENT_KEY = "comment";
+
+  private static final Set<String> DORIS_SYSTEM_DATABASE_NAMES =
+      ImmutableSet.of("information_schema");
 
   @Override
   public String generateCreateDatabaseSql(
@@ -115,5 +120,10 @@ public class DorisDatabaseOperations extends JdbcDatabaseOperations {
     }
 
     return DorisUtils.extractPropertiesFromSql(createDatabaseSql);
+  }
+
+  @Override
+  protected boolean isSystemDatabase(String dbName) {
+    return DORIS_SYSTEM_DATABASE_NAMES.contains(dbName);
   }
 }

--- a/catalogs/catalog-jdbc-doris/src/test/java/com/datastrato/gravitino/catalog/doris/integration/test/TestDorisDatabaseOperations.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/com/datastrato/gravitino/catalog/doris/integration/test/TestDorisDatabaseOperations.java
@@ -7,6 +7,7 @@ package com.datastrato.gravitino.catalog.doris.integration.test;
 import com.datastrato.gravitino.exceptions.SchemaAlreadyExistsException;
 import com.datastrato.gravitino.utils.RandomNameUtils;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
@@ -31,5 +32,11 @@ public class TestDorisDatabaseOperations extends TestDorisAbstractIT {
         () -> DATABASE_OPERATIONS.create(databaseName, "", properties));
 
     testDropDatabase(databaseName);
+  }
+
+  @Test
+  void testListSystemDatabase() {
+    List<String> databaseNames = DATABASE_OPERATIONS.listDatabases();
+    Assertions.assertFalse(databaseNames.contains("information_schema"));
   }
 }


### PR DESCRIPTION

### What changes were proposed in this pull request?

Filter system database `information_schema` when `list` or `get` table for Doris catalogs. 

### Why are the changes needed?

The system database/table should not be accessible to users directly, and both MySQL and PG have filtered it. 

Fix: #3275 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Added test `testListSystemDatabase`.
