### PR TITLE
[#3244] Improvement(core): add hidden property names cache for list catalog info

### DIFF
--- a/server/src/main/java/com/datastrato/gravitino/server/web/rest/CatalogOperations.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/rest/CatalogOperations.java
@@ -59,6 +59,10 @@ public class CatalogOperations {
   public Response listCatalogs(
       @PathParam("metalake") String metalake,
       @QueryParam("details") @DefaultValue("false") boolean verbose) {
+    LOG.info(
+        "Received list catalog {} request for metalake: {}, ",
+        verbose ? "infos" : "names",
+        metalake);
     try {
       return Utils.doAs(
           httpRequest,
@@ -71,10 +75,15 @@ public class CatalogOperations {
                 () -> {
                   if (verbose) {
                     Catalog[] catalogs = catalogDispatcher.listCatalogsInfo(catalogNS);
-                    return Utils.ok(new CatalogListResponse(DTOConverters.toDTOs(catalogs)));
+                    Response response =
+                        Utils.ok(new CatalogListResponse(DTOConverters.toDTOs(catalogs)));
+                    LOG.info("list {} catalogs info under metalake: {}", catalogs.length, metalake);
+                    return response;
                   } else {
                     NameIdentifier[] idents = catalogDispatcher.listCatalogs(catalogNS);
-                    return Utils.ok(new EntityListResponse(idents));
+                    Response response = Utils.ok(new EntityListResponse(idents));
+                    LOG.info("list {} catalogs under metalake: {}", idents.length, metalake);
+                    return response;
                   }
                 });
           });
@@ -87,6 +96,7 @@ public class CatalogOperations {
   @Produces("application/vnd.gravitino.v1+json")
   public Response createCatalog(
       @PathParam("metalake") String metalake, CatalogCreateRequest request) {
+    LOG.info("received create catalog request for metalake: {}", metalake);
     try {
       return Utils.doAs(
           httpRequest,
@@ -104,7 +114,9 @@ public class CatalogOperations {
                             request.getProvider(),
                             request.getComment(),
                             request.getProperties()));
-            return Utils.ok(new CatalogResponse(DTOConverters.toDTO(catalog)));
+            Response response = Utils.ok(new CatalogResponse(DTOConverters.toDTO(catalog)));
+            LOG.info("catalog created: {}.{}", metalake, catalog.name());
+            return response;
           });
 
     } catch (Exception e) {
@@ -118,12 +130,15 @@ public class CatalogOperations {
   @Produces("application/vnd.gravitino.v1+json")
   public Response loadCatalog(
       @PathParam("metalake") String metalakeName, @PathParam("catalog") String catalogName) {
+    LOG.info("received load catalog request for catalog: {}.{}", metalakeName, catalogName);
     try {
       NameIdentifier ident = NameIdentifier.ofCatalog(metalakeName, catalogName);
       Catalog catalog =
           TreeLockUtils.doWithTreeLock(
               ident, LockType.READ, () -> catalogDispatcher.loadCatalog(ident));
-      return Utils.ok(new CatalogResponse(DTOConverters.toDTO(catalog)));
+      Response response = Utils.ok(new CatalogResponse(DTOConverters.toDTO(catalog)));
+      LOG.info("catalog loaded: {}.{}", metalakeName, catalogName);
+      return response;
 
     } catch (Exception e) {
       return ExceptionHandlers.handleCatalogException(
@@ -138,6 +153,7 @@ public class CatalogOperations {
       @PathParam("metalake") String metalakeName,
       @PathParam("catalog") String catalogName,
       CatalogUpdatesRequest request) {
+    LOG.info("received alter catalog request for catalog: {}.{}", metalakeName, catalogName);
     try {
       return Utils.doAs(
           httpRequest,
@@ -153,7 +169,9 @@ public class CatalogOperations {
                     NameIdentifier.ofMetalake(metalakeName),
                     LockType.WRITE,
                     () -> catalogDispatcher.alterCatalog(ident, changes));
-            return Utils.ok(new CatalogResponse(DTOConverters.toDTO(catalog)));
+            Response response = Utils.ok(new CatalogResponse(DTOConverters.toDTO(catalog)));
+            LOG.info("catalog altered: {}.{}", metalakeName, catalogName);
+            return response;
           });
 
     } catch (Exception e) {
@@ -167,6 +185,7 @@ public class CatalogOperations {
   @Produces("application/vnd.gravitino.v1+json")
   public Response dropCatalog(
       @PathParam("metalake") String metalakeName, @PathParam("catalog") String catalogName) {
+    LOG.info("received drop catalog request for catalog: {}.{}", metalakeName, catalogName);
     try {
       return Utils.doAs(
           httpRequest,
@@ -181,7 +200,9 @@ public class CatalogOperations {
               LOG.warn("Failed to drop catalog {} under metalake {}", catalogName, metalakeName);
             }
 
-            return Utils.ok(new DropResponse(dropped));
+            Response response = Utils.ok(new DropResponse(dropped));
+            LOG.info("catalog dropped: {}.{}", metalakeName, catalogName);
+            return response;
           });
     } catch (Exception e) {
       return ExceptionHandlers.handleCatalogException(

--- a/server/src/main/java/com/datastrato/gravitino/server/web/rest/MetalakeOperations.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/rest/MetalakeOperations.java
@@ -61,6 +61,7 @@ public class MetalakeOperations {
   @Timed(name = "list-metalake." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
   @ResponseMetered(name = "list-metalake", absolute = true)
   public Response listMetalakes() {
+    LOG.info("received list metalakes request.");
     try {
       return Utils.doAs(
           httpRequest,
@@ -69,7 +70,9 @@ public class MetalakeOperations {
                 TreeLockUtils.doWithRootTreeLock(LockType.READ, metalakeDispatcher::listMetalakes);
             MetalakeDTO[] metalakeDTOS =
                 Arrays.stream(metalakes).map(DTOConverters::toDTO).toArray(MetalakeDTO[]::new);
-            return Utils.ok(new MetalakeListResponse(metalakeDTOS));
+            Response response = Utils.ok(new MetalakeListResponse(metalakeDTOS));
+            LOG.info("list {} metalakes in Gravitino", metalakeDTOS.length);
+            return response;
           });
 
     } catch (Exception e) {
@@ -83,6 +86,7 @@ public class MetalakeOperations {
   @Timed(name = "create-metalake." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
   @ResponseMetered(name = "create-metalake", absolute = true)
   public Response createMetalake(MetalakeCreateRequest request) {
+    LOG.info("received create metalake request for {}", request.getName());
     try {
       return Utils.doAs(
           httpRequest,
@@ -95,7 +99,9 @@ public class MetalakeOperations {
                     () ->
                         metalakeDispatcher.createMetalake(
                             ident, request.getComment(), request.getProperties()));
-            return Utils.ok(new MetalakeResponse(DTOConverters.toDTO(metalake)));
+            Response response = Utils.ok(new MetalakeResponse(DTOConverters.toDTO(metalake)));
+            LOG.info("metalake created: {}", metalake.name());
+            return response;
           });
 
     } catch (Exception e) {
@@ -109,6 +115,7 @@ public class MetalakeOperations {
   @Timed(name = "load-metalake." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
   @ResponseMetered(name = "load-metalake", absolute = true)
   public Response loadMetalake(@PathParam("name") String metalakeName) {
+    LOG.info("received load metalake request for metalake: {}", metalakeName);
     try {
       return Utils.doAs(
           httpRequest,
@@ -117,7 +124,9 @@ public class MetalakeOperations {
             Metalake metalake =
                 TreeLockUtils.doWithTreeLock(
                     identifier, LockType.READ, () -> metalakeDispatcher.loadMetalake(identifier));
-            return Utils.ok(new MetalakeResponse(DTOConverters.toDTO(metalake)));
+            Response response = Utils.ok(new MetalakeResponse(DTOConverters.toDTO(metalake)));
+            LOG.info("metalake loaded: {}", metalake.name());
+            return response;
           });
 
     } catch (Exception e) {
@@ -132,6 +141,7 @@ public class MetalakeOperations {
   @ResponseMetered(name = "alter-metalake", absolute = true)
   public Response alterMetalake(
       @PathParam("name") String metalakeName, MetalakeUpdatesRequest updatesRequest) {
+    LOG.info("received alter metalake request for metalake: {}", metalakeName);
     try {
       return Utils.doAs(
           httpRequest,
@@ -145,7 +155,10 @@ public class MetalakeOperations {
             Metalake updatedMetalake =
                 TreeLockUtils.doWithRootTreeLock(
                     LockType.WRITE, () -> metalakeDispatcher.alterMetalake(identifier, changes));
-            return Utils.ok(new MetalakeResponse(DTOConverters.toDTO(updatedMetalake)));
+            Response response =
+                Utils.ok(new MetalakeResponse(DTOConverters.toDTO(updatedMetalake)));
+            LOG.info("metalake altered: {}", updatedMetalake.name());
+            return response;
           });
 
     } catch (Exception e) {
@@ -159,6 +172,7 @@ public class MetalakeOperations {
   @Timed(name = "drop-metalake." + MetricNames.HTTP_PROCESS_DURATION, absolute = true)
   @ResponseMetered(name = "drop-metalake", absolute = true)
   public Response dropMetalake(@PathParam("name") String metalakeName) {
+    LOG.info("received drop metalake request for metalake: {}", metalakeName);
     try {
       return Utils.doAs(
           httpRequest,
@@ -171,7 +185,9 @@ public class MetalakeOperations {
               LOG.warn("Failed to drop metalake by name {}", metalakeName);
             }
 
-            return Utils.ok(new DropResponse(dropped));
+            Response response = Utils.ok(new DropResponse(dropped));
+            LOG.info("metalake dropped: {}", metalakeName);
+            return response;
           });
 
     } catch (Exception e) {

--- a/server/src/main/java/com/datastrato/gravitino/server/web/rest/SchemaOperations.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/rest/SchemaOperations.java
@@ -62,6 +62,7 @@ public class SchemaOperations {
   @ResponseMetered(name = "list-schema", absolute = true)
   public Response listSchemas(
       @PathParam("metalake") String metalake, @PathParam("catalog") String catalog) {
+    LOG.info("received list schema request for catalog: {}.{}", metalake, catalog);
     try {
       return Utils.doAs(
           httpRequest,
@@ -72,7 +73,9 @@ public class SchemaOperations {
                     NameIdentifier.of(metalake, catalog),
                     LockType.READ,
                     () -> dispatcher.listSchemas(schemaNS));
-            return Utils.ok(new EntityListResponse(idents));
+            Response response = Utils.ok(new EntityListResponse(idents));
+            LOG.info("list {} schemas in catalog {}.{}", idents.length, metalake, catalog);
+            return response;
           });
     } catch (Exception e) {
       return ExceptionHandlers.handleSchemaException(OperationType.LIST, "", catalog, e);
@@ -87,6 +90,7 @@ public class SchemaOperations {
       @PathParam("metalake") String metalake,
       @PathParam("catalog") String catalog,
       SchemaCreateRequest request) {
+    LOG.info("received create schema request: {}.{}.{}", metalake, catalog, request.getName());
     try {
       return Utils.doAs(
           httpRequest,
@@ -100,7 +104,9 @@ public class SchemaOperations {
                     () ->
                         dispatcher.createSchema(
                             ident, request.getComment(), request.getProperties()));
-            return Utils.ok(new SchemaResponse(DTOConverters.toDTO(schema)));
+            Response response = Utils.ok(new SchemaResponse(DTOConverters.toDTO(schema)));
+            LOG.info("schema created: {}.{}.{}", metalake, catalog, schema.name());
+            return response;
           });
 
     } catch (Exception e) {
@@ -118,6 +124,7 @@ public class SchemaOperations {
       @PathParam("metalake") String metalake,
       @PathParam("catalog") String catalog,
       @PathParam("schema") String schema) {
+    LOG.info("received load schema request for schema: {}.{}.{}", metalake, catalog, schema);
     try {
       return Utils.doAs(
           httpRequest,
@@ -126,7 +133,9 @@ public class SchemaOperations {
             Schema s =
                 TreeLockUtils.doWithTreeLock(
                     ident, LockType.READ, () -> dispatcher.loadSchema(ident));
-            return Utils.ok(new SchemaResponse(DTOConverters.toDTO(s)));
+            Response response = Utils.ok(new SchemaResponse(DTOConverters.toDTO(s)));
+            LOG.info("schema loaded: {}.{}.{}", metalake, catalog, s.name());
+            return response;
           });
 
     } catch (Exception e) {
@@ -144,6 +153,7 @@ public class SchemaOperations {
       @PathParam("catalog") String catalog,
       @PathParam("schema") String schema,
       SchemaUpdatesRequest request) {
+    LOG.info("received alter schema request: {}.{}.{}", metalake, catalog, schema);
     try {
       return Utils.doAs(
           httpRequest,
@@ -159,7 +169,9 @@ public class SchemaOperations {
                     NameIdentifier.ofCatalog(metalake, catalog),
                     LockType.WRITE,
                     () -> dispatcher.alterSchema(ident, changes));
-            return Utils.ok(new SchemaResponse(DTOConverters.toDTO(s)));
+            Response response = Utils.ok(new SchemaResponse(DTOConverters.toDTO(s)));
+            LOG.info("schema altered: {}.{}.{}", metalake, catalog, s.name());
+            return response;
           });
 
     } catch (Exception e) {
@@ -177,6 +189,7 @@ public class SchemaOperations {
       @PathParam("catalog") String catalog,
       @PathParam("schema") String schema,
       @DefaultValue("false") @QueryParam("cascade") boolean cascade) {
+    LOG.info("received drop schema request: {}.{}.{}", metalake, catalog, schema);
     try {
       return Utils.doAs(
           httpRequest,
@@ -191,7 +204,9 @@ public class SchemaOperations {
               LOG.warn("Fail to drop schema {} under namespace {}", schema, ident.namespace());
             }
 
-            return Utils.ok(new DropResponse(dropped));
+            Response response = Utils.ok(new DropResponse(dropped));
+            LOG.info("schema dropped: {}.{}.{}", metalake, catalog, schema);
+            return response;
           });
     } catch (Exception e) {
       return ExceptionHandlers.handleSchemaException(OperationType.DROP, schema, catalog, e);

--- a/server/src/main/java/com/datastrato/gravitino/server/web/rest/TableOperations.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/rest/TableOperations.java
@@ -63,6 +63,7 @@ public class TableOperations {
       @PathParam("metalake") String metalake,
       @PathParam("catalog") String catalog,
       @PathParam("schema") String schema) {
+    LOG.info("received list tables request for schema: {}.{}.{}", metalake, catalog, schema);
     try {
       return Utils.doAs(
           httpRequest,
@@ -73,7 +74,10 @@ public class TableOperations {
                     NameIdentifier.of(metalake, catalog, schema),
                     LockType.READ,
                     () -> dispatcher.listTables(tableNS));
-            return Utils.ok(new EntityListResponse(idents));
+            Response response = Utils.ok(new EntityListResponse(idents));
+            LOG.info(
+                "list {} tables under schema: {}.{}.{}", idents.length, metalake, catalog, schema);
+            return response;
           });
 
     } catch (Exception e) {
@@ -90,6 +94,7 @@ public class TableOperations {
       @PathParam("catalog") String catalog,
       @PathParam("schema") String schema,
       TableCreateRequest request) {
+    LOG.info("received create table request: {}.{}.{}", metalake, schema, request.getName());
     try {
       return Utils.doAs(
           httpRequest,
@@ -112,7 +117,9 @@ public class TableOperations {
                             fromDTO(request.getDistribution()),
                             fromDTOs(request.getSortOrders()),
                             fromDTOs(request.getIndexes())));
-            return Utils.ok(new TableResponse(DTOConverters.toDTO(table)));
+            Response response = Utils.ok(new TableResponse(DTOConverters.toDTO(table)));
+            LOG.info("table created: {}.{}.{}", metalake, schema, request.getName());
+            return response;
           });
 
     } catch (Exception e) {
@@ -131,6 +138,7 @@ public class TableOperations {
       @PathParam("catalog") String catalog,
       @PathParam("schema") String schema,
       @PathParam("table") String table) {
+    LOG.info("received load table request for table: {}.{}.{}", metalake, schema, table);
     try {
       return Utils.doAs(
           httpRequest,
@@ -139,7 +147,9 @@ public class TableOperations {
             Table t =
                 TreeLockUtils.doWithTreeLock(
                     ident, LockType.READ, () -> dispatcher.loadTable(ident));
-            return Utils.ok(new TableResponse(DTOConverters.toDTO(t)));
+            Response response = Utils.ok(new TableResponse(DTOConverters.toDTO(t)));
+            LOG.info("table loaded: {}.{}.{}", metalake, schema, table);
+            return response;
           });
     } catch (Exception e) {
       return ExceptionHandlers.handleTableException(OperationType.LOAD, table, schema, e);
@@ -157,6 +167,7 @@ public class TableOperations {
       @PathParam("schema") String schema,
       @PathParam("table") String table,
       TableUpdatesRequest request) {
+    LOG.info("received alter table request: {}.{}.{}", metalake, schema, table);
     try {
       return Utils.doAs(
           httpRequest,
@@ -172,7 +183,9 @@ public class TableOperations {
                     NameIdentifier.of(metalake, catalog, schema),
                     LockType.WRITE,
                     () -> dispatcher.alterTable(ident, changes));
-            return Utils.ok(new TableResponse(DTOConverters.toDTO(t)));
+            Response response = Utils.ok(new TableResponse(DTOConverters.toDTO(t)));
+            LOG.info("table altered: {}.{}.{}", metalake, schema, table);
+            return response;
           });
 
     } catch (Exception e) {
@@ -191,6 +204,7 @@ public class TableOperations {
       @PathParam("schema") String schema,
       @PathParam("table") String table,
       @QueryParam("purge") @DefaultValue("false") boolean purge) {
+    LOG.info("received drop table request: {}.{}.{}", metalake, schema, table);
     try {
       return Utils.doAs(
           httpRequest,
@@ -205,7 +219,9 @@ public class TableOperations {
               LOG.warn("Failed to drop table {} under schema {}", table, schema);
             }
 
-            return Utils.ok(new DropResponse(dropped));
+            Response response = Utils.ok(new DropResponse(dropped));
+            LOG.info("table dropped: {}.{}.{}", metalake, schema, table);
+            return response;
           });
 
     } catch (Exception e) {

--- a/web/src/app/metalakes/metalake/MetalakeView.js
+++ b/web/src/app/metalakes/metalake/MetalakeView.js
@@ -45,59 +45,62 @@ const MetalakeView = () => {
       fileset: searchParams.get('fileset'),
       topic: searchParams.get('topic')
     }
-    if ([...searchParams.keys()].length) {
-      const { metalake, catalog, type, schema, table, fileset, topic } = routeParams
+    async function fetchDependsData() {
+      if ([...searchParams.keys()].length) {
+        const { metalake, catalog, type, schema, table, fileset, topic } = routeParams
 
-      if (paramsSize === 1 && metalake) {
-        dispatch(fetchCatalogs({ init: true, page: 'metalakes', metalake }))
-        dispatch(getMetalakeDetails({ metalake }))
-      }
+        if (paramsSize === 1 && metalake) {
+          dispatch(fetchCatalogs({ init: true, page: 'metalakes', metalake }))
+          dispatch(getMetalakeDetails({ metalake }))
+        }
 
-      if (paramsSize === 3 && catalog) {
-        if (!store.catalogs.length) {
-          dispatch(fetchCatalogs({ metalake }))
+        if (paramsSize === 3 && catalog) {
+          if (!store.catalogs.length) {
+            await dispatch(fetchCatalogs({ metalake }))
+          }
+          dispatch(fetchSchemas({ init: true, page: 'catalogs', metalake, catalog, type }))
+          dispatch(getCatalogDetails({ metalake, catalog, type }))
         }
-        dispatch(fetchSchemas({ init: true, page: 'catalogs', metalake, catalog, type }))
-        dispatch(getCatalogDetails({ metalake, catalog, type }))
-      }
 
-      if (paramsSize === 4 && catalog && type && schema) {
-        if (!store.catalogs.length) {
-          dispatch(fetchCatalogs({ metalake }))
-          dispatch(fetchSchemas({ metalake, catalog, type }))
+        if (paramsSize === 4 && catalog && type && schema) {
+          if (!store.catalogs.length) {
+            await dispatch(fetchCatalogs({ metalake }))
+            await dispatch(fetchSchemas({ metalake, catalog, type }))
+          }
+          switch (type) {
+            case 'relational':
+              dispatch(fetchTables({ init: true, page: 'schemas', metalake, catalog, schema }))
+              break
+            case 'fileset':
+              dispatch(fetchFilesets({ init: true, page: 'schemas', metalake, catalog, schema }))
+              break
+            case 'messaging':
+              dispatch(fetchTopics({ init: true, page: 'schemas', metalake, catalog, schema }))
+              break
+            default:
+              break
+          }
+          dispatch(getSchemaDetails({ metalake, catalog, schema }))
         }
-        switch (type) {
-          case 'relational':
-            dispatch(fetchTables({ init: true, page: 'schemas', metalake, catalog, schema }))
-            break
-          case 'fileset':
-            dispatch(fetchFilesets({ init: true, page: 'schemas', metalake, catalog, schema }))
-            break
-          case 'messaging':
-            dispatch(fetchTopics({ init: true, page: 'schemas', metalake, catalog, schema }))
-            break
-          default:
-            break
-        }
-        dispatch(getSchemaDetails({ metalake, catalog, schema }))
-      }
 
-      if (paramsSize === 5 && catalog && schema) {
-        if (!store.catalogs.length) {
-          dispatch(fetchCatalogs({ metalake }))
-          dispatch(fetchSchemas({ metalake, catalog, type }))
-        }
-        if (table) {
-          dispatch(getTableDetails({ init: true, metalake, catalog, schema, table }))
-        }
-        if (fileset) {
-          dispatch(getFilesetDetails({ init: true, metalake, catalog, schema, fileset }))
-        }
-        if (topic) {
-          dispatch(getTopicDetails({ init: true, metalake, catalog, schema, topic }))
+        if (paramsSize === 5 && catalog && schema) {
+          if (!store.catalogs.length) {
+            await dispatch(fetchCatalogs({ metalake }))
+            await dispatch(fetchSchemas({ metalake, catalog, type }))
+          }
+          if (table) {
+            dispatch(getTableDetails({ init: true, metalake, catalog, schema, table }))
+          }
+          if (fileset) {
+            dispatch(getFilesetDetails({ init: true, metalake, catalog, schema, fileset }))
+          }
+          if (topic) {
+            dispatch(getTopicDetails({ init: true, metalake, catalog, schema, topic }))
+          }
         }
       }
     }
+    fetchDependsData()
 
     dispatch(
       setSelectedNodes(


### PR DESCRIPTION
### What changes were proposed in this pull request?

 - cache hidden property names when creating a catalog if necessary
 - get hidden property names from cache for list catalog info

### Why are the changes needed?

Because directly accessing catalog hidden property names requires switching the class loader context, it will incur additional overhead, which will increase as the number of catalog provider types grows.

Fix: #3244

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

existing tests
