### PR TITLE
[#3128] bugfix(hive): fix order of sort column for ascending sort direction should be 1

### DIFF
--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveTable.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveTable.java
@@ -100,7 +100,7 @@ public class HiveTable extends BaseTable {
                   f ->
                       SortOrders.of(
                           NamedReference.field(f.getCol()),
-                          f.getOrder() == 0 ? SortDirection.ASCENDING : SortDirection.DESCENDING))
+                          f.getOrder() == 1 ? SortDirection.ASCENDING : SortDirection.DESCENDING))
               .toArray(SortOrder[]::new);
     }
 
@@ -276,7 +276,7 @@ public class HiveTable extends BaseTable {
       for (SortOrder sortOrder : sortOrders) {
         String columnName = ((NamedReference.FieldReference) sortOrder.expression()).fieldName()[0];
         sd.addToSortCols(
-            new Order(columnName, sortOrder.direction() == SortDirection.ASCENDING ? 0 : 1));
+            new Order(columnName, sortOrder.direction() == SortDirection.ASCENDING ? 1 : 0));
       }
     }
 

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
@@ -1029,7 +1029,7 @@ public class CatalogHiveIT extends AbstractIT {
 
     for (int i = 0; i < sortOrders.length; i++) {
       Assertions.assertEquals(
-          sortOrders[i].direction() == SortDirection.ASCENDING ? 0 : 1,
+          sortOrders[i].direction() == SortDirection.ASCENDING ? 1 : 0,
           hiveTab.getSd().getSortCols().get(i).getOrder());
       Assertions.assertEquals(
           ((NamedReference.FieldReference) sortOrders[i].expression()).fieldName()[0],


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix order of sort column for ascending sort direction should be 1.

### Why are the changes needed?

The order of ascending sort direction should be 1 that refers to [L34](https://github.com/apache/hive/blob/master/ql/src/java/org/apache/hadoop/hive/ql/util/DirectionUtils.java#L34). Meanwhile, `HiveClientImpl` return empty sort columns for descending sort direction in spark connector which refers to [L461](https://github.com/apache/spark/blob/master/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala#L461).

Fix: #3128 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `CatalogHiveIT`