### PR TITLE
[#2543] feat(spark-connector): support row-level operations to iceberg Table

### DIFF
--- a/docs/spark-connector/spark-catalog-iceberg.md
+++ b/docs/spark-connector/spark-catalog-iceberg.md
@@ -8,7 +8,7 @@ This software is licensed under the Apache License version 2."
 
 ## Capabilities
 
-#### Support basic DML and DDL operations:
+#### Support DML and DDL operations:
 
 - `CREATE TABLE` 
  
@@ -18,13 +18,12 @@ Supports basic create table clause including table schema, properties, partition
 - `ALTER TABLE`
 - `INSERT INTO&OVERWRITE`
 - `SELECT`
-- `DELETE` 
- 
-Supports file delete only.
+- `MERGE INOT`
+- `DELETE FROM`
+- `UPDATE`
 
 #### Not supported operations:
 
-- Row level operations. like `MERGE INOT`, `DELETE FROM`, `UPDATE`
 - View operations.
 - Branching and tagging operations.
 - Spark procedures.
@@ -57,6 +56,22 @@ VALUES
 (3, 'Charlie', 'Sales', TIMESTAMP '2021-03-01 08:45:00');
 
 SELECT * FROM employee WHERE date(hire_date) = '2021-01-01'
+
+UPDATE employee SET department = 'Jenny' WHERE id = 1;
+
+DELETE FROM employee WHERE id < 2;
+
+MERGE INTO employee
+USING (SELECT 4 as id, 'David' as name, 'Engineering' as department, TIMESTAMP '2021-04-01 09:00:00' as hire_date) as new_employee
+ON employee.id = new_employee.id
+WHEN MATCHED THEN UPDATE SET *
+WHEN NOT MATCHED THEN INSERT *;
+
+MERGE INTO employee
+USING (SELECT 4 as id, 'David' as name, 'Engineering' as department, TIMESTAMP '2021-04-01 09:00:00' as hire_date) as new_employee
+ON employee.id = new_employee.id
+WHEN MATCHED THEN DELETE
+WHEN NOT MATCHED THEN INSERT *;
 ```
 
 ## Catalog properties

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -13,6 +13,8 @@ plugins {
 
 val scalaVersion: String = project.properties["scalaVersion"] as? String ?: extra["defaultScalaVersion"].toString()
 val sparkVersion: String = libs.versions.spark.get()
+val sparkMajorVersion: String = sparkVersion.substringBeforeLast(".")
+val kyuubiVersion: String = libs.versions.kyuubi.get()
 val icebergVersion: String = libs.versions.iceberg.get()
 val scalaCollectionCompatVersion: String = libs.versions.scala.collection.compat.get()
 
@@ -114,6 +116,8 @@ dependencies {
     exclude("io.dropwizard.metrics")
     exclude("org.rocksdb")
   }
+  testImplementation("org.apache.iceberg:iceberg-spark-runtime-${sparkMajorVersion}_$scalaVersion:$icebergVersion")
+  testImplementation("org.apache.kyuubi:kyuubi-spark-connector-hive_$scalaVersion:$kyuubiVersion")
 
   testImplementation(libs.okhttp3.loginterceptor)
   testImplementation(libs.postgresql.driver)

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/hive/SparkHiveCatalogIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/spark/hive/SparkHiveCatalogIT.java
@@ -57,6 +57,11 @@ public class SparkHiveCatalogIT extends SparkCommonIT {
     return true;
   }
 
+  @Override
+  protected boolean supportsDelete() {
+    return false;
+  }
+
   @Test
   void testCreateHiveFormatPartitionTable() {
     String tableName = "hive_partition_table";

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/spark/SparkTableInfo.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/spark/SparkTableInfo.java
@@ -6,7 +6,8 @@
 package com.datastrato.gravitino.integration.test.util.spark;
 
 import com.datastrato.gravitino.spark.connector.ConnectorConstants;
-import com.datastrato.gravitino.spark.connector.table.SparkBaseTable;
+import com.datastrato.gravitino.spark.connector.hive.SparkHiveTable;
+import com.datastrato.gravitino.spark.connector.iceberg.SparkIcebergTable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -18,6 +19,7 @@ import javax.ws.rs.NotSupportedException;
 import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.spark.sql.connector.catalog.SupportsMetadataColumns;
+import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.expressions.ApplyTransform;
 import org.apache.spark.sql.connector.expressions.BucketTransform;
@@ -29,6 +31,7 @@ import org.apache.spark.sql.connector.expressions.SortedBucketTransform;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.connector.expressions.YearsTransform;
 import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Assertions;
 
 /** SparkTableInfo is used to check the result in test. */
@@ -89,7 +92,7 @@ public class SparkTableInfo {
     }
   }
 
-  static SparkTableInfo create(SparkBaseTable baseTable) {
+  static SparkTableInfo create(Table baseTable) {
     SparkTableInfo sparkTableInfo = new SparkTableInfo();
     String identifier = baseTable.name();
     String[] items = identifier.split("\\.");
@@ -98,7 +101,9 @@ public class SparkTableInfo {
     sparkTableInfo.tableName = items[1];
     sparkTableInfo.database = items[0];
     sparkTableInfo.columns =
-        Arrays.stream(baseTable.schema().fields())
+        // using `baseTable.schema()` directly will failed because the method named `schema` is
+        // Deprecated in Spark Table interface
+        Arrays.stream(getSchema(baseTable).fields())
             .map(
                 sparkField ->
                     new SparkColumnInfo(
@@ -109,14 +114,12 @@ public class SparkTableInfo {
             .collect(Collectors.toList());
     sparkTableInfo.comment = baseTable.properties().remove(ConnectorConstants.COMMENT);
     sparkTableInfo.tableProperties = baseTable.properties();
-    boolean supportsBucketPartition =
-        baseTable.getSparkTransformConverter().isSupportsBucketPartition();
     Arrays.stream(baseTable.partitioning())
         .forEach(
             transform -> {
               if (transform instanceof BucketTransform
                   || transform instanceof SortedBucketTransform) {
-                if (isBucketPartition(supportsBucketPartition, transform)) {
+                if (isBucketPartition(baseTable, transform)) {
                   sparkTableInfo.addPartition(transform);
                 } else {
                   sparkTableInfo.setBucket(transform);
@@ -149,10 +152,6 @@ public class SparkTableInfo {
     return sparkTableInfo;
   }
 
-  private static boolean isBucketPartition(boolean supportsBucketPartition, Transform transform) {
-    return supportsBucketPartition && !(transform instanceof SortedBucketTransform);
-  }
-
   public List<SparkColumnInfo> getUnPartitionedColumns() {
     return columns.stream()
         .filter(column -> !partitionColumnNames.contains(column.name))
@@ -163,6 +162,21 @@ public class SparkTableInfo {
     return columns.stream()
         .filter(column -> partitionColumnNames.contains(column.name))
         .collect(Collectors.toList());
+  }
+
+  private static boolean isBucketPartition(Table baseTable, Transform transform) {
+    return baseTable instanceof SparkIcebergTable && !(transform instanceof SortedBucketTransform);
+  }
+
+  private static StructType getSchema(Table baseTable) {
+    if (baseTable instanceof SparkHiveTable) {
+      return ((SparkHiveTable) baseTable).schema();
+    } else if (baseTable instanceof SparkIcebergTable) {
+      return ((SparkIcebergTable) baseTable).schema();
+    } else {
+      throw new IllegalArgumentException(
+          "Doesn't support Spark table: " + baseTable.getClass().getName());
+    }
   }
 
   @Data

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/spark/SparkUtilIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/util/spark/SparkUtilIT.java
@@ -20,7 +20,6 @@
 package com.datastrato.gravitino.integration.test.util.spark;
 
 import com.datastrato.gravitino.integration.test.util.AbstractIT;
-import com.datastrato.gravitino.spark.connector.table.SparkBaseTable;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
@@ -130,8 +129,7 @@ public abstract class SparkUtilIT extends AbstractIT {
     CommandResult result = (CommandResult) ds.logicalPlan();
     DescribeRelation relation = (DescribeRelation) result.commandLogicalPlan();
     ResolvedTable table = (ResolvedTable) relation.child();
-    SparkBaseTable baseTable = (SparkBaseTable) table.table();
-    return SparkTableInfo.create(baseTable);
+    return SparkTableInfo.create(table.table());
   }
 
   protected void dropTableIfExists(String tableName) {
@@ -157,6 +155,10 @@ public abstract class SparkUtilIT extends AbstractIT {
 
   protected void insertTableAsSelect(String tableName, String newName) {
     sql(String.format("INSERT INTO TABLE %s SELECT * FROM %s", newName, tableName));
+  }
+
+  protected static String getSelectAllSqlWithOrder(String tableName, String orderByColumn) {
+    return String.format("SELECT * FROM %s ORDER BY %s", tableName, orderByColumn);
   }
 
   private static String getSelectAllSql(String tableName) {

--- a/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/ConnectorConstants.java
+++ b/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/ConnectorConstants.java
@@ -14,6 +14,7 @@ public class ConnectorConstants {
   public static final String LOCATION = "location";
 
   public static final String DOT = ".";
+  public static final String COMMA = ",";
 
   private ConnectorConstants() {}
 }

--- a/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/SparkTransformConverter.java
+++ b/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/SparkTransformConverter.java
@@ -13,7 +13,6 @@ import com.datastrato.gravitino.rel.expressions.sorts.SortOrder;
 import com.datastrato.gravitino.rel.expressions.sorts.SortOrders;
 import com.datastrato.gravitino.rel.expressions.transforms.Transform;
 import com.datastrato.gravitino.rel.expressions.transforms.Transforms;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -57,11 +56,6 @@ public class SparkTransformConverter {
 
   public SparkTransformConverter(boolean supportsBucketPartition) {
     this.supportsBucketPartition = supportsBucketPartition;
-  }
-
-  @VisibleForTesting
-  public boolean isSupportsBucketPartition() {
-    return supportsBucketPartition;
   }
 
   @Getter

--- a/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/hive/GravitinoHiveCatalog.java
+++ b/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/hive/GravitinoHiveCatalog.java
@@ -9,9 +9,10 @@ import com.datastrato.gravitino.rel.Table;
 import com.datastrato.gravitino.spark.connector.PropertiesConverter;
 import com.datastrato.gravitino.spark.connector.SparkTransformConverter;
 import com.datastrato.gravitino.spark.connector.catalog.BaseCatalog;
-import com.datastrato.gravitino.spark.connector.table.SparkBaseTable;
 import java.util.Map;
+import org.apache.kyuubi.spark.connector.hive.HiveTable;
 import org.apache.kyuubi.spark.connector.hive.HiveTableCatalog;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
@@ -30,14 +31,29 @@ public class GravitinoHiveCatalog extends BaseCatalog {
   }
 
   @Override
-  protected SparkBaseTable createSparkTable(
+  protected org.apache.spark.sql.connector.catalog.Table createSparkTable(
       Identifier identifier,
       Table gravitinoTable,
-      TableCatalog sparkCatalog,
+      TableCatalog sparkHiveCatalog,
       PropertiesConverter propertiesConverter,
       SparkTransformConverter sparkTransformConverter) {
+    org.apache.spark.sql.connector.catalog.Table sparkTable;
+    try {
+      sparkTable = sparkHiveCatalog.loadTable(identifier);
+    } catch (NoSuchTableException e) {
+      throw new RuntimeException(
+          String.format(
+              "Failed to load the real sparkTable: %s",
+              String.join(".", getDatabase(identifier), identifier.name())),
+          e);
+    }
     return new SparkHiveTable(
-        identifier, gravitinoTable, sparkCatalog, propertiesConverter, sparkTransformConverter);
+        identifier,
+        gravitinoTable,
+        (HiveTable) sparkTable,
+        (HiveTableCatalog) sparkHiveCatalog,
+        propertiesConverter,
+        sparkTransformConverter);
   }
 
   @Override

--- a/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/hive/SparkHiveTable.java
+++ b/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/hive/SparkHiveTable.java
@@ -8,23 +8,51 @@ package com.datastrato.gravitino.spark.connector.hive;
 import com.datastrato.gravitino.rel.Table;
 import com.datastrato.gravitino.spark.connector.PropertiesConverter;
 import com.datastrato.gravitino.spark.connector.SparkTransformConverter;
-import com.datastrato.gravitino.spark.connector.table.SparkBaseTable;
+import com.datastrato.gravitino.spark.connector.utils.GravitinoTableInfoHelper;
+import java.util.Map;
+import org.apache.kyuubi.spark.connector.hive.HiveTable;
+import org.apache.kyuubi.spark.connector.hive.HiveTableCatalog;
+import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.types.StructType;
 
-/** May support more capabilities like partition management. */
-public class SparkHiveTable extends SparkBaseTable {
+/** Keep consistent behavior with the SparkIcebergTable */
+public class SparkHiveTable extends HiveTable {
+
+  private GravitinoTableInfoHelper gravitinoTableInfoHelper;
+
   public SparkHiveTable(
       Identifier identifier,
       Table gravitinoTable,
-      TableCatalog sparkCatalog,
+      HiveTable hiveTable,
+      HiveTableCatalog hiveTableCatalog,
       PropertiesConverter propertiesConverter,
       SparkTransformConverter sparkTransformConverter) {
-    super(identifier, gravitinoTable, sparkCatalog, propertiesConverter, sparkTransformConverter);
+    super(SparkSession.active(), hiveTable.catalogTable(), hiveTableCatalog);
+    this.gravitinoTableInfoHelper =
+        new GravitinoTableInfoHelper(
+            false, identifier, gravitinoTable, propertiesConverter, sparkTransformConverter);
   }
 
   @Override
-  protected boolean isCaseSensitive() {
-    return false;
+  public String name() {
+    return gravitinoTableInfoHelper.name();
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
+  public StructType schema() {
+    return gravitinoTableInfoHelper.schema();
+  }
+
+  @Override
+  public Map<String, String> properties() {
+    return gravitinoTableInfoHelper.properties();
+  }
+
+  @Override
+  public Transform[] partitioning() {
+    return gravitinoTableInfoHelper.partitioning();
   }
 }

--- a/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/plugin/GravitinoDriverPlugin.java
+++ b/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/plugin/GravitinoDriverPlugin.java
@@ -5,6 +5,9 @@
 
 package com.datastrato.gravitino.spark.connector.plugin;
 
+import static com.datastrato.gravitino.spark.connector.ConnectorConstants.COMMA;
+import static com.datastrato.gravitino.spark.connector.utils.ConnectorUtil.removeDuplicateSparkExtensions;
+
 import com.datastrato.gravitino.Catalog;
 import com.datastrato.gravitino.spark.connector.GravitinoSparkConfig;
 import com.datastrato.gravitino.spark.connector.catalog.GravitinoCatalogManager;
@@ -15,10 +18,12 @@ import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
 import org.apache.spark.api.plugin.DriverPlugin;
 import org.apache.spark.api.plugin.PluginContext;
+import org.apache.spark.sql.internal.StaticSQLConf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,6 +35,8 @@ public class GravitinoDriverPlugin implements DriverPlugin {
   private static final Logger LOG = LoggerFactory.getLogger(GravitinoDriverPlugin.class);
 
   private GravitinoCatalogManager catalogManager;
+  private static final String[] GRAVITINO_DRIVER_EXTENSIONS =
+      new String[] {IcebergSparkSessionExtensions.class.getName()};
 
   @Override
   public Map<String, String> init(SparkContext sc, PluginContext pluginContext) {
@@ -48,7 +55,7 @@ public class GravitinoDriverPlugin implements DriverPlugin {
     catalogManager = GravitinoCatalogManager.create(gravitinoUri, metalake);
     catalogManager.loadRelationalCatalogs();
     registerGravitinoCatalogs(conf, catalogManager.getCatalogs());
-    registerSqlExtensions();
+    registerSqlExtensions(conf);
     return Collections.emptyMap();
   }
 
@@ -103,6 +110,20 @@ public class GravitinoDriverPlugin implements DriverPlugin {
     LOG.info("Register {} catalog to Spark catalog manager.", catalogName);
   }
 
-  // Todo inject Iceberg extensions
-  private void registerSqlExtensions() {}
+  private void registerSqlExtensions(SparkConf conf) {
+    String gravitinoDriverExtensions = String.join(COMMA, GRAVITINO_DRIVER_EXTENSIONS);
+    if (conf.contains(StaticSQLConf.SPARK_SESSION_EXTENSIONS().key())) {
+      String sparkSessionExtensions = conf.get(StaticSQLConf.SPARK_SESSION_EXTENSIONS().key());
+      if (StringUtils.isNotBlank(sparkSessionExtensions)) {
+        conf.set(
+            StaticSQLConf.SPARK_SESSION_EXTENSIONS().key(),
+            removeDuplicateSparkExtensions(
+                GRAVITINO_DRIVER_EXTENSIONS, sparkSessionExtensions.split(COMMA)));
+      } else {
+        conf.set(StaticSQLConf.SPARK_SESSION_EXTENSIONS().key(), gravitinoDriverExtensions);
+      }
+    } else {
+      conf.set(StaticSQLConf.SPARK_SESSION_EXTENSIONS().key(), gravitinoDriverExtensions);
+    }
+  }
 }

--- a/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/utils/ConnectorUtil.java
+++ b/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/utils/ConnectorUtil.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright 2024 Datastrato Pvt Ltd.
+ *  This software is licensed under the Apache License version 2.
+ */
+
+package com.datastrato.gravitino.spark.connector.utils;
+
+import static com.datastrato.gravitino.spark.connector.ConnectorConstants.COMMA;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
+
+public class ConnectorUtil {
+
+  public static String removeDuplicateSparkExtensions(
+      String[] extensions, String[] addedExtensions) {
+    Set<String> uniqueElements = new LinkedHashSet<>(Arrays.asList(extensions));
+    if (addedExtensions != null && StringUtils.isNoneBlank(addedExtensions)) {
+      uniqueElements.addAll(Arrays.asList(addedExtensions));
+    }
+    return uniqueElements.stream()
+        .reduce((element1, element2) -> element1 + COMMA + element2)
+        .orElse("");
+  }
+}

--- a/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/utils/GravitinoTableInfoHelper.java
+++ b/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/utils/GravitinoTableInfoHelper.java
@@ -3,7 +3,7 @@
  *  This software is licensed under the Apache License version 2.
  */
 
-package com.datastrato.gravitino.spark.connector.table;
+package com.datastrato.gravitino.spark.connector.utils;
 
 import com.datastrato.gravitino.rel.expressions.distributions.Distribution;
 import com.datastrato.gravitino.rel.expressions.sorts.SortOrder;
@@ -11,65 +11,49 @@ import com.datastrato.gravitino.spark.connector.ConnectorConstants;
 import com.datastrato.gravitino.spark.connector.PropertiesConverter;
 import com.datastrato.gravitino.spark.connector.SparkTransformConverter;
 import com.datastrato.gravitino.spark.connector.SparkTypeConverter;
-import com.google.common.annotations.VisibleForTesting;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.catalog.SupportsRead;
-import org.apache.spark.sql.connector.catalog.SupportsWrite;
-import org.apache.spark.sql.connector.catalog.Table;
-import org.apache.spark.sql.connector.catalog.TableCapability;
-import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.expressions.Transform;
-import org.apache.spark.sql.connector.read.ScanBuilder;
-import org.apache.spark.sql.connector.write.LogicalWriteInfo;
-import org.apache.spark.sql.connector.write.WriteBuilder;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.MetadataBuilder;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 /**
- * Provides schema info from Gravitino, IO from the internal spark table. The specific catalog table
- * could implement more capabilities like SupportsPartitionManagement for Hive table, SupportsIndex
- * for JDBC table, SupportsRowLevelOperations for Iceberg table.
+ * GravitinoTableInfoHelper is a common helper class that is used to retrieve table info from the
+ * Gravitino Server
  */
-public abstract class SparkBaseTable implements Table, SupportsRead, SupportsWrite {
+public class GravitinoTableInfoHelper {
+
+  private boolean isCaseSensitive;
   private Identifier identifier;
   private com.datastrato.gravitino.rel.Table gravitinoTable;
-  private TableCatalog sparkCatalog;
-  private Table lazySparkTable;
   private PropertiesConverter propertiesConverter;
   private SparkTransformConverter sparkTransformConverter;
 
-  public SparkBaseTable(
+  public GravitinoTableInfoHelper(
+      boolean isCaseSensitive,
       Identifier identifier,
       com.datastrato.gravitino.rel.Table gravitinoTable,
-      TableCatalog sparkCatalog,
       PropertiesConverter propertiesConverter,
       SparkTransformConverter sparkTransformConverter) {
+    this.isCaseSensitive = isCaseSensitive;
     this.identifier = identifier;
     this.gravitinoTable = gravitinoTable;
-    this.sparkCatalog = sparkCatalog;
     this.propertiesConverter = propertiesConverter;
     this.sparkTransformConverter = sparkTransformConverter;
   }
 
-  @Override
   public String name() {
     return getNormalizedIdentifier(identifier, gravitinoTable.name());
   }
 
-  @Override
-  @SuppressWarnings("deprecation")
   public StructType schema() {
     List<StructField> structs =
         Arrays.stream(gravitinoTable.columns())
@@ -93,7 +77,6 @@ public abstract class SparkBaseTable implements Table, SupportsRead, SupportsWri
     return DataTypes.createStructType(structs);
   }
 
-  @Override
   public Map<String, String> properties() {
     Map properties = new HashMap();
     if (gravitinoTable.properties() != null) {
@@ -110,22 +93,6 @@ public abstract class SparkBaseTable implements Table, SupportsRead, SupportsWri
     return properties;
   }
 
-  @Override
-  public Set<TableCapability> capabilities() {
-    return getSparkTable().capabilities();
-  }
-
-  @Override
-  public ScanBuilder newScanBuilder(CaseInsensitiveStringMap options) {
-    return ((SupportsRead) getSparkTable()).newScanBuilder(options);
-  }
-
-  @Override
-  public WriteBuilder newWriteBuilder(LogicalWriteInfo info) {
-    return ((SupportsWrite) getSparkTable()).newWriteBuilder(info);
-  }
-
-  @Override
   public Transform[] partitioning() {
     com.datastrato.gravitino.rel.expressions.transforms.Transform[] partitions =
         gravitinoTable.partitioning();
@@ -134,24 +101,8 @@ public abstract class SparkBaseTable implements Table, SupportsRead, SupportsWri
     return sparkTransformConverter.toSparkTransform(partitions, distribution, sortOrders);
   }
 
-  protected Table getSparkTable() {
-    if (lazySparkTable == null) {
-      try {
-        this.lazySparkTable = sparkCatalog.loadTable(identifier);
-      } catch (NoSuchTableException e) {
-        throw new RuntimeException(e);
-      }
-    }
-    return lazySparkTable;
-  }
-
-  @VisibleForTesting
   public SparkTransformConverter getSparkTransformConverter() {
     return sparkTransformConverter;
-  }
-
-  protected boolean isCaseSensitive() {
-    return true;
   }
 
   // The underlying catalogs may not case-sensitive, to keep consistent with the action of SparkSQL,
@@ -162,7 +113,7 @@ public abstract class SparkBaseTable implements Table, SupportsRead, SupportsWri
     }
 
     String databaseName = tableIdentifier.namespace()[0];
-    if (isCaseSensitive() == false) {
+    if (!isCaseSensitive) {
       databaseName = databaseName.toLowerCase(Locale.ROOT);
     }
 

--- a/spark-connector/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/utils/TestConnectorUtil.java
+++ b/spark-connector/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/utils/TestConnectorUtil.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright 2024 Datastrato Pvt Ltd.
+ *  This software is licensed under the Apache License version 2.
+ */
+
+package com.datastrato.gravitino.spark.connector.utils;
+
+import static com.datastrato.gravitino.spark.connector.ConnectorConstants.COMMA;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class TestConnectorUtil {
+
+  @Test
+  void testRemoveDuplicateSparkExtensions() {
+    String[] extensions = {"a", "b", "c"};
+    String addedExtensions = "a,d,e";
+    String result =
+        ConnectorUtil.removeDuplicateSparkExtensions(extensions, addedExtensions.split(COMMA));
+    Assertions.assertEquals(result, "a,b,c,d,e");
+
+    extensions = new String[] {"a", "a", "b", "c"};
+    addedExtensions = "";
+    result = ConnectorUtil.removeDuplicateSparkExtensions(extensions, addedExtensions.split(COMMA));
+    Assertions.assertEquals(result, "a,b,c");
+
+    extensions = new String[] {"a", "a", "b", "c"};
+    addedExtensions = "b";
+    result = ConnectorUtil.removeDuplicateSparkExtensions(extensions, addedExtensions.split(COMMA));
+    Assertions.assertEquals(result, "a,b,c");
+
+    extensions = new String[] {"a", "a", "b", "c"};
+    result = ConnectorUtil.removeDuplicateSparkExtensions(extensions, null);
+    Assertions.assertEquals(result, "a,b,c");
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

- refactor table implementation, make `SparkIcebergTable` extend Iceberg `SparkTable`, and `SparkHiveTable` extend Kyuubi `HiveTable`.

- support row-level operations to iceberg Table

```
1. update tableName set c1=v1, c2=v2, ...

2. merge into targetTable t
   using sourceTable s
   on s.key=t.key
   when matched then ...
   when not matched then ...

3. delete from table where xxx
```

### Why are the changes needed?

1. For spark-connector in Iceberg, it explicitly uses `SparkTable` to identify whether it is an Iceberg table, so the `SparkIcebergTable` must extend `SparkTable`.

2. support row-level operations to iceberg Table.

Fix: https://github.com/datastrato/gravitino/issues/2543

### Does this PR introduce any user-facing change? 
Yes, support update ... , merge into ..., delete from ...

### How was this patch tested?
New ITs.