### PR TITLE
[#3285] fix(web): disable the metalake select with only one

### DIFF
--- a/web/src/app/rootLayout/AppBar.js
+++ b/web/src/app/rootLayout/AppBar.js
@@ -90,6 +90,7 @@ const AppBar = () => {
                       data-refer='select-metalake'
                       value={metalake}
                       label='Metalake'
+                      disabled={store.metalakes.length === 1}
                       sx={{ width: '100%' }}
                     >
                       {metalakes.map(item => {


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
disable the metalake select with only one
<img width="505" alt="image" src="https://github.com/datastrato/gravitino/assets/9210625/f91df10f-3856-4947-a8cb-6e6cdbe004f3">

### Why are the changes needed?
With only one metalake UI presents user with a choice

Fix: #3285

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
manual
