### PR TITLE
[#3434] Improvement(build): Avoid name conflicts with `project.properties`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ out/**
 *.ipr
 
 distribution
-common/src/main/resources/project.properties
+common/src/main/resources/gravitino-build-info.properties
 
 dev/docker/*/packages
 docs/build

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -55,7 +55,7 @@ fun getGitCommitId(): String {
   return gitCommitId
 }
 
-val propertiesFile = "src/main/resources/project.properties"
+val propertiesFile = "src/main/resources/gravitino-build-info.properties"
 fun writeProjectPropertiesFile() {
   val propertiesFile = file(propertiesFile)
   if (propertiesFile.exists()) {
@@ -93,7 +93,7 @@ tasks {
     }
 
     from("src/main/resources") {
-      include("project.properties").duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+      include("gravitino-build-info.properties").duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     }
   }
 

--- a/common/src/main/java/com/datastrato/gravitino/Version.java
+++ b/common/src/main/java/com/datastrato/gravitino/Version.java
@@ -22,7 +22,7 @@ public class Version {
     try {
       VersionInfo currentVersionInfo = new VersionInfo();
       projectProperties.load(
-          Version.class.getClassLoader().getResourceAsStream("project.properties"));
+          Version.class.getClassLoader().getResourceAsStream("gravitino-build-info.properties"));
       currentVersionInfo.version = projectProperties.getProperty("project.version");
       currentVersionInfo.compileDate = projectProperties.getProperty("compile.date");
       currentVersionInfo.gitCommit = projectProperties.getProperty("git.commit.id");


### PR DESCRIPTION
### What changes were proposed in this pull request?

The naming of `project.properties` may conflict with other dependencies. When the class loading order is uncertain, it will cause the version comparison of the client and server to fail because of using the file of other dependencies. The naming rules here refer to Gluten(https://github.com/apache/incubator-gluten/blob/main/dev/gluten-build-info.sh).

### Why are the changes needed?

Fix: #3434 
