### PR TITLE
[#3313] feat(common): refactor JsonUtils object mapper to client and service side

### DIFF
--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClientBase.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/GravitinoClientBase.java
@@ -11,8 +11,6 @@ import com.datastrato.gravitino.dto.responses.MetalakeResponse;
 import com.datastrato.gravitino.dto.responses.VersionResponse;
 import com.datastrato.gravitino.exceptions.GravitinoRuntimeException;
 import com.datastrato.gravitino.exceptions.NoSuchMetalakeException;
-import com.datastrato.gravitino.json.JsonUtils;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.InlineMe;
@@ -53,8 +51,7 @@ public abstract class GravitinoClientBase implements Closeable {
       AuthDataProvider authDataProvider,
       boolean checkVersion,
       Map<String, String> headers) {
-    ObjectMapper mapper = JsonUtils.objectMapper();
-    mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    ObjectMapper mapper = ObjectMapperProvider.objectMapper();
 
     if (checkVersion) {
       this.restClient =

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/HTTPClient.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/HTTPClient.java
@@ -22,7 +22,6 @@ package com.datastrato.gravitino.client;
 import com.datastrato.gravitino.auth.AuthConstants;
 import com.datastrato.gravitino.dto.responses.ErrorResponse;
 import com.datastrato.gravitino.exceptions.RESTException;
-import com.datastrato.gravitino.json.JsonUtils;
 import com.datastrato.gravitino.rest.RESTRequest;
 import com.datastrato.gravitino.rest.RESTResponse;
 import com.datastrato.gravitino.rest.RESTUtils;
@@ -695,7 +694,7 @@ public class HTTPClient implements RESTClient {
 
     private final Map<String, String> baseHeaders = Maps.newHashMap();
     private String uri;
-    private ObjectMapper mapper = JsonUtils.objectMapper();
+    private ObjectMapper mapper = ObjectMapperProvider.objectMapper();
     private AuthDataProvider authDataProvider;
     private Runnable beforeConnectHandler;
 

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/OAuth2ClientUtil.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/OAuth2ClientUtil.java
@@ -126,7 +126,8 @@ class OAuth2ClientUtil {
 
     JsonNode node;
     try {
-      node = JsonUtils.objectMapper().readTree(Base64.getUrlDecoder().decode(parts.get(1)));
+      node =
+          ObjectMapperProvider.objectMapper().readTree(Base64.getUrlDecoder().decode(parts.get(1)));
     } catch (IOException e) {
       return null;
     }

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/ObjectMapperProvider.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/ObjectMapperProvider.java
@@ -32,7 +32,7 @@ public class ObjectMapperProvider {
   /**
    * Retrieves a globally shared {@link ObjectMapper} instance.
    *
-   * <p>Note: This ObjectMapper is shared across all users. If you need to modify the default
+   * <p>Note: This ObjectMapper is a global singe instance. If you need to modify the default
    * serialization/deserialization settings, make changes within the INSTANCE builder directly.
    * Avoid modifying properties of the returned {@code ObjectMapper} instance to prevent unintended
    * side effects.
@@ -42,4 +42,6 @@ public class ObjectMapperProvider {
   public static ObjectMapper objectMapper() {
     return ObjectMapperHolder.INSTANCE;
   }
+
+  private ObjectMapperProvider() {}
 }

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/ObjectMapperProvider.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/ObjectMapperProvider.java
@@ -1,30 +1,31 @@
 /*
- * Copyright 2023 Datastrato Pvt Ltd.
- * This software is licensed under the Apache License version 2.
+ *  Copyright 2024 Datastrato Pvt Ltd.
+ *  This software is licensed under the Apache License version 2.
  */
-package com.datastrato.gravitino.server.web;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
+package com.datastrato.gravitino.client;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.cfg.EnumFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import javax.ws.rs.ext.ContextResolver;
-import javax.ws.rs.ext.Provider;
 
-@Provider
-public class ObjectMapperProvider implements ContextResolver<ObjectMapper> {
-
+/**
+ * Provides a singleton {@link ObjectMapper} configured for specific serialization and
+ * deserialization behaviors.
+ */
+public class ObjectMapperProvider {
   private static class ObjectMapperHolder {
     private static final ObjectMapper INSTANCE =
         JsonMapper.builder()
             .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
             .configure(EnumFeature.WRITE_ENUMS_TO_LOWERCASE, true)
             .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
             .build()
-            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
             .registerModule(new JavaTimeModule());
   }
 
@@ -39,11 +40,6 @@ public class ObjectMapperProvider implements ContextResolver<ObjectMapper> {
    * @return the globally shared {@link ObjectMapper} instance
    */
   public static ObjectMapper objectMapper() {
-    return ObjectMapperHolder.INSTANCE;
-  }
-
-  @Override
-  public ObjectMapper getContext(Class<?> type) {
     return ObjectMapperHolder.INSTANCE;
   }
 }

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestBase.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestBase.java
@@ -4,7 +4,6 @@
  */
 package com.datastrato.gravitino.client;
 
-import com.datastrato.gravitino.json.JsonUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collections;
@@ -22,7 +21,7 @@ import org.mockserver.model.Parameter;
 
 public abstract class TestBase {
 
-  protected static final ObjectMapper MAPPER = JsonUtils.objectMapper();
+  protected static final ObjectMapper MAPPER = ObjectMapperProvider.objectMapper();
 
   protected static ClientAndServer mockServer;
 

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestHTTPClient.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestHTTPClient.java
@@ -29,7 +29,6 @@ import static org.mockserver.model.HttpResponse.response;
 
 import com.datastrato.gravitino.dto.responses.ErrorResponse;
 import com.datastrato.gravitino.exceptions.NotFoundException;
-import com.datastrato.gravitino.json.JsonUtils;
 import com.datastrato.gravitino.rest.RESTRequest;
 import com.datastrato.gravitino.rest.RESTResponse;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -58,7 +57,7 @@ import org.mockserver.model.HttpResponse;
  */
 public class TestHTTPClient {
 
-  private static final ObjectMapper MAPPER = JsonUtils.objectMapper();
+  private static final ObjectMapper MAPPER = ObjectMapperProvider.objectMapper();
 
   private static ClientAndServer mockServer;
   private static RESTClient restClient;

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestOAuth2TokenProvider.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestOAuth2TokenProvider.java
@@ -13,7 +13,7 @@ import com.datastrato.gravitino.dto.responses.OAuth2ErrorResponse;
 import com.datastrato.gravitino.dto.responses.OAuth2TokenResponse;
 import com.datastrato.gravitino.exceptions.BadRequestException;
 import com.datastrato.gravitino.exceptions.UnauthorizedException;
-import com.datastrato.gravitino.json.JsonUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -67,7 +67,7 @@ public class TestOAuth2TokenProvider {
         HttpResponse.response().withStatusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
     OAuth2ErrorResponse respBody =
         new OAuth2ErrorResponse(OAuth2ClientUtil.INVALID_CLIENT_ERROR, "invalid");
-    String respJson = JsonUtils.objectMapper().writeValueAsString(respBody);
+    String respJson = ObjectMapperProvider.objectMapper().writeValueAsString(respBody);
     mockResponse = mockResponse.withBody(respJson);
     mockServer.when(any(), Times.exactly(1)).respond(mockResponse);
     OAuth2TokenProvider.Builder builder =
@@ -79,7 +79,7 @@ public class TestOAuth2TokenProvider {
     Assertions.assertThrows(UnauthorizedException.class, builder::build);
 
     respBody = new OAuth2ErrorResponse(OAuth2ClientUtil.INVALID_GRANT_ERROR, "invalid");
-    respJson = JsonUtils.objectMapper().writeValueAsString(respBody);
+    respJson = ObjectMapperProvider.objectMapper().writeValueAsString(respBody);
     mockResponse = mockResponse.withBody(respJson);
     mockServer.when(any(), Times.exactly(1)).respond(mockResponse);
     Assertions.assertThrows(BadRequestException.class, builder::build);
@@ -94,14 +94,15 @@ public class TestOAuth2TokenProvider {
             .withPath("oauth/token")
             .withScope("test");
 
+    ObjectMapper objectMapper = ObjectMapperProvider.objectMapper();
     HttpResponse mockResponse = HttpResponse.response().withStatusCode(HttpStatus.SC_OK);
     OAuth2TokenResponse response = new OAuth2TokenResponse("1", "2", "3", 1, "test", null);
-    String respJson = JsonUtils.objectMapper().writeValueAsString(response);
+    String respJson = objectMapper.writeValueAsString(response);
     mockResponse = mockResponse.withBody(respJson);
     mockServer.when(any(), Times.exactly(1)).respond(mockResponse);
     Assertions.assertThrows(IllegalArgumentException.class, builder::build);
     response = new OAuth2TokenResponse("1", "2", "bearer", 1, "test", null);
-    respJson = JsonUtils.objectMapper().writeValueAsString(response);
+    respJson = objectMapper.writeValueAsString(response);
     mockResponse = mockResponse.withBody(respJson);
     mockServer.when(any(), Times.exactly(1)).respond(mockResponse);
     OAuth2TokenProvider provider = builder.build();
@@ -117,7 +118,7 @@ public class TestOAuth2TokenProvider {
             .compact();
 
     response = new OAuth2TokenResponse(oldAccessToken, "2", "bearer", 1, "test", null);
-    respJson = JsonUtils.objectMapper().writeValueAsString(response);
+    respJson = objectMapper.writeValueAsString(response);
     mockResponse = mockResponse.withBody(respJson);
     mockServer.when(any(), Times.exactly(1)).respond(mockResponse);
     provider = builder.build();
@@ -130,7 +131,7 @@ public class TestOAuth2TokenProvider {
             .compact();
 
     response = new OAuth2TokenResponse(accessToken, "2", "bearer", 1, "test", null);
-    respJson = JsonUtils.objectMapper().writeValueAsString(response);
+    respJson = ObjectMapperProvider.objectMapper().writeValueAsString(response);
     mockResponse = mockResponse.withBody(respJson);
     mockServer.when(any(), Times.exactly(1)).respond(mockResponse);
     Assertions.assertNotEquals(accessToken, oldAccessToken);

--- a/common/src/main/java/com/datastrato/gravitino/json/JsonUtils.java
+++ b/common/src/main/java/com/datastrato/gravitino/json/JsonUtils.java
@@ -56,6 +56,7 @@ import com.fasterxml.jackson.databind.cfg.EnumFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -237,8 +238,13 @@ public class JsonUtils {
   /**
    * Get the shared ObjectMapper instance for JSON serialization/deserialization.
    *
-   * @return The ObjectMapper instance.
+   * <p>This instance should only be used for testing. For production or other environments, obtain
+   * an {@link ObjectMapper} from the appropriate {@code ObjectMapperProvider} on the server or
+   * client side.
+   *
+   * @return the shared {@link ObjectMapper} instance for tests.
    */
+  @VisibleForTesting
   public static ObjectMapper objectMapper() {
     return ObjectMapperHolder.INSTANCE;
   }

--- a/common/src/main/java/com/datastrato/gravitino/json/JsonUtils.java
+++ b/common/src/main/java/com/datastrato/gravitino/json/JsonUtils.java
@@ -236,13 +236,17 @@ public class JsonUtils {
   }
 
   /**
-   * Get the shared ObjectMapper instance for JSON serialization/deserialization.
+   * Returns a shared {@link ObjectMapper} instance for JSON serialization/deserialization test.
    *
-   * <p>This instance should only be used for testing. For production or other environments, obtain
-   * an {@link ObjectMapper} from the appropriate {@code ObjectMapperProvider} on the server or
-   * client side.
+   * <p>Note: This instance is intended for testing purposes only. For production use, obtain an
+   * {@link ObjectMapper} from the following providers:
    *
-   * @return the shared {@link ObjectMapper} instance for tests.
+   * <ul>
+   *   <li>Client side: {@code com.datastrato.gravitino.client.ObjectMapperProvider}
+   *   <li>Server side: {@code com.datastrato.gravitino.server.web.ObjectMapperProvider}
+   * </ul>
+   *
+   * @return the shared {@link ObjectMapper} instance for testing.
    */
   @VisibleForTesting
   public static ObjectMapper objectMapper() {

--- a/server/src/main/java/com/datastrato/gravitino/server/web/ConfigServlet.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/ConfigServlet.java
@@ -7,10 +7,8 @@ package com.datastrato.gravitino.server.web;
 import com.datastrato.gravitino.Configs;
 import com.datastrato.gravitino.auth.AuthenticatorType;
 import com.datastrato.gravitino.config.ConfigEntry;
-import com.datastrato.gravitino.json.JsonUtils;
 import com.datastrato.gravitino.server.ServerConfig;
 import com.datastrato.gravitino.server.authentication.OAuthConfig;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import java.io.IOException;
@@ -51,9 +49,8 @@ public class ConfigServlet extends HttpServlet {
   protected void doGet(HttpServletRequest req, HttpServletResponse res)
       throws IllegalStateException, IOException {
     try (PrintWriter writer = res.getWriter()) {
-      ObjectMapper objectMapper = JsonUtils.objectMapper();
       res.setContentType("application/json;charset=utf-8");
-      writer.write(objectMapper.writeValueAsString(configs));
+      writer.write(ObjectMapperProvider.objectMapper().writeValueAsString(configs));
     } catch (IllegalStateException exception) {
       LOG.error("Illegal state occurred when calling getWriter()");
     } catch (IOException exception) {

--- a/server/src/main/java/com/datastrato/gravitino/server/web/ObjectMapperProvider.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/ObjectMapperProvider.java
@@ -31,7 +31,7 @@ public class ObjectMapperProvider implements ContextResolver<ObjectMapper> {
   /**
    * Retrieves a globally shared {@link ObjectMapper} instance.
    *
-   * <p>Note: This ObjectMapper is shared across all users. If you need to modify the default
+   * <p>Note: This ObjectMapper is a global single instance. If you need to modify the default
    * serialization/deserialization settings, make changes within the INSTANCE builder directly.
    * Avoid modifying properties of the returned {@code ObjectMapper} instance to prevent unintended
    * side effects.


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. provide separate method to get object mapper in  client and service side
2. rename `JsonUtils.objectMapper` to `JsonUtils.objectMapperForTest`

### Why are the changes needed?

Fix: #3313 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
existing tests
