### PR TITLE
[#3288] improve(web): rename the ASF providers to their correct names

### DIFF
--- a/web/src/lib/utils/initial.js
+++ b/web/src/lib/utils/initial.js
@@ -5,7 +5,7 @@
 
 export const filesetProviders = [
   {
-    label: 'hadoop',
+    label: 'Apache Hadoop',
     value: 'hadoop',
     defaultProps: [
       {
@@ -20,14 +20,14 @@ export const filesetProviders = [
 
 export const messagingProviders = [
   {
-    label: 'kafka',
+    label: 'Apache Kafka',
     value: 'kafka',
     defaultProps: [
       {
         key: 'bootstrap.servers',
         value: '',
         required: true,
-        description: 'The Kafka broker(s) to connect to, allowing for multiple brokers by comma-separating them'
+        description: 'The Apache Kafka broker(s) to connect to, allowing for multiple brokers by comma-separating them'
       }
     ]
   }
@@ -35,39 +35,39 @@ export const messagingProviders = [
 
 export const providers = [
   {
-    label: 'hive',
+    label: 'Apache Hive',
     value: 'hive',
     defaultProps: [
       {
         key: 'metastore.uris',
         value: '',
         required: true,
-        description: 'The Hive metastore URIs'
+        description: 'The Apache Hive metastore URIs'
       }
     ]
   },
   {
-    label: 'iceberg',
+    label: 'Apache Iceberg',
     value: 'lakehouse-iceberg',
     defaultProps: [
       {
         key: 'catalog-backend',
         value: 'hive',
         required: true,
-        description: 'Iceberg catalog type choose properties',
+        description: 'Apache Iceberg catalog type choose properties',
         select: ['hive', 'jdbc']
       },
       {
         key: 'uri',
         value: '',
         required: true,
-        description: 'Iceberg catalog uri config'
+        description: 'Apache Iceberg catalog uri config'
       },
       {
         key: 'warehouse',
         value: '',
         required: true,
-        description: 'Iceberg catalog warehouse config'
+        description: 'Apache Iceberg catalog warehouse config'
       },
       {
         key: 'jdbc-driver',
@@ -91,7 +91,7 @@ export const providers = [
     ]
   },
   {
-    label: 'mysql',
+    label: 'MySQL',
     value: 'jdbc-mysql',
     defaultProps: [
       {
@@ -119,7 +119,7 @@ export const providers = [
     ]
   },
   {
-    label: 'postgresql',
+    label: 'PostgreSQL',
     value: 'jdbc-postgresql',
     defaultProps: [
       {
@@ -152,7 +152,7 @@ export const providers = [
     ]
   },
   {
-    label: 'doris',
+    label: 'Apache Doris',
     value: 'jdbc-doris',
     defaultProps: [
       {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rename the ASF providers to their correct names.

### Why are the changes needed?

Fix: #3288

### Does this PR introduce _any_ user-facing change?

<img width="503" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/f96b4c70-7740-4dd1-bb72-e1c347677db3">

<img width="514" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/d59d9c04-ec84-4c37-b44e-0b8e5bbaa7bb">

<img width="496" alt="image" src="https://github.com/datastrato/gravitino/assets/17310559/9057ba3a-02fb-426f-9ec0-737c1c052036">


### How was this patch tested?

IT
