### PR TITLE
[#2711] feat(filesystem): Support Kerberos client authentication in gvfs

### DIFF
--- a/clients/filesystem-hadoop3/build.gradle.kts
+++ b/clients/filesystem-hadoop3/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
   testImplementation(libs.hadoop3.common)
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
+  testImplementation(libs.minikdc)
   testImplementation(libs.mockito.core)
   testImplementation(libs.mockserver.netty) {
     exclude("com.google.guava", "guava")

--- a/clients/filesystem-hadoop3/src/main/java/com/datastrato/gravitino/filesystem/hadoop/GravitinoVirtualFileSystemConfiguration.java
+++ b/clients/filesystem-hadoop3/src/main/java/com/datastrato/gravitino/filesystem/hadoop/GravitinoVirtualFileSystemConfiguration.java
@@ -20,7 +20,7 @@ class GravitinoVirtualFileSystemConfiguration {
 
   public static final String SIMPLE_AUTH_TYPE = "simple";
   public static final String OAUTH2_AUTH_TYPE = "oauth2";
-
+  public static final String KERBEROS_AUTH_TYPE = "kerberos";
   // oauth2
   /** The configuration key for the URI of the default OAuth server. */
   public static final String FS_GRAVITINO_CLIENT_OAUTH2_SERVER_URI_KEY =
@@ -37,6 +37,14 @@ class GravitinoVirtualFileSystemConfiguration {
   /** The configuration key for the scope of the token. */
   public static final String FS_GRAVITINO_CLIENT_OAUTH2_SCOPE_KEY =
       "fs.gravitino.client.oauth2.scope";
+
+  /** The configuration key for the principal. */
+  public static final String FS_GRAVITINO_CLIENT_KERBEROS_PRINCIPAL_KEY =
+      "fs.gravitino.client.kerberos.principal";
+
+  /** The configuration key for the keytab file path corresponding to the principal. */
+  public static final String FS_GRAVITINO_CLIENT_KERBEROS_KEYTAB_FILE_PATH_KEY =
+      "fs.gravitino.client.kerberos.keytabFilePath";
 
   /** The configuration key for the maximum capacity of the Gravitino fileset cache. */
   public static final String FS_GRAVITINO_FILESET_CACHE_MAX_CAPACITY_KEY =

--- a/clients/filesystem-hadoop3/src/test/java/com/datastrato/gravitino/filesystem/hadoop/GravitinoMockServerBase.java
+++ b/clients/filesystem-hadoop3/src/test/java/com/datastrato/gravitino/filesystem/hadoop/GravitinoMockServerBase.java
@@ -40,7 +40,7 @@ import org.mockserver.model.Parameter;
 public abstract class GravitinoMockServerBase {
   private static final ObjectMapper MAPPER = JsonUtils.objectMapper();
   private static ClientAndServer mockServer;
-  private static final String MOCK_SERVER_HOST = "http://127.0.0.1:";
+  private static final String MOCK_SERVER_HOST = "http://localhost:";
   private static int port;
   protected static final String metalakeName = "metalake_1";
   protected static final String catalogName = "fileset_catalog_1";

--- a/clients/filesystem-hadoop3/src/test/java/com/datastrato/gravitino/filesystem/hadoop/KdcServerBase.java
+++ b/clients/filesystem-hadoop3/src/test/java/com/datastrato/gravitino/filesystem/hadoop/KdcServerBase.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+
+package com.datastrato.gravitino.filesystem.hadoop;
+
+import java.io.File;
+import java.util.UUID;
+import org.apache.hadoop.minikdc.KerberosSecurityTestcase;
+
+public class KdcServerBase extends KerberosSecurityTestcase {
+  private static final KerberosSecurityTestcase INSTANCE = new KerberosSecurityTestcase();
+  private static final String CLIENT_PRINCIPAL = "client@EXAMPLE.COM";
+  private static final String SERVER_PRINCIPAL = "HTTP/localhost@EXAMPLE.COM";
+  private static final String KEYTAB_FILE =
+      new File(System.getProperty("test.dir", "target"), UUID.randomUUID().toString())
+          .getAbsolutePath();
+
+  static {
+    try {
+      INSTANCE.startMiniKdc();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private KdcServerBase() {}
+
+  public static void stopKdc() {
+    INSTANCE.stopMiniKdc();
+  }
+
+  public static void initKeyTab() throws Exception {
+    File keytabFile = new File(KEYTAB_FILE);
+    String clientPrincipal = removeRealm(CLIENT_PRINCIPAL);
+    String serverPrincipal = removeRealm(SERVER_PRINCIPAL);
+    INSTANCE.getKdc().createPrincipal(keytabFile, clientPrincipal, serverPrincipal);
+  }
+
+  private static String removeRealm(String principal) {
+    return principal.substring(0, principal.lastIndexOf("@"));
+  }
+
+  public static String getServerPrincipal() {
+    return SERVER_PRINCIPAL;
+  }
+
+  public static String getClientPrincipal() {
+    return CLIENT_PRINCIPAL;
+  }
+
+  public static String getKeytabFile() {
+    return KEYTAB_FILE;
+  }
+}

--- a/clients/filesystem-hadoop3/src/test/java/com/datastrato/gravitino/filesystem/hadoop/TestKerberosClient.java
+++ b/clients/filesystem-hadoop3/src/test/java/com/datastrato/gravitino/filesystem/hadoop/TestKerberosClient.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.filesystem.hadoop;
+
+import static com.datastrato.gravitino.server.authentication.KerberosConfig.KEYTAB;
+import static com.datastrato.gravitino.server.authentication.KerberosConfig.PRINCIPAL;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockserver.model.HttpResponse.response;
+
+import com.datastrato.gravitino.Config;
+import com.datastrato.gravitino.server.authentication.KerberosAuthenticator;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.Method;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockserver.matchers.Times;
+import org.mockserver.model.Header;
+import org.mockserver.model.HttpRequest;
+
+public class TestKerberosClient extends TestGvfsBase {
+
+  @BeforeAll
+  public static void setup() {
+    try {
+      KdcServerBase.initKeyTab();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    TestGvfsBase.setup();
+    conf.set(
+        GravitinoVirtualFileSystemConfiguration.FS_GRAVITINO_CLIENT_AUTH_TYPE_KEY,
+        GravitinoVirtualFileSystemConfiguration.KERBEROS_AUTH_TYPE);
+    conf.set(
+        GravitinoVirtualFileSystemConfiguration.FS_GRAVITINO_CLIENT_KERBEROS_PRINCIPAL_KEY,
+        KdcServerBase.getClientPrincipal());
+    conf.set(
+        GravitinoVirtualFileSystemConfiguration.FS_GRAVITINO_CLIENT_KERBEROS_KEYTAB_FILE_PATH_KEY,
+        KdcServerBase.getKeytabFile());
+  }
+
+  @AfterAll
+  public static void teardown() {
+    KdcServerBase.stopKdc();
+  }
+
+  @Test
+  public void testAuthConfigs() {
+    // init conf
+    Configuration configuration = new Configuration();
+    configuration.set(
+        String.format(
+            "fs.%s.impl.disable.cache", GravitinoVirtualFileSystemConfiguration.GVFS_SCHEME),
+        "true");
+    configuration.set("fs.gvfs.impl", GVFS_IMPL_CLASS);
+    configuration.set("fs.AbstractFileSystem.gvfs.impl", GVFS_ABSTRACT_IMPL_CLASS);
+    configuration.set(
+        GravitinoVirtualFileSystemConfiguration.FS_GRAVITINO_CLIENT_METALAKE_KEY, metalakeName);
+    configuration.set(
+        GravitinoVirtualFileSystemConfiguration.FS_GRAVITINO_SERVER_URI_KEY,
+        GravitinoMockServerBase.serverUri());
+
+    // set auth type, but do not set other configs
+    configuration.set(
+        GravitinoVirtualFileSystemConfiguration.FS_GRAVITINO_CLIENT_AUTH_TYPE_KEY,
+        GravitinoVirtualFileSystemConfiguration.KERBEROS_AUTH_TYPE);
+    assertThrows(
+        IllegalArgumentException.class, () -> managedFilesetPath.getFileSystem(configuration));
+
+    // set not exist keytab path
+    configuration.set(
+        GravitinoVirtualFileSystemConfiguration.FS_GRAVITINO_CLIENT_KERBEROS_KEYTAB_FILE_PATH_KEY,
+        "file://tmp/test.keytab");
+    assertThrows(
+        IllegalArgumentException.class, () -> managedFilesetPath.getFileSystem(configuration));
+  }
+
+  @Test
+  public void testAuthWithPrincipalAndKeytabNormally() throws Exception {
+    KerberosAuthenticator kerberosAuthenticator = new KerberosAuthenticator();
+    Config config = new Config(false) {};
+    config.set(PRINCIPAL, KdcServerBase.getServerPrincipal());
+    config.set(KEYTAB, KdcServerBase.getKeytabFile());
+    kerberosAuthenticator.initialize(config);
+
+    Configuration configuration = new Configuration(conf);
+    configuration.set(
+        GravitinoVirtualFileSystemConfiguration.FS_GRAVITINO_CLIENT_KERBEROS_PRINCIPAL_KEY,
+        KdcServerBase.getClientPrincipal());
+    configuration.set(
+        GravitinoVirtualFileSystemConfiguration.FS_GRAVITINO_CLIENT_KERBEROS_KEYTAB_FILE_PATH_KEY,
+        KdcServerBase.getKeytabFile());
+
+    // mock load metalake with principal and keytab
+    String testMetalake = "test_kerberos_normally";
+    HttpRequest mockRequest =
+        HttpRequest.request("/api/metalakes/" + testMetalake)
+            .withMethod(Method.GET.name())
+            .withQueryStringParameters(Collections.emptyMap());
+    GravitinoMockServerBase.mockServer()
+        .when(mockRequest, Times.unlimited())
+        .respond(
+            httpRequest -> {
+              List<Header> headers = httpRequest.getHeaders().getEntries();
+              for (Header header : headers) {
+                if (header.getName().equalsIgnoreCase("Authorization")) {
+                  byte[] tokenValue =
+                      header.getValues().get(0).getValue().getBytes(StandardCharsets.UTF_8);
+                  kerberosAuthenticator.authenticateToken(tokenValue);
+                }
+              }
+              return response().withStatusCode(HttpStatus.SC_OK);
+            });
+    Path newPath = new Path(managedFilesetPath.toString().replace(metalakeName, testMetalake));
+    // Should auth successfully
+    newPath.getFileSystem(configuration);
+  }
+
+  @Test
+  public void testAuthWithInvalidInfo() throws Exception {
+    KerberosAuthenticator kerberosAuthenticator = new KerberosAuthenticator();
+    Config config = new Config(false) {};
+    config.set(PRINCIPAL, KdcServerBase.getServerPrincipal());
+    config.set(KEYTAB, KdcServerBase.getKeytabFile());
+    kerberosAuthenticator.initialize(config);
+
+    // test with invalid principal and keytab
+    Configuration conf1 = new Configuration(conf);
+    conf1.set(
+        GravitinoVirtualFileSystemConfiguration.FS_GRAVITINO_CLIENT_KERBEROS_PRINCIPAL_KEY,
+        "invalid@EXAMPLE.COM");
+    conf1.set(
+        GravitinoVirtualFileSystemConfiguration.FS_GRAVITINO_CLIENT_KERBEROS_KEYTAB_FILE_PATH_KEY,
+        KdcServerBase.getKeytabFile());
+
+    String testMetalake = "test_invalid";
+    HttpRequest mockRequest =
+        HttpRequest.request("/api/metalakes/" + testMetalake)
+            .withMethod(Method.GET.name())
+            .withQueryStringParameters(Collections.emptyMap());
+    GravitinoMockServerBase.mockServer()
+        .when(mockRequest, Times.unlimited())
+        .respond(
+            httpRequest -> {
+              List<Header> headers = httpRequest.getHeaders().getEntries();
+              for (Header header : headers) {
+                if (header.getName().equalsIgnoreCase("Authorization")) {
+                  byte[] tokenValue =
+                      header.getValues().get(0).getValue().getBytes(StandardCharsets.UTF_8);
+                  kerberosAuthenticator.authenticateToken(tokenValue);
+                }
+              }
+              return response().withStatusCode(HttpStatus.SC_OK);
+            });
+    Path newPath = new Path(managedFilesetPath.toString().replace(metalakeName, testMetalake));
+    Assertions.assertThrows(IllegalStateException.class, () -> newPath.getFileSystem(conf1));
+
+    // test with principal and invalid keytab
+    File invalidKeytabFile =
+        new File(System.getProperty("test.dir", "target"), UUID.randomUUID().toString());
+    if (invalidKeytabFile.exists()) {
+      invalidKeytabFile.delete();
+    }
+    invalidKeytabFile.createNewFile();
+
+    Configuration conf2 = new Configuration(conf);
+    conf2.set(
+        GravitinoVirtualFileSystemConfiguration.FS_GRAVITINO_CLIENT_KERBEROS_PRINCIPAL_KEY,
+        KdcServerBase.getClientPrincipal());
+    conf2.set(
+        GravitinoVirtualFileSystemConfiguration.FS_GRAVITINO_CLIENT_KERBEROS_KEYTAB_FILE_PATH_KEY,
+        invalidKeytabFile.getAbsolutePath());
+    Assertions.assertThrows(IllegalStateException.class, () -> newPath.getFileSystem(conf2));
+    invalidKeytabFile.delete();
+
+    // test with principal and no keytab
+    Configuration conf3 = new Configuration(conf);
+    conf3.set(
+        GravitinoVirtualFileSystemConfiguration.FS_GRAVITINO_CLIENT_KERBEROS_PRINCIPAL_KEY,
+        KdcServerBase.getClientPrincipal());
+    // remove keytab configuration
+    conf3.unset(
+        GravitinoVirtualFileSystemConfiguration.FS_GRAVITINO_CLIENT_KERBEROS_KEYTAB_FILE_PATH_KEY);
+    Assertions.assertThrows(IllegalStateException.class, () -> newPath.getFileSystem(conf3));
+  }
+}

--- a/docs/how-to-use-gvfs.md
+++ b/docs/how-to-use-gvfs.md
@@ -40,20 +40,22 @@ the path mapping and convert automatically.
 
 ## Configuration
 
-| Configuration item                                    | Description                                                                                                                                                                                       | Default value | Required                          | Since version |
-|-------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|-----------------------------------|---------------|
-| `fs.AbstractFileSystem.gvfs.impl`                     | The Gravitino Virtual File System abstract class, set it to `com.datastrato.gravitino.filesystem.hadoop.Gvfs`.                                                                       | (none)        | Yes                               | 0.5.0         |
-| `fs.gvfs.impl`                                        | The Gravitino Virtual File System implementation class, set it to `com.datastrato.gravitino.filesystem.hadoop.GravitinoVirtualFileSystem`.                                           | (none)        | Yes                               | 0.5.0         |
-| `fs.gvfs.impl.disable.cache`                          | Disable the Gravitino Virtual File System cache in the Hadoop environment. If you need to proxy multi-user operations, please set this value to `true` and create a separate File System for each user. | `false`       | No                                | 0.5.0         |
-| `fs.gravitino.server.uri`                             | The Gravitino server URI which GVFS needs to load the fileset metadata.                                                                                                                               | (none)        | Yes                               | 0.5.0         |
-| `fs.gravitino.client.metalake`                        | The metalake to which the fileset belongs.                                                                                                                                                               | (none)        | Yes                               | 0.5.0         |
-| `fs.gravitino.client.authType`                        | The auth type to initialize the Gravitino client to use with the Gravitino Virtual File System. Currently only supports `simple` and `oauth2` auth types.                                                             | `simple`      | No                                | 0.5.0         |
-| `fs.gravitino.client.oauth2.serverUri`                | The auth server URI for the Gravitino client when using `oauth2` auth type with the Gravitino Virtual File System.                                                                                     | (none)        | Yes if you use `oauth2` auth type | 0.5.0         |
-| `fs.gravitino.client.oauth2.credential`               | The auth credential for the Gravitino client when using `oauth2` auth type in the Gravitino Virtual File System.                                                                                     | (none)        | Yes if you use `oauth2` auth type | 0.5.0         |
-| `fs.gravitino.client.oauth2.path`                     | The auth server path for the Gravitino client when using `oauth2` auth type with the Gravitino Virtual File System. Please remove the first slash `/` from the path, for example `oauth/token`.            | (none)        | Yes if you use `oauth2` auth type | 0.5.0         |
-| `fs.gravitino.client.oauth2.scope`                    | The auth scope for the Gravitino client when using `oauth2` auth type with the Gravitino Virtual File System.                                                                                          | (none)        | Yes if you use `oauth2` auth type | 0.5.0         |
-| `fs.gravitino.fileset.cache.maxCapacity`              | The cache capacity of the Gravitino Virtual File System.                                                                                                                                          | `20`          | No                                | 0.5.0         |
-| `fs.gravitino.fileset.cache.evictionMillsAfterAccess` | The value of time that the cache expires after accessing in the Gravitino Virtual File System. The value is in `milliseconds`.                                                            | `300000`      | No                                | 0.5.0         |
+| Configuration item                                    | Description                                                                                                                                                                                             | Default value | Required                            | Since version |
+|-------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|-------------------------------------|---------------|
+| `fs.AbstractFileSystem.gvfs.impl`                     | The Gravitino Virtual File System abstract class, set it to `com.datastrato.gravitino.filesystem.hadoop.Gvfs`.                                                                                          | (none)        | Yes                                 | 0.5.0         |
+| `fs.gvfs.impl`                                        | The Gravitino Virtual File System implementation class, set it to `com.datastrato.gravitino.filesystem.hadoop.GravitinoVirtualFileSystem`.                                                              | (none)        | Yes                                 | 0.5.0         |
+| `fs.gvfs.impl.disable.cache`                          | Disable the Gravitino Virtual File System cache in the Hadoop environment. If you need to proxy multi-user operations, please set this value to `true` and create a separate File System for each user. | `false`       | No                                  | 0.5.0         |
+| `fs.gravitino.server.uri`                             | The Gravitino server URI which GVFS needs to load the fileset metadata.                                                                                                                                 | (none)        | Yes                                 | 0.5.0         |
+| `fs.gravitino.client.metalake`                        | The metalake to which the fileset belongs.                                                                                                                                                              | (none)        | Yes                                 | 0.5.0         |
+| `fs.gravitino.client.authType`                        | The auth type to initialize the Gravitino client to use with the Gravitino Virtual File System. Currently only supports `simple`, `oauth2` and `kerberos` auth types.                                   | `simple`      | No                                  | 0.5.0         |
+| `fs.gravitino.client.oauth2.serverUri`                | The auth server URI for the Gravitino client when using `oauth2` auth type with the Gravitino Virtual File System.                                                                                      | (none)        | Yes if you use `oauth2` auth type   | 0.5.0         |
+| `fs.gravitino.client.oauth2.credential`               | The auth credential for the Gravitino client when using `oauth2` auth type in the Gravitino Virtual File System.                                                                                        | (none)        | Yes if you use `oauth2` auth type   | 0.5.0         |
+| `fs.gravitino.client.oauth2.path`                     | The auth server path for the Gravitino client when using `oauth2` auth type with the Gravitino Virtual File System. Please remove the first slash `/` from the path, for example `oauth/token`.         | (none)        | Yes if you use `oauth2` auth type   | 0.5.0         |
+| `fs.gravitino.client.oauth2.scope`                    | The auth scope for the Gravitino client when using `oauth2` auth type with the Gravitino Virtual File System.                                                                                           | (none)        | Yes if you use `oauth2` auth type   | 0.5.0         |
+| `fs.gravitino.client.kerberos.principal`              | The auth principal for the Gravitino client when using `kerberos` auth type with the Gravitino Virtual File System.                                                                                     | (none)        | Yes if you use `kerberos` auth type | 0.5.1         |
+| `fs.gravitino.client.kerberos.keytabFilePath`         | The auth keytab file path for the Gravitino client when using `kerberos` auth type in the Gravitino Virtual File System.                                                                                | (none)        | No                                  | 0.5.1         |
+| `fs.gravitino.fileset.cache.maxCapacity`              | The cache capacity of the Gravitino Virtual File System.                                                                                                                                                | `20`          | No                                  | 0.5.0         |
+| `fs.gravitino.fileset.cache.evictionMillsAfterAccess` | The value of time that the cache expires after accessing in the Gravitino Virtual File System. The value is in `milliseconds`.                                                                          | `300000`      | No                                  | 0.5.0         |
 
 You can configure these properties in two ways:
 
@@ -280,6 +282,29 @@ conf.set("fs.gravitino.client.oauth2.serverUri", "${your_oauth_server_uri}");
 conf.set("fs.gravitino.client.oauth2.credential", "${your_client_credential}");
 conf.set("fs.gravitino.client.oauth2.path", "${your_oauth_server_path}");
 conf.set("fs.gravitino.client.oauth2.scope", "${your_client_scope}");
+Path filesetPath = new Path("gvfs://fileset/test_catalog/test_schema/test_fileset_1");
+FileSystem fs = filesetPath.getFileSystem(conf);
+```
+
+#### Using `Kerberos` authentication
+
+If you want to use `kerberos` authentication for the Gravitino client in the Gravitino Virtual File System,
+please refer to this document to complete the configuration of the Gravitino server: [Security](./security.md).
+
+Then, you can configure the Hadoop configuration like this:
+
+```java
+Configuration conf = new Configuration();
+conf.set("fs.AbstractFileSystem.gvfs.impl","com.datastrato.gravitino.filesystem.hadoop.Gvfs");
+conf.set("fs.gvfs.impl","com.datastrato.gravitino.filesystem.hadoop.GravitinoVirtualFileSystem");
+conf.set("fs.gravitino.server.uri","http://localhost:8090");
+conf.set("fs.gravitino.client.metalake","test_metalake");
+// Configure the auth type to kerberos.
+conf.set("fs.gravitino.client.authType", "kerberos");
+// Configure the Kerberos configuration.
+conf.set("fs.gravitino.client.kerberos.principal", "${your_kerberos_principal}");
+// Optional. You don't need to set the keytab if you use kerberos ticket cache.
+conf.set("fs.gravitino.client.kerberos.keytabFilePath", "${your_kerberos_keytab}");
 Path filesetPath = new Path("gvfs://fileset/test_catalog/test_schema/test_fileset_1");
 FileSystem fs = filesetPath.getFileSystem(conf);
 ```


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support using Kerberos authentication type to initialize Gravitino client in gvfs.

### Why are the changes needed?

Fix: #2711 

### How was this patch tested?

Add some uts for: 
1. use principal and keytab to auth.
2. kerberos configs for gvfs.
3. some invalid kerberos case.

Test locally and use `kerberos ticket cache` to initialize gvfs. The steps are as follows: 
1. Deploy the KDC server locally, refer to the doc: https://blog.csdn.net/lo085213/article/details/105057186.
2. Register the service account `HTTP/localhost@HADOOP.COM` and client account `client@HADOOP.COM` in the KDC server.
3. Execute the `kinit -kt client.keytab client@HADOOP.COM` command locally.
4. Use the `klist` command to check the environment for tickets containing `client@HADOOP.COM`.
5. Write a unit test to load metalake through gvfs with the kerberos ticket cache.
![image](https://github.com/datastrato/gravitino/assets/26177232/f655e687-8412-4000-bb07-bd9ccadd8387)
![image](https://github.com/datastrato/gravitino/assets/26177232/a3d36646-37ad-44b9-8cca-129a18196663)
![image](https://github.com/datastrato/gravitino/assets/26177232/df7504a2-046d-45fa-9da3-7b681ebfd7e1)