### PR TITLE
[#3186] feat(spark-connector): Support Iceberg Spark Procedure

### DIFF
--- a/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/iceberg/GravitinoIcebergCatalog.java
+++ b/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/iceberg/GravitinoIcebergCatalog.java
@@ -9,16 +9,24 @@ import com.datastrato.gravitino.rel.Table;
 import com.datastrato.gravitino.spark.connector.PropertiesConverter;
 import com.datastrato.gravitino.spark.connector.SparkTransformConverter;
 import com.datastrato.gravitino.spark.connector.catalog.BaseCatalog;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Map;
+import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.iceberg.spark.procedures.SparkProcedures;
+import org.apache.iceberg.spark.source.HasIcebergCatalog;
 import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.spark.sql.catalyst.analysis.NoSuchFunctionException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
+import org.apache.spark.sql.catalyst.analysis.NoSuchProcedureException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.connector.catalog.FunctionCatalog;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.catalog.functions.UnboundFunction;
+import org.apache.spark.sql.connector.iceberg.catalog.Procedure;
+import org.apache.spark.sql.connector.iceberg.catalog.ProcedureCatalog;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 /**
@@ -28,7 +36,8 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  * StagingTableCatalog and FunctionCatalog, allowing for advanced operations like table staging and
  * function management tailored to the needs of Iceberg tables.
  */
-public class GravitinoIcebergCatalog extends BaseCatalog implements FunctionCatalog {
+public class GravitinoIcebergCatalog extends BaseCatalog
+    implements FunctionCatalog, ProcedureCatalog, HasIcebergCatalog {
 
   @Override
   protected TableCatalog createAndInitSparkCatalog(
@@ -84,5 +93,47 @@ public class GravitinoIcebergCatalog extends BaseCatalog implements FunctionCata
   @Override
   public UnboundFunction loadFunction(Identifier ident) throws NoSuchFunctionException {
     return ((SparkCatalog) sparkCatalog).loadFunction(ident);
+  }
+
+  /**
+   * Proceduers will validate the equality of the catalog registered to Spark catalogManager and the
+   * catalog passed to `ProcedureBuilder` which invokes loadProceduer(). To meet the requirement ,
+   * override the method to pass `GravitinoIcebergCatalog` to the `ProcedureBuilder` instead of the
+   * internal spark catalog.
+   */
+  @Override
+  public Procedure loadProcedure(Identifier identifier) throws NoSuchProcedureException {
+    String[] namespace = identifier.namespace();
+    String name = identifier.name();
+
+    try {
+      if (isSystemNamespace(namespace)) {
+        SparkProcedures.ProcedureBuilder builder = SparkProcedures.newBuilder(name);
+        if (builder != null) {
+          return builder.withTableCatalog(this).build();
+        }
+      }
+    } catch (NoSuchMethodException
+        | IllegalAccessException
+        | InvocationTargetException
+        | ClassNotFoundException e) {
+      throw new RuntimeException("Failed to load Iceberg Procedure " + identifier, e);
+    }
+
+    throw new NoSuchProcedureException(identifier);
+  }
+
+  @Override
+  public Catalog icebergCatalog() {
+    return ((SparkCatalog) sparkCatalog).icebergCatalog();
+  }
+
+  private boolean isSystemNamespace(String[] namespace)
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException,
+          ClassNotFoundException {
+    Class<?> baseCatalog = Class.forName("org.apache.iceberg.spark.BaseCatalog");
+    Method isSystemNamespace = baseCatalog.getDeclaredMethod("isSystemNamespace", String[].class);
+    isSystemNamespace.setAccessible(true);
+    return (Boolean) isSystemNamespace.invoke(baseCatalog, (Object) namespace);
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support Iceberg Spark Procedure.

### Why are the changes needed?

Support manage Iceberg metadata using Spark SQL.

Fix: https://github.com/datastrato/gravitino/issues/3186

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

New ITs.
