### PR TITLE
[#3149] feat(catalog-lakehouse-iceberg): Support Iceberg RestCatalog in Gravitino

### DIFF
--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogBackend.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogBackend.java
@@ -7,5 +7,6 @@ package com.datastrato.gravitino.catalog.lakehouse.iceberg;
 public enum IcebergCatalogBackend {
   HIVE,
   JDBC,
-  MEMORY
+  MEMORY,
+  REST
 }

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/utils/IcebergCatalogUtil.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/utils/IcebergCatalogUtil.java
@@ -17,6 +17,7 @@ import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.inmemory.InMemoryCatalog;
 import org.apache.iceberg.jdbc.JdbcCatalog;
+import org.apache.iceberg.rest.RESTCatalog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,6 +67,15 @@ public class IcebergCatalogUtil {
     return jdbcCatalog;
   }
 
+  private static Catalog loadRestCatalog(Map<String, String> properties) {
+    RESTCatalog restCatalog = new RESTCatalog();
+    HdfsConfiguration hdfsConfiguration = new HdfsConfiguration();
+    properties.forEach(hdfsConfiguration::set);
+    restCatalog.setConf(hdfsConfiguration);
+    restCatalog.initialize("rest", properties);
+    return restCatalog;
+  }
+
   public static Catalog loadCatalogBackend(String catalogType) {
     return loadCatalogBackend(catalogType, Collections.emptyMap());
   }
@@ -79,6 +89,8 @@ public class IcebergCatalogUtil {
         return loadHiveCatalog(properties);
       case JDBC:
         return loadJdbcCatalog(properties);
+      case REST:
+        return loadRestCatalog(properties);
       default:
         throw new RuntimeException(
             catalogType

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergHiveIT.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergHiveIT.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.catalog.lakehouse.iceberg.integration.test;
+
+import com.datastrato.gravitino.integration.test.container.HiveContainer;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInstance;
+
+@Tag("gravitino-docker-it")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class CatalogIcebergHiveIT extends CatalogIcebergBaseIT {
+
+  @Override
+  protected void initIcebergCatalogProperties() {
+    URIS =
+        String.format(
+            "thrift://%s:%d",
+            containerSuite.getHiveContainer().getContainerIpAddress(),
+            HiveContainer.HIVE_METASTORE_PORT);
+    TYPE = "hive";
+    WAREHOUSE =
+        String.format(
+            "hdfs://%s:%d/user/hive/warehouse-catalog-iceberg/",
+            containerSuite.getHiveContainer().getContainerIpAddress(),
+            HiveContainer.HDFS_DEFAULTFS_PORT);
+  }
+}

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergRestIT.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergRestIT.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.catalog.lakehouse.iceberg.integration.test;
+
+import com.datastrato.gravitino.auxiliary.AuxiliaryServiceManager;
+import com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergConfig;
+import com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergRESTService;
+import com.datastrato.gravitino.integration.test.container.HiveContainer;
+import com.datastrato.gravitino.server.web.JettyServerConfig;
+import com.datastrato.gravitino.utils.MapUtils;
+import java.util.Map;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInstance;
+
+@Tag("gravitino-docker-it")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class CatalogIcebergRestIT extends CatalogIcebergBaseIT {
+
+  @Override
+  protected void initIcebergCatalogProperties() {
+    Map<String, String> map =
+        serverConfig.getConfigsWithPrefix(AuxiliaryServiceManager.GRAVITINO_AUX_SERVICE_PREFIX);
+    map = MapUtils.getPrefixMap(map, IcebergRESTService.SERVICE_NAME + ".");
+    IcebergConfig icebergConfig = new IcebergConfig(map);
+    String host = icebergConfig.get(JettyServerConfig.WEBSERVER_HOST);
+    int port = icebergConfig.get(JettyServerConfig.WEBSERVER_HTTP_PORT);
+    URIS = String.format("http://%s:%d/iceberg/", host, port);
+    TYPE = "rest";
+    WAREHOUSE =
+        String.format(
+            "hdfs://%s:%d/user/hive/warehouse-catalog-iceberg/",
+            containerSuite.getHiveContainer().getContainerIpAddress(),
+            HiveContainer.HDFS_DEFAULTFS_PORT);
+  }
+}

--- a/docs/lakehouse-iceberg-catalog.md
+++ b/docs/lakehouse-iceberg-catalog.md
@@ -27,17 +27,17 @@ Builds with Hadoop 2.10.x, there may be compatibility issues when accessing Hado
 
 ### Catalog capabilities
 
-- Works as a catalog proxy, supporting `HiveCatalog` and `JdbcCatalog`.
+- Works as a catalog proxy, supporting `HiveCatalog`, `JdbcCatalog` and `RESTCatalog`.
 - Supports DDL operations for Iceberg schemas and tables.
 - Doesn't support snapshot or table management operations.
 
 ### Catalog properties
 
-| Property name     | Description                                                                                                                                                          | Default value | Required | Since Version |
-|-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|----------|---------------|
-| `catalog-backend` | Catalog backend of Gravitino Iceberg catalog. Supports `hive` or `jdbc`.                                                                                             | (none)        | Yes      | 0.2.0         |
-| `uri`             | The URI configuration of the Iceberg catalog. `thrift://127.0.0.1:9083` or `jdbc:postgresql://127.0.0.1:5432/db_name` or `jdbc:mysql://127.0.0.1:3306/metastore_db`. | (none)        | Yes      | 0.2.0         |
-| `warehouse`       | Warehouse directory of catalog. `file:///user/hive/warehouse-hive/` for local fs or `hdfs://namespace/hdfs/path` for HDFS.                                           | (none)        | Yes      | 0.2.0         |
+| Property name     | Description                                                                                                                                                                                     | Default value | Required | Since Version |
+|-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|----------|---------------|
+| `catalog-backend` | Catalog backend of Gravitino Iceberg catalog. Supports `hive` or `jdbc` or `rest`.                                                                                                              | (none)        | Yes      | 0.2.0         |
+| `uri`             | The URI configuration of the Iceberg catalog. `thrift://127.0.0.1:9083` or `jdbc:postgresql://127.0.0.1:5432/db_name` or `jdbc:mysql://127.0.0.1:3306/metastore_db` or `http://127.0.0.1:9001`. | (none)        | Yes      | 0.2.0         |
+| `warehouse`       | Warehouse directory of catalog. `file:///user/hive/warehouse-hive/` for local fs or `hdfs://namespace/hdfs/path` for HDFS.                                                                      | (none)        | Yes      | 0.2.0         |
 
 Any properties not defined by Gravitino with `gravitino.bypass.` prefix will pass to Iceberg catalog properties and HDFS configuration. For example, if specify `gravitino.bypass.list-all-tables`, `list-all-tables` will pass to Iceberg catalog properties.
 


### PR DESCRIPTION
### What changes were proposed in this pull request? 
Add Iceberg `RestCatalog` backend in Gravitino

### Why are the changes needed?
As discussed in https://github.com/datastrato/gravitino/issues/2716, we should support Iceberg `RESTCatalog` in Gravitino, and after supporting this, we can use `RESTCatalog` in spark-connector.

Fix: https://github.com/datastrato/gravitino/issues/3149

### Does this PR introduce _any_ user-facing change? 
No

### How was this patch tested?
New UTs and ITs.
And tested locally.
