### PR TITLE
[#3319] fix(PyClient): ./gradlew test -PskipITs failed in python-client

### DIFF
--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -65,7 +65,7 @@ jobs:
           for pythonVersion in "3.8" "3.9" "3.10" "3.11"
           do
             echo "Use Python version ${pythonVersion} to test the Python client."
-            ./gradlew -PjdkVersion=${{ matrix.java-version }} -PpythonVersion=${pythonVersion} :client:client-python:test
+            ./gradlew -PjdkVersion=${{ matrix.java-version }} -PpythonVersion=${pythonVersion} :clients:client-python:test
             # Clean Gravitino database to clean test data
             rm -rf ./distribution/package/data
           done

--- a/clients/client-python/build.gradle.kts
+++ b/clients/client-python/build.gradle.kts
@@ -51,25 +51,38 @@ tasks {
     args = listOf("./gravitino", "./tests")
   }
 
+  val integrationTest by registering(VenvTask::class) {
+    doFirst {
+      gravitinoServer("start")
+    }
+
+    venvExec = "python"
+    args = listOf("-m", "unittest")
+    workingDir = projectDir.resolve("./tests/integration")
+    environment = mapOf(
+      "PROJECT_VERSION" to project.version,
+      "GRAVITINO_HOME" to project.rootDir.path + "/distribution/package",
+      "START_EXTERNAL_GRAVITINO" to "true"
+    )
+
+    doLast {
+      gravitinoServer("stop")
+    }
+  }
+
+  val unitTests by registering(VenvTask::class) {
+    venvExec = "python"
+    args = listOf("-m", "unittest")
+    workingDir = projectDir.resolve("./tests/unittests")
+  }
+
   val test by registering(VenvTask::class) {
+    dependsOn(pipInstall, pylint, unitTests)
+
     val skipPyClientITs = project.hasProperty("skipPyClientITs")
-    if (!skipPyClientITs) {
-      doFirst {
-        gravitinoServer("start")
-      }
-
-      venvExec = "python"
-      args = listOf("-m", "unittest")
-      workingDir = projectDir.resolve(".")
-      environment = mapOf(
-        "PROJECT_VERSION" to project.version,
-        "GRAVITINO_HOME" to project.rootDir.path + "/distribution/package",
-        "START_EXTERNAL_GRAVITINO" to "true"
-      )
-
-      doLast {
-        gravitinoServer("stop")
-      }
+    val skipITs = project.hasProperty("skipITs")
+    if (!skipITs && !skipPyClientITs) {
+      dependsOn(integrationTest)
     }
   }
 

--- a/clients/client-python/tests/integration/test_metalake.py
+++ b/clients/client-python/tests/integration/test_metalake.py
@@ -10,7 +10,6 @@ from gravitino.client.gravitino_admin_client import GravitinoAdminClient
 from gravitino.client.gravitino_metalake import GravitinoMetalake
 from gravitino.dto.dto_converters import DTOConverters
 from gravitino.dto.requests.metalake_updates_request import MetalakeUpdatesRequest
-from gravitino.dto.responses.metalake_response import MetalakeResponse
 from gravitino.api.metalake_change import MetalakeChange
 from gravitino.name_identifier import NameIdentifier
 from tests.integration.integration_test_env import IntegrationTestEnv
@@ -112,35 +111,6 @@ class TestMetalake(IntegrationTestEnv):
             '{"@type": "updateComment", "newComment": "new metalake comment"}]}'
         )
         self.assertEqual(updates_request.to_json(), valid_json)
-
-    def test_from_json_metalake_response(self):
-        str_json = (
-            b'{"code":0,"metalake":{"name":"example_name18","comment":"This is a sample comment",'
-            b'"properties":{"key1":"value1","key2":"value2"},'
-            b'"audit":{"creator":"anonymous","createTime":"2024-04-05T10:10:35.218Z"}}}'
-        )
-        metalake_response = MetalakeResponse.from_json(str_json, infer_missing=True)
-        self.assertEqual(metalake_response.code(), 0)
-        self.assertIsNotNone(metalake_response._metalake)
-        self.assertEqual(metalake_response._metalake.name(), "example_name18")
-        self.assertEqual(
-            metalake_response._metalake.audit_info().creator(), "anonymous"
-        )
-
-    def test_from_error_json_metalake_response(self):
-        str_json = (
-            b'{"code":0, "undefine-key1":"undefine-value1", '
-            b'"metalake":{"undefine-key2":1, "name":"example_name18","comment":"This is a sample comment",'
-            b'"properties":{"key1":"value1","key2":"value2"},'
-            b'"audit":{"creator":"anonymous","createTime":"2024-04-05T10:10:35.218Z"}}}'
-        )
-        metalake_response = MetalakeResponse.from_json(str_json, infer_missing=True)
-        self.assertEqual(metalake_response.code(), 0)
-        self.assertIsNotNone(metalake_response._metalake)
-        self.assertEqual(metalake_response._metalake.name(), "example_name18")
-        self.assertEqual(
-            metalake_response._metalake.audit_info().creator(), "anonymous"
-        )
 
     def test_list_metalakes(self):
         self.create_metalake(self.metalake_name)

--- a/clients/client-python/tests/unittests/test_metalake.py
+++ b/clients/client-python/tests/unittests/test_metalake.py
@@ -1,0 +1,39 @@
+"""
+Copyright 2024 Datastrato Pvt Ltd.
+This software is licensed under the Apache License version 2.
+"""
+
+import unittest
+
+from gravitino.dto.responses.metalake_response import MetalakeResponse
+
+
+class TestMetalake(unittest.TestCase):
+    def test_from_json_metalake_response(self):
+        str_json = (
+            b'{"code":0,"metalake":{"name":"example_name18","comment":"This is a sample comment",'
+            b'"properties":{"key1":"value1","key2":"value2"},'
+            b'"audit":{"creator":"anonymous","createTime":"2024-04-05T10:10:35.218Z"}}}'
+        )
+        metalake_response = MetalakeResponse.from_json(str_json, infer_missing=True)
+        self.assertEqual(metalake_response.code(), 0)
+        self.assertIsNotNone(metalake_response._metalake)
+        self.assertEqual(metalake_response._metalake.name(), "example_name18")
+        self.assertEqual(
+            metalake_response._metalake.audit_info().creator(), "anonymous"
+        )
+
+    def test_from_error_json_metalake_response(self):
+        str_json = (
+            b'{"code":0, "undefine-key1":"undefine-value1", '
+            b'"metalake":{"undefine-key2":1, "name":"example_name18","comment":"This is a sample comment",'
+            b'"properties":{"key1":"value1","key2":"value2"},'
+            b'"audit":{"creator":"anonymous","createTime":"2024-04-05T10:10:35.218Z"}}}'
+        )
+        metalake_response = MetalakeResponse.from_json(str_json, infer_missing=True)
+        self.assertEqual(metalake_response.code(), 0)
+        self.assertIsNotNone(metalake_response._metalake)
+        self.assertEqual(metalake_response._metalake.name(), "example_name18")
+        self.assertEqual(
+            metalake_response._metalake.audit_info().creator(), "anonymous"
+        )


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Add `skipITs` build params in the Python Client Gradle script.
2. Use different directory storage integration test and unit tests.

### Why are the changes needed?

When running this command ./gradlew test -PskipITs directly. the Gradle python test task will be failed because of lacking compileDistribution step. we should fix it to make all the commands work.

Fix: #3319

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

CI Passed
