### PR TITLE
[#3320] fix(client): shadow slf4j for client-java-runtime 

### DIFF
--- a/clients/client-java-runtime/build.gradle.kts
+++ b/clients/client-java-runtime/build.gradle.kts
@@ -24,6 +24,7 @@ tasks.withType<ShadowJar>(ShadowJar::class.java) {
   relocate("com.fasterxml", "com.datastrato.gravitino.shaded.com.fasterxml")
   relocate("org.apache.httpcomponents", "com.datastrato.gravitino.shaded.org.apache.httpcomponents")
   relocate("org.apache.commons", "com.datastrato.gravitino.shaded.org.apache.commons")
+  relocate("org.apache.logging.slf4j", "com.datastrato.gravitino.shaded.org.apache.logging.slf4j")
   relocate("org.antlr", "com.datastrato.gravitino.shaded.org.antlr")
 }
 

--- a/spark-connector/spark-connector-runtime/build.gradle.kts
+++ b/spark-connector/spark-connector-runtime/build.gradle.kts
@@ -29,6 +29,7 @@ tasks.withType<ShadowJar>(ShadowJar::class.java) {
   relocate("com.google", "com.datastrato.gravitino.shaded.com.google")
   relocate("google", "com.datastrato.gravitino.shaded.google")
   relocate("org.apache.hc", "com.datastrato.gravitino.shaded.org.apache.hc")
+  relocate("org.apache.logging.slf4j", "com.datastrato.gravitino.shaded.org.apache.logging.slf4j")
 }
 
 tasks.jar {

--- a/spark-connector/spark-connector-runtime/build.gradle.kts
+++ b/spark-connector/spark-connector-runtime/build.gradle.kts
@@ -29,7 +29,6 @@ tasks.withType<ShadowJar>(ShadowJar::class.java) {
   relocate("com.google", "com.datastrato.gravitino.shaded.com.google")
   relocate("google", "com.datastrato.gravitino.shaded.google")
   relocate("org.apache.hc", "com.datastrato.gravitino.shaded.org.apache.hc")
-  relocate("org.apache.logging.slf4j", "com.datastrato.gravitino.shaded.org.apache.logging.slf4j")
 }
 
 tasks.jar {


### PR DESCRIPTION
### What changes were proposed in this pull request?
shadow slf4j for client-java-runtime and spark-connector-runtime 

### Why are the changes needed?
some systems like spark 3.3 need low version log4j, will encounter the conflict bug:

```
java.lang.NoSuchMethodError: org.apache.logging.slf4j.Log4jLoggerFactory: method 'void <init>()' not found
```

fix: #3320 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
existing tests
