### PR TITLE
[#3210] improve(web): add checking table properties to the web e2e test

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
@@ -165,6 +165,8 @@ public class CatalogsPageTest extends AbstractWebIT {
   private SortOrder[] createSortOrder() {
     return new SortOrders.SortImpl[] {
       SortOrders.of(
+          NamedReference.field(COLUMN_NAME), SortDirection.DESCENDING, NullOrdering.NULLS_FIRST),
+      SortOrders.of(
           NamedReference.field(COLUMN_NAME_2), SortDirection.DESCENDING, NullOrdering.NULLS_FIRST)
     };
   }
@@ -464,11 +466,14 @@ public class CatalogsPageTest extends AbstractWebIT {
 
   @Test
   @Order(15)
-  public void testShowColumnTooltip() {
+  public void testShowTablePropertiesTooltip() {
     mouseMoveTo(By.xpath("//*[@data-refer='col-icon-distribution-" + COLUMN_NAME + "']"));
-    Assertions.assertTrue(catalogsPage.verifyTableProperty("distribution", COLUMN_NAME));
+    Assertions.assertTrue(catalogsPage.verifyTableProperties("distribution", COLUMN_NAME));
     mouseMoveTo(By.xpath("//*[@data-refer='col-icon-sortOrders-" + COLUMN_NAME_2 + "']"));
-    Assertions.assertTrue(catalogsPage.verifyTableProperty("sortOrders", COLUMN_NAME_2));
+    Assertions.assertTrue(catalogsPage.verifyTableProperties("sortOrders", COLUMN_NAME_2));
+    mouseMoveTo(By.xpath("//*[@data-refer='overview-tip-sortOrders']"));
+    Assertions.assertTrue(
+        catalogsPage.verifyTablePropertiesOverview(Arrays.asList(COLUMN_NAME, COLUMN_NAME_2)));
   }
 
   @Test

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.openqa.selenium.By;
 
 @Tag("gravitino-docker-it")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -464,7 +465,10 @@ public class CatalogsPageTest extends AbstractWebIT {
   @Test
   @Order(15)
   public void testShowColumnTooltip() {
-    Assertions.assertTrue(catalogsPage.verifyTableProperty(COLUMN_NAME));
+    mouseMoveTo(By.xpath("//*[@data-refer='col-icon-distribution-" + COLUMN_NAME + "']"));
+    Assertions.assertTrue(catalogsPage.verifyTableProperty("distribution", COLUMN_NAME));
+    mouseMoveTo(By.xpath("//*[@data-refer='col-icon-sortOrders-" + COLUMN_NAME_2 + "']"));
+    Assertions.assertTrue(catalogsPage.verifyTableProperty("sortOrders", COLUMN_NAME_2));
   }
 
   @Test

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
@@ -463,6 +463,12 @@ public class CatalogsPageTest extends AbstractWebIT {
 
   @Test
   @Order(15)
+  public void testShowColumnTooltip() {
+    Assertions.assertTrue(catalogsPage.verifyTableProperty(COLUMN_NAME));
+  }
+
+  @Test
+  @Order(16)
   public void testRefreshTablePage() {
     driver.navigate().refresh();
     Assertions.assertEquals(WEB_TITLE, driver.getTitle());
@@ -483,7 +489,7 @@ public class CatalogsPageTest extends AbstractWebIT {
   }
 
   @Test
-  @Order(16)
+  @Order(17)
   public void testRelationalHiveCatalogTreeNode() throws InterruptedException {
     String hiveNode =
         String.format(
@@ -514,7 +520,7 @@ public class CatalogsPageTest extends AbstractWebIT {
   }
 
   @Test
-  @Order(17)
+  @Order(18)
   public void testTreeNodeRefresh() throws InterruptedException {
     createHiveTableAndColumn(METALAKE_NAME, MODIFIED_HIVE_CATALOG_NAME, SCHEMA_NAME, TABLE_NAME_2);
     String hiveNode =
@@ -542,7 +548,7 @@ public class CatalogsPageTest extends AbstractWebIT {
   }
 
   @Test
-  @Order(18)
+  @Order(19)
   public void testOtherRelationaCatalogTreeNode() throws InterruptedException {
     String icebergNode =
         String.format(
@@ -562,7 +568,7 @@ public class CatalogsPageTest extends AbstractWebIT {
   }
 
   @Test
-  @Order(19)
+  @Order(20)
   public void testSelectMetalake() throws InterruptedException {
     catalogsPage.metalakeSelectChange(METALAKE_SELECT_NAME);
     Assertions.assertTrue(catalogsPage.verifyEmptyTableData());
@@ -572,7 +578,7 @@ public class CatalogsPageTest extends AbstractWebIT {
   }
 
   @Test
-  @Order(20)
+  @Order(21)
   public void testFilesetCatalogTreeNode() throws InterruptedException {
     // 1. create schema and fileset of fileset catalog
     createSchema(METALAKE_NAME, FILESET_CATALOG_NAME, SCHEMA_NAME_FILESET);
@@ -634,7 +640,7 @@ public class CatalogsPageTest extends AbstractWebIT {
   }
 
   @Test
-  @Order(21)
+  @Order(22)
   public void testBackHomePage() throws InterruptedException {
     clickAndWait(catalogsPage.backHomeBtn);
     Assertions.assertTrue(catalogsPage.verifyBackHomePage());

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/CatalogsPageTest.java
@@ -94,6 +94,9 @@ public class CatalogsPageTest extends AbstractWebIT {
   private static final String COMMON_JDBC_USER = "trino";
   private static final String COMMON_JDBC_PWD = "ds123";
 
+  public static final String DISTRIBUTION = "distribution";
+  public static final String SORT_ORDERS = "sortOrders";
+
   private static String defaultBaseLocation;
 
   @BeforeAll
@@ -467,11 +470,11 @@ public class CatalogsPageTest extends AbstractWebIT {
   @Test
   @Order(15)
   public void testShowTablePropertiesTooltip() {
-    mouseMoveTo(By.xpath("//*[@data-refer='col-icon-distribution-" + COLUMN_NAME + "']"));
-    Assertions.assertTrue(catalogsPage.verifyTableProperties("distribution", COLUMN_NAME));
-    mouseMoveTo(By.xpath("//*[@data-refer='col-icon-sortOrders-" + COLUMN_NAME_2 + "']"));
-    Assertions.assertTrue(catalogsPage.verifyTableProperties("sortOrders", COLUMN_NAME_2));
-    mouseMoveTo(By.xpath("//*[@data-refer='overview-tip-sortOrders']"));
+    mouseMoveTo(By.xpath("//*[@data-refer='col-icon-" + DISTRIBUTION + "-" + COLUMN_NAME + "']"));
+    Assertions.assertTrue(catalogsPage.verifyTableProperties(DISTRIBUTION, COLUMN_NAME));
+    mouseMoveTo(By.xpath("//*[@data-refer='col-icon-" + SORT_ORDERS + "-" + COLUMN_NAME_2 + "']"));
+    Assertions.assertTrue(catalogsPage.verifyTableProperties(SORT_ORDERS, COLUMN_NAME_2));
+    mouseMoveTo(By.xpath("//*[@data-refer='overview-tip-" + SORT_ORDERS + "']"));
     Assertions.assertTrue(
         catalogsPage.verifyTablePropertiesOverview(Arrays.asList(COLUMN_NAME, COLUMN_NAME_2)));
   }

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
@@ -548,15 +548,24 @@ public class CatalogsPage extends AbstractWebIT {
     }
   }
 
-  public boolean verifyTableProperty(String colName) {
+  public boolean verifyTableProperty(String type, String colName) {
     try {
-      moveTo("col-icon-" + colName);
-      String xpath = "*[@data-refer='tip-item-" + colName + "']";
-      waitShowText("", By.xpath(xpath));
-      WebElement item = driver.findElement(By.xpath(xpath));
-      boolean matches = Objects.equals(item.getText(), "HASH[10](" + colName + ")");
+      String xpath = "";
+      String formattedColName = "";
+      if (type.equals("distribution")) {
+        xpath = "//*[@data-refer='tip-distribution-item-" + colName + "']";
+        formattedColName = "hash[10](" + colName + ")";
+      } else if (type.equals("sortOrders")) {
+        xpath = "//*[@data-refer='tip-sortOrders-item-" + colName + "']";
+        formattedColName = colName + " desc nulls_last";
+      }
+      WebElement tooltipItem = driver.findElement(By.xpath(xpath));
+      new WebDriverWait(driver, MAX_TIMEOUT)
+          .until(ExpectedConditions.visibilityOfElementLocated(By.xpath(xpath)));
+      waitShowText(formattedColName, tooltipItem);
+      boolean matches = Objects.equals(tooltipItem.getText(), formattedColName);
       if (!matches) {
-        LOG.error("Tooltip item {} does not match, expected '{}'", colName, item.getText());
+        LOG.error("Tooltip item {} does not match, expected '{}'", colName, tooltipItem.getText());
         return false;
       }
       return true;

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
@@ -548,6 +548,24 @@ public class CatalogsPage extends AbstractWebIT {
     }
   }
 
+  public boolean verifyTableProperty(String colName) {
+    try {
+      moveTo("col-icon-" + colName);
+      String xpath = "*[@data-refer='tip-item-" + colName + "']";
+      waitShowText("", By.xpath(xpath));
+      WebElement item = driver.findElement(By.xpath(xpath));
+      boolean matches = Objects.equals(item.getText(), "HASH[10](" + colName + ")");
+      if (!matches) {
+        LOG.error("Tooltip item {} does not match, expected '{}'", colName, item.getText());
+        return false;
+      }
+      return true;
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      return false;
+    }
+  }
+
   public boolean verifyBackHomePage() {
     try {
       WebDriverWait wait = new WebDriverWait(driver, MAX_TIMEOUT);

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
@@ -563,7 +563,7 @@ public class CatalogsPage extends AbstractWebIT {
       new WebDriverWait(driver, MAX_TIMEOUT)
           .until(ExpectedConditions.visibilityOfElementLocated(By.xpath(xpath)));
       List<String> texts = new ArrayList<>();
-      for (WebElement text: tooltipItems) {
+      for (WebElement text : tooltipItems) {
         texts.add(text.getText());
       }
       if (!texts.contains(formattedColName)) {
@@ -589,7 +589,7 @@ public class CatalogsPage extends AbstractWebIT {
         texts.add(text.getText());
       }
       List<String> colsTexts = new ArrayList<>();
-      for (String col: cols) {
+      for (String col : cols) {
         colsTexts.add(col + " desc nulls_last");
       }
       if (!isMatchText || !texts.containsAll(colsTexts)) {

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
@@ -5,6 +5,9 @@
 
 package com.datastrato.gravitino.integration.test.web.ui.pages;
 
+import static com.datastrato.gravitino.integration.test.web.ui.CatalogsPageTest.DISTRIBUTION;
+import static com.datastrato.gravitino.integration.test.web.ui.CatalogsPageTest.SORT_ORDERS;
+
 import com.datastrato.gravitino.integration.test.web.ui.utils.AbstractWebIT;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -552,11 +555,11 @@ public class CatalogsPage extends AbstractWebIT {
     try {
       String xpath = "";
       String formattedColName = "";
-      if (type.equals("distribution")) {
-        xpath = "//*[@data-refer='tip-distribution-item-" + colName + "']";
+      if (type.equals(DISTRIBUTION)) {
+        xpath = "//*[@data-refer='tip-" + DISTRIBUTION + "-item-" + colName + "']";
         formattedColName = "hash[10](" + colName + ")";
-      } else if (type.equals("sortOrders")) {
-        xpath = "//*[@data-refer='tip-sortOrders-item-" + colName + "']";
+      } else if (type.equals(SORT_ORDERS)) {
+        xpath = "//*[@data-refer='tip-" + SORT_ORDERS + "-item-" + colName + "']";
         formattedColName = colName + " desc nulls_last";
       }
       List<WebElement> tooltipItems = driver.findElements(By.xpath(xpath));

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/pages/CatalogsPage.java
@@ -548,7 +548,7 @@ public class CatalogsPage extends AbstractWebIT {
     }
   }
 
-  public boolean verifyTableProperty(String type, String colName) {
+  public boolean verifyTableProperties(String type, String colName) {
     try {
       String xpath = "";
       String formattedColName = "";
@@ -559,13 +559,41 @@ public class CatalogsPage extends AbstractWebIT {
         xpath = "//*[@data-refer='tip-sortOrders-item-" + colName + "']";
         formattedColName = colName + " desc nulls_last";
       }
-      WebElement tooltipItem = driver.findElement(By.xpath(xpath));
+      List<WebElement> tooltipItems = driver.findElements(By.xpath(xpath));
       new WebDriverWait(driver, MAX_TIMEOUT)
           .until(ExpectedConditions.visibilityOfElementLocated(By.xpath(xpath)));
-      waitShowText(formattedColName, tooltipItem);
-      boolean matches = Objects.equals(tooltipItem.getText(), formattedColName);
-      if (!matches) {
-        LOG.error("Tooltip item {} does not match, expected '{}'", colName, tooltipItem.getText());
+      List<String> texts = new ArrayList<>();
+      for (WebElement text: tooltipItems) {
+        texts.add(text.getText());
+      }
+      if (!texts.contains(formattedColName)) {
+        LOG.error("Tooltip item {} does not match, expected '{}'", colName, texts);
+        return false;
+      }
+      return true;
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      return false;
+    }
+  }
+
+  public boolean verifyTablePropertiesOverview(List<String> cols) {
+    try {
+      WebElement columnsText =
+          driver.findElement(By.xpath("//*[@data-refer='overview-sortOrders-items']"));
+      boolean isMatchText = columnsText.getText().contains(",");
+      List<WebElement> tooltipCols =
+          driver.findElements(By.xpath("//*[@data-refer='overview-tip-sortOrders-items']"));
+      List<String> texts = new ArrayList<>();
+      for (WebElement text : tooltipCols) {
+        texts.add(text.getText());
+      }
+      List<String> colsTexts = new ArrayList<>();
+      for (String col: cols) {
+        colsTexts.add(col + " desc nulls_last");
+      }
+      if (!isMatchText || !texts.containsAll(colsTexts)) {
+        LOG.error("Overview tooltip {} does not match, expected '{}'", colsTexts, texts);
         return false;
       }
       return true;

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/AbstractWebIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/AbstractWebIT.java
@@ -45,9 +45,9 @@ public class AbstractWebIT extends AbstractIT {
     }
   }
 
-  protected void moveTo(final Object locator) {
+  protected void mouseMoveTo(final Object locator) {
     Actions action = new Actions(driver);
-    action.moveToElement(locatorElement(locator)).build().perform();
+    action.moveToElement(locatorElement(locator)).perform();
   }
 
   protected WebElement pollingWait(final By locator, final long maxTimeout) {

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/AbstractWebIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/AbstractWebIT.java
@@ -45,6 +45,11 @@ public class AbstractWebIT extends AbstractIT {
     }
   }
 
+  protected void moveTo(final Object locator) {
+    Actions action = new Actions(driver);
+    action.moveToElement(locatorElement(locator)).build().perform();
+  }
+
   protected WebElement pollingWait(final By locator, final long maxTimeout) {
     Wait<WebDriver> wait =
         new FluentWait<>(driver)

--- a/web/src/app/metalakes/metalake/rightContent/tabsContent/TabsContent.js
+++ b/web/src/app/metalakes/metalake/rightContent/tabsContent/TabsContent.js
@@ -173,6 +173,7 @@ const TabsContent = () => {
                                       color='white'
                                       className={fonts.className}
                                       sx={{ display: 'flex', flexDirection: 'column' }}
+                                      data-refer={`overview-tip-${item.type}-items`}
                                     >
                                       {item.type === 'sortOrders'
                                         ? it.text
@@ -213,7 +214,7 @@ const TabsContent = () => {
                           </>
                         }
                       >
-                        <ListItem sx={{ maxWidth: 140, py: 0 }}>
+                        <ListItem sx={{ maxWidth: 140, py: 0 }} data-refer={`overview-tip-${item.type}`}>
                           <ListItemText
                             sx={{ m: 0 }}
                             primary={
@@ -248,6 +249,7 @@ const TabsContent = () => {
                                   whiteSpace: 'nowrap',
                                   textOverflow: 'ellipsis'
                                 }}
+                                data-refer={`overview-${item.type}-items`}
                               >
                                 {item.items.map((it, idx) => {
                                   return (

--- a/web/src/app/metalakes/metalake/rightContent/tabsContent/tableView/TableView.js
+++ b/web/src/app/metalakes/metalake/rightContent/tabsContent/tableView/TableView.js
@@ -119,7 +119,7 @@ const TableView = () => {
                           color='white'
                           className={fonts.className}
                           sx={{ display: 'flex', flexDirection: 'column' }}
-                          data-refer={`tip-item-${it.name}`}
+                          data-refer={`tip-${type}-item-${name}`}
                         >
                           {it.text || it.fields}
                         </Typography>
@@ -140,7 +140,7 @@ const TableView = () => {
               </>
             }
           >
-            <Box sx={{ display: 'flex', alignItems: 'center' }} data-refer={`col-icon-${name}`}>
+            <Box sx={{ display: 'flex', alignItems: 'center' }} data-refer={`col-icon-${type}-${name}`}>
               <Icon icon={icon} />
             </Box>
           </CustomTooltip>

--- a/web/src/app/metalakes/metalake/rightContent/tabsContent/tableView/TableView.js
+++ b/web/src/app/metalakes/metalake/rightContent/tabsContent/tableView/TableView.js
@@ -119,6 +119,7 @@ const TableView = () => {
                           color='white'
                           className={fonts.className}
                           sx={{ display: 'flex', flexDirection: 'column' }}
+                          data-refer={`tip-item-${it.name}`}
                         >
                           {it.text || it.fields}
                         </Typography>
@@ -139,7 +140,7 @@ const TableView = () => {
               </>
             }
           >
-            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center' }} data-refer={`col-icon-${name}`}>
               <Icon icon={icon} />
             </Box>
           </CustomTooltip>


### PR DESCRIPTION
### What changes were proposed in this pull request?

add checking table properties to the web e2e test

<img width="647" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/012fcd91-ab31-46a0-8e87-3c5d66ffd21f">

<img width="655" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/c226551b-24e2-4c5e-88aa-24c2cfb10c2f">



### Why are the changes needed?

Fix: #3210

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

IT
