### PR TITLE
[MINOR] fix use wrong createCatalog method

### DIFF
--- a/catalogs/catalog-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/integration/test/CatalogKafkaIT.java
+++ b/catalogs/catalog-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/integration/test/CatalogKafkaIT.java
@@ -179,7 +179,7 @@ public class CatalogKafkaIT extends AbstractIT {
     // Test BOOTSTRAP_SERVERS that cannot be linked
     Catalog kafka =
         metalake.createCatalog(
-            NameIdentifier.of(METALAKE_NAME, catalogName),
+            catalogName,
             Catalog.Type.MESSAGING,
             PROVIDER,
             "comment",


### PR DESCRIPTION
### What changes were proposed in this pull request?

fix use wrong `createCatalog` method

### Why are the changes needed?

client API changed

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

no
