### PR TITLE
[#3422]improve(doc, build): Set code tab switching params in the Python Client doc

### DIFF
--- a/clients/client-python/MANIFEST.in
+++ b/clients/client-python/MANIFEST.in
@@ -1,0 +1,6 @@
+# Copyright 2024 Datastrato Pvt Ltd.
+# This software is licensed under the Apache License version 2.
+
+include requirements.txt
+include requirements-dev.txt
+include README.md

--- a/clients/client-python/build.gradle.kts
+++ b/clients/client-python/build.gradle.kts
@@ -64,15 +64,18 @@ fun generatePypiProjectHomePage() {
     val content = outputFile.readText()
     val docsUrl = "https://datastrato.ai/docs/latest"
 
-    // Use regular expression to match the `[](./a/b/c.md#arg1)` link in the content
-    val patternDocs = "(?<!!)\\[([^]]+)]\\(\\.\\/([^)]*\\.md(?:#[^)]*)?)\\)".toRegex()
+    // Use regular expression to match the `[](./a/b/c.md?language=python)` or `[](./a/b/c.md#arg1)` link in the content
+    // Convert `[](./a/b/c.md?language=python)` to `[](https://datastrato.ai/docs/latest/a/b/c/language=python)`
+    val patternDocs = Regex("""(?<!!)\[([^\]]+)]\(\.\/([^)]+)\.md([?#][^)]+)?\)""")
     val contentUpdateDocs = patternDocs.replace(content) { matchResult ->
-      val linkText = matchResult.groupValues[1]
-      val relativePath = matchResult.groupValues[2].replace(".md", "/")
-      "[$linkText]($docsUrl/$relativePath)"
+      val text = matchResult.groupValues[1]
+      val path = matchResult.groupValues[2]
+      val params = matchResult.groupValues[3]
+      "[$text]($docsUrl/$path/$params)"
     }
 
     // Use regular expression to match the `![](./a/b/c.png)` link in the content
+    // Convert `![](./a/b/c.png)` to `[](https://raw.githubusercontent.com/datastrato/gravitino/main/docs/a/b/c.png)`
     val assertUrl = "https://raw.githubusercontent.com/datastrato/gravitino/main/docs"
     val patternImage = """!\[([^\]]+)]\(\./assets/([^)]+)\)""".toRegex()
     val contentUpdateImage = patternImage.replace(contentUpdateDocs) { matchResult ->
@@ -147,6 +150,7 @@ tasks {
 
   val distribution by registering(VenvTask::class) {
     doFirst {
+      delete("README.md")
       generatePypiProjectHomePage()
       delete("dist")
     }

--- a/clients/client-python/setup.py
+++ b/clients/client-python/setup.py
@@ -15,7 +15,7 @@ except FileNotFoundError:
 setup(
     name="gravitino",
     description="Python lib/client for Gravitino",
-    version="0.5.0.dev12",
+    version="0.5.0.dev21",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/datastrato/gravitino",
@@ -37,4 +37,5 @@ setup(
     extras_require={
         "dev": open("requirements-dev.txt").read(),
     },
+    include_package_data=True,
 )

--- a/docs/how-to-use-python-client.md
+++ b/docs/how-to-use-python-client.md
@@ -29,8 +29,8 @@ install it in your local.
 pip install gravitino
 ```
 
-1. [Manage metalake using Gravitino Python API](./manage-metalake-using-gravitino.md)
-2. [Manage fileset metadata using Gravitino Python API](./manage-fileset-metadata-using-gravitino.md)
+1. [Manage metalake using Gravitino Python API](./manage-metalake-using-gravitino.md?language=python)
+2. [Manage fileset metadata using Gravitino Python API](./manage-fileset-metadata-using-gravitino.md?language=python)
 
 ### Gravitino Fileset Example
 
@@ -40,9 +40,9 @@ document [How to use the playground#Launch AI components of playground](./how-to
 to launch a Gravitino server, HDFS and Jupyter notebook environment in you local Docker environment.
 
 Waiting for the playground Docker environment to start, you can directly open
-`http://localhost:8888/lab/tree/gravitino-fileset-sample.ipynb` in the browser and run the example.
+`http://localhost:8888/lab/tree/gravitino-fileset-example.ipynb` in the browser and run the example.
 
-The [gravitino-fileset-example](https://github.com/datastrato/gravitino-playground/blob/main/init/jupyter/gravitino-fileset-sample.ipynb)
+The [gravitino-fileset-example](https://github.com/datastrato/gravitino-playground/blob/main/init/jupyter/gravitino-fileset-example.ipynb)
 contains the following code snippets:
 
 1. Install HDFS Python client.

--- a/docs/how-to-use-the-playground.md
+++ b/docs/how-to-use-the-playground.md
@@ -75,9 +75,9 @@ You can refer document of [Launch AI components of playground](#launch-ai-compon
 to launch a Gravitino server, HDFS and Jupyter notebook environment in you local Docker environment.
 
 Waiting for the playground Docker environment to start, you can directly open
-`http://localhost:8888/lab/tree/gravitino-fileset-sample.ipynb` in the browser and run the example.
+`http://localhost:8888/lab/tree/gravitino-fileset-example.ipynb` in the browser and run the example.
 
-The [gravitino-fileset-example](https://github.com/datastrato/gravitino-playground/blob/main/init/jupyter/gravitino-fileset-sample.ipynb)
+The [gravitino-fileset-example](https://github.com/datastrato/gravitino-playground/blob/main/init/jupyter/gravitino-fileset-example.ipynb)
 contains the following code snippets:
 
 1. Install HDFS Python client.


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Update markdown file
2. Optimized Gradle script in the Python client module.

### Why are the changes needed?

1. add missing Python tab switch params in the `how-to-use-python-client.md`
3. Optimized Gravitino Python client Gradle build script

Fix: #3422

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

CI Passed
