### PR TITLE
[#2266] fix(partition): enable preassign partition when creating range and list partitioning table

### DIFF
--- a/api/src/main/java/com/datastrato/gravitino/rel/expressions/transforms/Transform.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/expressions/transforms/Transform.java
@@ -20,9 +20,12 @@
 
 package com.datastrato.gravitino.rel.expressions.transforms;
 
+import static com.datastrato.gravitino.rel.partitions.Partitions.EMPTY_PARTITIONS;
+
 import com.datastrato.gravitino.annotation.Evolving;
 import com.datastrato.gravitino.rel.expressions.Expression;
 import com.datastrato.gravitino.rel.expressions.NamedReference;
+import com.datastrato.gravitino.rel.partitions.Partition;
 import java.util.Objects;
 
 /**
@@ -40,11 +43,12 @@ public interface Transform extends Expression {
   Expression[] arguments();
 
   /**
-   * @return The preassigned partitions in the partitioning. Currently, only ListTransform and
-   *     RangeTransform need to deal with assignments
+   * @return The preassigned partitions in the partitioning. Currently, only {@link
+   *     Transforms.ListTransform} and {@link Transforms.RangeTransform} need to deal with
+   *     assignments
    */
-  default Expression[] assignments() {
-    return Expression.EMPTY_EXPRESSION;
+  default Partition[] assignments() {
+    return EMPTY_PARTITIONS;
   }
 
   @Override

--- a/api/src/main/java/com/datastrato/gravitino/rel/partitions/Partitions.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/partitions/Partitions.java
@@ -12,6 +12,9 @@ import java.util.Objects;
 /** The helper class for partition expressions. */
 public class Partitions {
 
+  /** An empty array of partitions. */
+  public static Partition[] EMPTY_PARTITIONS = new Partition[0];
+
   /**
    * Creates a range partition.
    *

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/ListPartitioningDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/ListPartitioningDTO.java
@@ -7,6 +7,7 @@ package com.datastrato.gravitino.dto.rel.partitioning;
 import static com.datastrato.gravitino.dto.rel.PartitionUtils.validateFieldExistence;
 
 import com.datastrato.gravitino.dto.rel.ColumnDTO;
+import com.datastrato.gravitino.dto.rel.partitions.ListPartitionDTO;
 import com.datastrato.gravitino.rel.expressions.Expression;
 import com.datastrato.gravitino.rel.expressions.NamedReference;
 import java.util.Arrays;
@@ -17,24 +18,42 @@ import lombok.EqualsAndHashCode;
 public final class ListPartitioningDTO implements Partitioning {
 
   /**
-   * Creates a new ListPartitioningDTO.
+   * Creates a new ListPartitioningDTO with no pre-assigned partitions.
    *
    * @param fieldNames The names of the fields to partition.
    * @return The new ListPartitioningDTO.
    */
   public static ListPartitioningDTO of(String[][] fieldNames) {
-    return new ListPartitioningDTO(fieldNames);
+    return of(fieldNames, new ListPartitionDTO[0]);
+  }
+
+  /**
+   * Creates a new ListPartitioningDTO.
+   *
+   * @param fieldNames The names of the fields to partition.
+   * @param assignments The pre-assigned list partitions.
+   * @return The new ListPartitioningDTO.
+   */
+  public static ListPartitioningDTO of(String[][] fieldNames, ListPartitionDTO[] assignments) {
+    return new ListPartitioningDTO(fieldNames, assignments);
   }
 
   private final String[][] fieldNames;
+  private final ListPartitionDTO[] assignments;
 
-  private ListPartitioningDTO(String[][] fieldNames) {
+  private ListPartitioningDTO(String[][] fieldNames, ListPartitionDTO[] assignments) {
     this.fieldNames = fieldNames;
+    this.assignments = assignments;
   }
 
   /** @return The names of the fields to partition. */
   public String[][] fieldNames() {
     return fieldNames;
+  }
+
+  @Override
+  public ListPartitionDTO[] assignments() {
+    return assignments;
   }
 
   /** @return The strategy of the partitioning. */
@@ -64,35 +83,5 @@ public final class ListPartitioningDTO implements Partitioning {
   @Override
   public Expression[] arguments() {
     return Arrays.stream(fieldNames).map(NamedReference::field).toArray(Expression[]::new);
-  }
-
-  /** The builder for ListPartitioningDTO. */
-  public static class Builder {
-    private String[][] fieldNames;
-
-    /**
-     * Set the field names for the builder.
-     *
-     * @param fieldNames The names of the fields to partition.
-     * @return The builder.
-     */
-    public Builder withFieldNames(String[][] fieldNames) {
-      this.fieldNames = fieldNames;
-      return this;
-    }
-
-    /**
-     * Builds the ListPartitioningDTO.
-     *
-     * @return The ListPartitioningDTO.
-     */
-    public ListPartitioningDTO build() {
-      return new ListPartitioningDTO(fieldNames);
-    }
-  }
-
-  /** @return the builder for creating a new instance of ListPartitioningDTO. */
-  public static Builder builder() {
-    return new Builder();
   }
 }

--- a/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/RangePartitioningDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/rel/partitioning/RangePartitioningDTO.java
@@ -8,6 +8,7 @@ import static com.datastrato.gravitino.dto.rel.PartitionUtils.validateFieldExist
 import static com.datastrato.gravitino.rel.expressions.NamedReference.field;
 
 import com.datastrato.gravitino.dto.rel.ColumnDTO;
+import com.datastrato.gravitino.dto.rel.partitions.RangePartitionDTO;
 import com.datastrato.gravitino.rel.expressions.Expression;
 import lombok.EqualsAndHashCode;
 
@@ -16,19 +17,32 @@ import lombok.EqualsAndHashCode;
 public final class RangePartitioningDTO implements Partitioning {
 
   /**
-   * Creates a new RangePartitioningDTO.
+   * Creates a new RangePartitioningDTO with no pre-assigned partitions.
    *
    * @param fieldName The name of the field to partition.
    * @return The new RangePartitioningDTO.
    */
   public static RangePartitioningDTO of(String[] fieldName) {
-    return new RangePartitioningDTO(fieldName);
+    return of(fieldName, new RangePartitionDTO[0]);
+  }
+
+  /**
+   * Creates a new RangePartitioningDTO.
+   *
+   * @param fieldName The name of the field to partition.
+   * @param assignments The pre-assigned range partitions.
+   * @return The new RangePartitioningDTO.
+   */
+  public static RangePartitioningDTO of(String[] fieldName, RangePartitionDTO[] assignments) {
+    return new RangePartitioningDTO(fieldName, assignments);
   }
 
   private final String[] fieldName;
+  private final RangePartitionDTO[] assignments;
 
-  private RangePartitioningDTO(String[] fieldName) {
+  private RangePartitioningDTO(String[] fieldName, RangePartitionDTO[] assignments) {
     this.fieldName = fieldName;
+    this.assignments = assignments;
   }
 
   /** @return The name of the field to partition. */
@@ -40,6 +54,11 @@ public final class RangePartitioningDTO implements Partitioning {
   @Override
   public String name() {
     return strategy().name().toLowerCase();
+  }
+
+  @Override
+  public RangePartitionDTO[] assignments() {
+    return assignments;
   }
 
   /** @return The arguments of the partitioning. */
@@ -63,35 +82,5 @@ public final class RangePartitioningDTO implements Partitioning {
   @Override
   public void validate(ColumnDTO[] columns) throws IllegalArgumentException {
     validateFieldExistence(columns, fieldName);
-  }
-
-  /** The builder for the RangePartitioningDTO. */
-  public static class Builder {
-    private String[] fieldName;
-
-    /**
-     * Set the field name for the builder.
-     *
-     * @param fieldName The name of the field to partition.
-     * @return The builder.
-     */
-    public Builder withFieldName(String[] fieldName) {
-      this.fieldName = fieldName;
-      return this;
-    }
-
-    /**
-     * Builds the RangePartitioningDTO.
-     *
-     * @return The new RangePartitioningDTO.
-     */
-    public RangePartitioningDTO build() {
-      return new RangePartitioningDTO(fieldName);
-    }
-  }
-
-  /** @return the builder for creating a new instance of RangePartitioningDTO. */
-  public static Builder builder() {
-    return new Builder();
   }
 }

--- a/docs/open-api/partitioning.yaml
+++ b/docs/open-api/partitioning.yaml
@@ -144,6 +144,11 @@ components:
             - "list"
         fieldNames:
           $ref: "./tables.yaml#/components/schemas/FieldNames"
+        assignments:
+          type: array
+          description: The pre-assigned list partitions
+          items:
+            $ref: "./partitions.yaml#/components/schemas/ListPartition"
 
     RangePartitioning:
       type: object
@@ -157,6 +162,11 @@ components:
             - "range"
         fieldName:
           $ref: "./tables.yaml#/components/schemas/FieldName"
+        assignments:
+          type: array
+          description: The pre-assigned range partitions
+          items:
+            $ref: "./partitions.yaml#/components/schemas/RangePartition"
 
     FunctionPartitioning:
       type: object


### PR DESCRIPTION
### What changes were proposed in this pull request?

enable pre-assign partition when creating range and list partitioning table

### Why are the changes needed?

Fix: #2266 

### Does this PR introduce _any_ user-facing change?

yes, enable pre-assign partition when creating range and list partitioning table

### How was this patch tested?

tests modified
