### PR TITLE
[#2226] dev(docker): Add a Hive with Kerberos mode Docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,6 +15,7 @@ on:
           - 'gravitino-ci-doris'
           - 'trino'
           - 'hive'
+          - 'gravitino-ci-kerberos-hive'
       tag:
         description: 'Docker tag to apply to this image'
         required: true
@@ -37,6 +38,9 @@ jobs:
           if [ "${{ github.event.inputs.image }}" == "gravitino-ci-hive" ]; then
             echo "image_type=hive" >> $GITHUB_ENV
             echo "image_name=datastrato/gravitino-ci-hive" >> $GITHUB_ENV
+          elif [ "${{ github.event.inputs.image }}" == "gravitino-ci-kerberos-hive" ]; then
+            echo "image_type=kerberos-hive" >> $GITHUB_ENV
+            echo "image_name=datastrato/gravitino-ci-kerberos-hive" >> $GITHUB_ENV
           elif [ "${{ github.event.inputs.image }}" == "gravitino-ci-trino" ]; then
             echo "image_type=trino" >> $GITHUB_ENV
             echo "image_name=datastrato/gravitino-ci-trino" >> $GITHUB_ENV

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -464,6 +464,8 @@ tasks.rat {
     // Ignore files we track but do not need headers
     "**/.github/**/*",
     "dev/docker/**/*.xml",
+    "dev/docker/**/*.conf",
+    "dev/docker/kerberos-hive/kadm5.acl",
     "**/*.log",
     "**/licenses/*.txt",
     "**/licenses/*.md",

--- a/dev/docker/build-docker.sh
+++ b/dev/docker/build-docker.sh
@@ -13,7 +13,7 @@ usage() {
   cat << EOF
 Usage:
 
-./build-docker.sh --platform [all|linux/amd64|linux/arm64] --type [gravitino|hive|trino|doris] --image {image_name} --tag {tag_name} --latest
+./build-docker.sh --platform [all|linux/amd64|linux/arm64] --type [gravitino|hive|trino|doris|kerberos-hive] --image {image_name} --tag {tag_name} --latest
 
 Notice: You shouldn't use 'all' for the platform if you don't use the Github action to publish the Docker image.
 EOF
@@ -73,6 +73,9 @@ fi
 
 if [[ "${component_type}" == "hive" ]]; then
   . ${script_dir}/hive/hive-dependency.sh
+  build_args="--build-arg HADOOP_PACKAGE_NAME=${HADOOP_PACKAGE_NAME} --build-arg HIVE_PACKAGE_NAME=${HIVE_PACKAGE_NAME} --build-arg JDBC_DIVER_PACKAGE_NAME=${JDBC_DIVER_PACKAGE_NAME}"
+elif [[ "${component_type}" == "kerberos-hive" ]]; then
+  . ${script_dir}/kerberos-hive/hive-dependency.sh
   build_args="--build-arg HADOOP_PACKAGE_NAME=${HADOOP_PACKAGE_NAME} --build-arg HIVE_PACKAGE_NAME=${HIVE_PACKAGE_NAME} --build-arg JDBC_DIVER_PACKAGE_NAME=${JDBC_DIVER_PACKAGE_NAME}"
 elif [ "${component_type}" == "trino" ]; then
   . ${script_dir}/trino/trino-dependency.sh

--- a/dev/docker/kerberos-hive/Dockerfile
+++ b/dev/docker/kerberos-hive/Dockerfile
@@ -1,0 +1,172 @@
+#
+# Copyright 2024 Datastrato Pvt Ltd.
+# This software is licensed under the Apache License version 2.
+#
+
+FROM ubuntu:16.04
+LABEL maintainer="support@datastrato.com"
+
+ARG HADOOP_PACKAGE_NAME
+ARG HIVE_PACKAGE_NAME
+ARG JDBC_DIVER_PACKAGE_NAME
+
+WORKDIR /
+
+################################################################################
+# update and install basic tools
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get upgrade -y && apt-get install --fix-missing -yq \
+  git \
+  libkrb5-dev \
+  libmysqlclient-dev \
+  libssl-dev \
+  libsasl2-dev \
+  libsasl2-modules-gssapi-mit \
+  libsqlite3-dev \
+  libtidy-0.99-0 \
+  libxml2-dev \
+  libxslt-dev \
+  libffi-dev \
+  libldap2-dev \
+  python-dev \
+  python-setuptools \
+  libgmp3-dev \
+  libz-dev \
+  curl \
+  software-properties-common \
+  vim \
+  openssh-server \
+  wget \
+  sudo \
+  openjdk-8-jdk \
+  krb5-kdc \
+  krb5-admin-server \
+  krb5-user \
+  krb5-config \
+  jsvc
+
+#################################################################################
+## setup ssh
+RUN mkdir /root/.ssh
+RUN cat /dev/zero | ssh-keygen -q -N "" > /dev/null && cat /root/.ssh/id_rsa.pub > /root/.ssh/authorized_keys
+
+COPY packages /tmp/packages
+COPY kdc.conf /etc/krb5kdc/kdc.conf
+COPY kadm5.acl /etc/krb5kdc/kadm5.acl
+COPY krb5.conf /etc/krb5.conf
+
+################################################################################
+# set environment variables
+ENV JAVA_HOME=/usr/local/jdk
+ENV HIVE_HOME=/usr/local/hive
+ENV JSVC_HOME=/user/bin
+ENV HADOOP_SECURE_DN_USER=hdfs
+ENV HADOOP_HOME=/usr/local/hadoop
+ENV HADOOP_HEAPSIZE=128
+ENV HADOOP_INSTALL=${HADOOP_HOME}
+ENV HADOOP_MAPRED_HOME=${HADOOP_INSTALL}
+ENV HADOOP_COMMON_HOME=${HADOOP_INSTALL}
+ENV HADOOP_HDFS_HOME=${HADOOP_INSTALL}
+ENV HADOOP_CONF_DIR=${HADOOP_HOME}/etc/hadoop
+ENV YARN_HOME=${HADOOP_INSTALL}
+ENV KRB5CCNAME=krb5cc_cli_0
+
+ENV PATH=${JAVA_HOME}/bin:${HADOOP_HOME}/bin:${HADOOP_INSTALL}/sbin:${HIVE_HOME}/bin:${PATH}
+ENV CLASSPATH=${HADOOP_HOME}/lib/*:HIVE_HOME/lib/*:.
+ENV LD_LIBRARY_PATH=${HADOOP_HOME}/lib/native
+
+################################################################################
+# add the above env for all users
+RUN ARCH=$(uname -m) && \
+  if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \
+    ln -s /usr/lib/jvm/java-8-openjdk-arm64 ${JAVA_HOME}; \
+  else \
+    ln -s /usr/lib/jvm/java-8-openjdk-amd64 ${JAVA_HOME}; \
+  fi
+
+RUN echo "JAVA_HOME=${JAVA_HOME}" >> /etc/environment
+RUN echo "HADOOP_HEAPSIZE=${HADOOP_HEAPSIZE}" >> /etc/environment
+RUN echo "HADOOP_HOME=${HADOOP_HOME}" >> /etc/environment
+RUN echo "HADOOP_INSTALL=${HADOOP_INSTALL}" >> /etc/environment
+RUN echo "HADOOP_MAPRED_HOME=${HADOOP_MAPRED_HOME}" >> /etc/environment
+RUN echo "HADOOP_COMMON_HOME=${HADOOP_COMMON_HOME}" >> /etc/environment
+RUN echo "HADOOP_HDFS_HOME=${HADOOP_HDFS_HOME}" >> /etc/environment
+RUN echo "HADOOP_CONF_DIR=${HADOOP_CONF_DIR}" >> /etc/environment
+RUN echo "HADOOP_CLASSPATH=${JAVA_HOME}/lib/tools.jar" >> /etc/environment
+RUN echo "YARN_HOME=${YARN_HOME}" >> /etc/environment
+RUN echo "HIVE_HOME=${HIVE_HOME}" >> /etc/environment
+RUN echo "PATH=${PATH}" >> /etc/environment
+RUN echo "CLASSPATH=${CLASSPATH}" >> /etc/environment
+RUN echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> /etc/environment
+
+################################################################################
+# install hadoop
+RUN mkdir ${HADOOP_HOME}
+RUN tar -xz -C ${HADOOP_HOME} --strip-components 1 -f /tmp/packages/${HADOOP_PACKAGE_NAME}
+
+# replace configuration templates
+RUN rm -f ${HADOOP_CONF_DIR}/core-site.xml
+RUN rm -f ${HADOOP_CONF_DIR}/hadoop-env.sh
+RUN rm -f ${HADOOP_CONF_DIR}/yarn-env.sh
+RUN rm -f ${HADOOP_CONF_DIR}/hdfs-site.xml
+RUN rm -f ${HADOOP_CONF_DIR}/mapred-site.xml
+
+ADD core-site.xml ${HADOOP_CONF_DIR}/core-site.xml
+ADD hadoop-env.sh ${HADOOP_CONF_DIR}/hadoop-env.sh
+ADD yarn-env.sh ${HADOOP_CONF_DIR}/yarn-env.sh
+ADD hdfs-site.xml ${HADOOP_CONF_DIR}/hdfs-site.xml
+ADD mapred-site.xml ${HADOOP_CONF_DIR}/mapred-site.xml
+ADD yarn-site.xml ${HADOOP_CONF_DIR}/yarn-site.xml
+ADD check-status.sh /tmp/check-status.sh
+
+
+################################################################################
+# install hive
+RUN mkdir ${HIVE_HOME}
+RUN tar -xz -C ${HIVE_HOME} --strip-components 1 -f /tmp/packages/${HIVE_PACKAGE_NAME}
+ADD hive-site.xml ${HIVE_HOME}/conf/hive-site.xml
+
+################################################################################
+# install MySQL
+ENV MYSQL_PWD=ds123
+RUN echo "mysql-server mysql-server/root_password password ${MYSQL_PWD}" | debconf-set-selections
+RUN echo "mysql-server mysql-server/root_password_again password ${MYSQL_PWD}" | debconf-set-selections
+RUN apt-get install -y mysql-server
+
+RUN chown -R mysql:mysql /var/lib/mysql
+RUN usermod -d /var/lib/mysql/ mysql
+RUN sed -i "s/.*bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/mysql.conf.d/mysqld.cnf
+
+################################################################################
+# add mysql jdbc driver
+RUN tar -xz -C ${HIVE_HOME}/lib --strip-components 1 -f /tmp/packages/${JDBC_DIVER_PACKAGE_NAME}
+
+################################################################################
+# add users and groups
+RUN groupadd hdfs && groupadd hadoop && groupadd hive && groupadd mapred
+
+RUN useradd -g hadoop datastrato && echo "datastrato:ds123" | chpasswd && adduser datastrato sudo
+RUN usermod -s /bin/bash datastrato
+
+RUN usermod -a -G hdfs datastrato
+RUN usermod -a -G hadoop datastrato
+RUN usermod -a -G hive datastrato
+RUN usermod -a -G mapred datastrato
+
+RUN mkdir /home/datastrato
+RUN chown -R datastrato:hadoop /home/datastrato
+
+################################################################################
+# removed install packages
+RUN rm -rf /tmp/packages
+
+################################################################################
+# expose port
+EXPOSE 3306 9000 9083 10000 10002 50070 50075 50010 88
+
+################################################################################
+# create startup script and set ENTRYPOINT
+WORKDIR /
+ADD start.sh /usr/local/sbin
+ENTRYPOINT ["/bin/bash", "/usr/local/sbin/start.sh"]

--- a/dev/docker/kerberos-hive/check-status.sh
+++ b/dev/docker/kerberos-hive/check-status.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Copyright 2024 Datastrato Pvt Ltd.
+# This software is licensed under the Apache License version 2.
+#
+set -ex
+
+hdfs_ready=$(hdfs dfsadmin -report | grep "Live datanodes" | awk '{print $3}')
+if [[ ${hdfs_ready} == "(1):" ]]; then
+  echo "HDFS is ready"
+else
+  echo "HDFS is not ready"
+  exit 1
+fi
+
+hive_ready=$(hive -e "select 1;" 2>&1)
+if [[ ${hive_ready} == *"FAILED"* ]]; then
+  echo "Hive is not ready"
+  exit 1
+else
+  echo "Hive is ready"
+fi
+
+exit 0

--- a/dev/docker/kerberos-hive/core-site.xml
+++ b/dev/docker/kerberos-hive/core-site.xml
@@ -1,0 +1,48 @@
+<configuration>
+  <property>
+    <name>fs.defaultFS</name>
+    <value>hdfs://0.0.0.0:9000</value>
+  </property>
+
+  <property>
+    <name>name</name>
+    <value>Development Cluster</value>
+  </property>
+
+  <property>
+    <name>hadoop.http.staticuser.user</name>
+    <value>hadoopuser</value>
+  </property>
+
+  <property>
+    <name>hadoop.proxyuser.hive.hosts</name>
+    <value>*</value>
+  </property>
+
+  <property>
+    <name>hadoop.proxyuser.hive.groups</name>
+    <value>*</value>
+  </property>
+
+  <property>
+    <name>hadoop.proxyuser.root.groups</name>
+    <value>*</value>
+  </property>
+
+  <property>
+    <name>hadoop.proxyuser.root.hosts</name>
+    <value>*</value>
+  </property>
+
+  <property>
+    <name>hadoop.security.auth_to_local</name>
+    <value>
+      RULE:[2:$1@$0](.*@HADOOPKRB)s/.*/hadoop/
+      DEFAULT
+    </value>
+  </property>
+  <property>
+    <name>hadoop.security.authentication</name>
+    <value>kerberos</value>
+  </property>
+</configuration>

--- a/dev/docker/kerberos-hive/hadoop-env.sh
+++ b/dev/docker/kerberos-hive/hadoop-env.sh
@@ -1,0 +1,95 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Set Hadoop-specific environment variables here.
+
+# The only required environment variable is JAVA_HOME.  All others are
+# optional.  When running a distributed configuration it is best to
+# set JAVA_HOME in this file, so that it is correctly defined on
+# remote nodes.
+
+# The java implementation to use.
+export JAVA_HOME=${JAVA_HOME}
+
+# The jsvc implementation to use. Jsvc is required to run secure datanodes
+# that bind to privileged ports to provide authentication of data transfer
+# protocol.  Jsvc is not required if SASL is configured for authentication of
+# data transfer protocol using non-privileged ports.
+#export JSVC_HOME=${JSVC_HOME}
+
+export HADOOP_CONF_DIR=/usr/local/hadoop/etc/hadoop
+
+# Extra Java CLASSPATH elements.  Automatically insert capacity-scheduler.
+for f in ${HADOOP_HOME}/contrib/capacity-scheduler/*.jar; do
+  if [ "${HADOOP_CLASSPATH}" ]; then
+    export HADOOP_CLASSPATH=${HADOOP_CLASSPATH}:$f
+  else
+    export HADOOP_CLASSPATH=$f
+  fi
+done
+
+# The maximum amount of heap to use, in MB. Default is 1000.
+export HADOOP_HEAPSIZE=128
+
+# Extra Java runtime options.  Empty by default.
+export HADOOP_OPTS="${HADOOP_OPTS} -Djava.net.preferIPv4Stack=true -XX:MaxPermSize=128m"
+
+# Command specific options appended to HADOOP_OPTS when specified
+export HADOOP_NAMENODE_OPTS="-Dhadoop.security.logger=${HADOOP_SECURITY_LOGGER:-INFO,RFAS} -Dhdfs.audit.logger=${HDFS_AUDIT_LOGGER:-INFO,NullAppender} ${HADOOP_NAMENODE_OPTS}"
+export HADOOP_DATANODE_OPTS="-Dhadoop.security.logger=ERROR,RFAS ${HADOOP_DATANODE_OPTS}"
+
+export HADOOP_SECONDARYNAMENODE_OPTS="-Dhadoop.security.logger=${HADOOP_SECURITY_LOGGER:-INFO,RFAS} -Dhdfs.audit.logger=${HDFS_AUDIT_LOGGER:-INFO,NullAppender} ${HADOOP_SECONDARYNAMENODE_OPTS}"
+
+export HADOOP_NFS3_OPTS="${HADOOP_NFS3_OPTS}"
+export HADOOP_PORTMAP_OPTS="${HADOOP_PORTMAP_OPTS}"
+
+# The following applies to multiple commands (fs, dfs, fsck, distcp etc)
+export HADOOP_CLIENT_OPTS="${HADOOP_CLIENT_OPTS}"
+
+# On secure datanodes, user to run the datanode as after dropping privileges.
+# This **MUST** be uncommented to enable secure HDFS if using privileged ports
+# to provide authentication of data transfer protocol.  This **MUST NOT** be
+# defined if SASL is configured for authentication of data transfer protocol
+# using non-privileged ports.
+export HADOOP_SECURE_DN_USER=${HADOOP_SECURE_DN_USER}
+
+# Where log files are stored.  ${HADOOP_HOME}/logs by default.
+
+# Where log files are stored in the secure data environment.
+export HADOOP_SECURE_DN_LOG_DIR=${HADOOP_LOG_DIR}/${HADOOP_HDFS_USER}
+
+###
+# HDFS Mover specific parameters
+###
+# Specify the JVM options to be used when starting the HDFS Mover.
+# These options will be appended to the options specified as HADOOP_OPTS
+# and therefore may override any similar flags set in HADOOP_OPTS
+#
+# export HADOOP_MOVER_OPTS=""
+
+###
+# Advanced Users Only!
+###
+
+# The directory where pid files are stored. /tmp by default.
+# NOTE: this should be set to a directory that can only be written to by
+#       the user that will run the hadoop daemons.  Otherwise there is the
+#       potential for a symlink attack.
+export HADOOP_PID_DIR=${HADOOP_PID_DIR}
+export HADOOP_SECURE_DN_PID_DIR=${HADOOP_PID_DIR}
+
+# A string representing this instance of hadoop. ${USER} by default.
+export HADOOP_IDENT_STRING=${USER}

--- a/dev/docker/kerberos-hive/hdfs-site.xml
+++ b/dev/docker/kerberos-hive/hdfs-site.xml
@@ -1,0 +1,63 @@
+<configuration>
+  <property>
+    <name>dfs.replication</name>
+    <value>1</value>
+  </property>
+
+  <property>
+    <name>dfs.webhdfs.enabled</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>dfs.permissions.superusergroup</name>
+    <value>hdfs</value>
+  </property>
+
+  <property>
+    <name>dfs.block.access.token.enable</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>dfs.namenode.kerberos.principal</name>
+    <value>hdfs/mockhost@HADOOPKRB</value>
+  </property>
+  <property>
+    <name>dfs.namenode.keytab.file</name>
+    <value>/hdfs.keytab</value>
+  </property>
+  <property>
+    <name>dfs.namenode.kerberos.internal.spnego.principal</name>
+    <value>HTTP/mockhost@HADOOPKRB</value>
+  </property>
+  <property>
+    <name>dfs.web.authentication.kerberos.keytab</name>
+    <value>/hdfs.keytab</value>
+  </property>
+  <property>
+    <name>dfs.web.authentication.kerberos.principal</name>
+    <value>HTTP/mockhost@HADOOPKRB</value>
+  </property>
+
+  <property>
+    <name>dfs.datanode.kerberos.principal</name>
+    <value>hdfs/mockhost@HADOOPKRB</value>
+  </property>
+  <property>
+    <name>dfs.datanode.keytab.file</name>
+    <value>/hdfs.keytab</value>
+  </property>
+  <property>
+    <name>dfs.datanode.address</name>
+    <value>0.0.0.0:578</value>
+  </property>
+  <property>
+    <name>dfs.datanode.http.address</name>
+    <value>0.0.0.0:579</value>
+  </property>
+  <property>
+    <name>ignore.secure.ports.for.testing</name>
+    <value>true</value>
+  </property>
+</configuration>

--- a/dev/docker/kerberos-hive/hive-dependency.sh
+++ b/dev/docker/kerberos-hive/hive-dependency.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Copyright 2024 Datastrato Pvt Ltd.
+# This software is licensed under the Apache License version 2.
+#
+set -ex
+hive_dir="$(dirname "${BASH_SOURCE-$0}")"
+hive_dir="$(cd "${hive_dir}">/dev/null; pwd)"
+
+# Environment variables definition
+HADOOP_VERSION="2.7.3"
+HIVE_VERSION="2.3.9"
+MYSQL_JDBC_DRIVER_VERSION="8.0.15"
+
+HADOOP_PACKAGE_NAME="hadoop-${HADOOP_VERSION}.tar.gz" # Must export this variable for Dockerfile
+HADOOP_DOWNLOAD_URL="https://archive.apache.org/dist/hadoop/core/hadoop-${HADOOP_VERSION}/${HADOOP_PACKAGE_NAME}"
+
+HIVE_PACKAGE_NAME="apache-hive-${HIVE_VERSION}-bin.tar.gz" # Must export this variable for Dockerfile
+HIVE_DOWNLOAD_URL="https://archive.apache.org/dist/hive/hive-${HIVE_VERSION}/${HIVE_PACKAGE_NAME}"
+
+JDBC_DIVER_PACKAGE_NAME="mysql-connector-java-${MYSQL_JDBC_DRIVER_VERSION}.tar.gz" # Must export this variable for Dockerfile
+JDBC_DIVER_DOWNLOAD_URL="https://downloads.mysql.com/archives/get/p/3/file/${JDBC_DIVER_PACKAGE_NAME}"
+
+# Prepare download packages
+if [[ ! -d "${hive_dir}/packages" ]]; then
+  mkdir -p "${hive_dir}/packages"
+fi
+
+if [ ! -f "${hive_dir}/packages/${HADOOP_PACKAGE_NAME}" ]; then
+  curl -L -s -o "${hive_dir}/packages/${HADOOP_PACKAGE_NAME}" ${HADOOP_DOWNLOAD_URL}
+fi
+
+if [ ! -f "${hive_dir}/packages/${HIVE_PACKAGE_NAME}" ]; then
+  curl -L -s -o "${hive_dir}/packages/${HIVE_PACKAGE_NAME}" ${HIVE_DOWNLOAD_URL}
+fi
+
+if [ ! -f "${hive_dir}/packages/${JDBC_DIVER_PACKAGE_NAME}" ]; then
+  curl -L -s -o "${hive_dir}/packages/${JDBC_DIVER_PACKAGE_NAME}" ${JDBC_DIVER_DOWNLOAD_URL}
+fi

--- a/dev/docker/kerberos-hive/hive-site.xml
+++ b/dev/docker/kerberos-hive/hive-site.xml
@@ -1,0 +1,71 @@
+<configuration>
+  <property>
+    <name>hive.server2.enable.doAs</name>
+    <value>true</value>
+    <description>Disable user impersonation for HiveServer2</description>
+  </property>
+
+  <property>
+    <name>hive.exec.scratchdir</name>
+    <value>/tmp</value>
+    <description>Scratch space for Hive jobs</description>
+  </property>
+
+  <property>
+    <name>mapred.child.java.opts</name>
+    <value>-Xmx4G -XX:+UseConcMarkSweepGC</value>
+    <description>Max memory for Map Reduce Jobs</description>
+  </property>
+
+  <property>
+    <name>javax.jdo.option.ConnectionURL</name>
+    <value>jdbc:mysql://localhost/metastore_db?createDatabaseIfNotExist=true&amp;useSSL=false</value>
+  </property>
+
+  <property>
+    <name>javax.jdo.option.ConnectionUserName</name>
+    <value>hive</value>
+  </property>
+
+  <property>
+    <name>javax.jdo.option.ConnectionPassword</name>
+    <value>hive</value>
+  </property>
+
+  <property>
+    <name>javax.jdo.option.ConnectionDriverName</name>
+    <value>com.mysql.jdbc.Driver</value>
+  </property>
+
+  <property>
+    <name>hive.metastore.warehouse.dir</name>
+    <value>hdfs://localhost:9000/user/hive/warehouse</value>
+    <description>location of default database for the warehouse</description>
+  </property>
+
+  <property>
+    <name>hive.server2.authentication</name>
+    <value>KERBEROS</value>
+  </property>
+  <property>
+    <name>hive.server2.authentication.kerberos.principal</name>
+    <value>hive/mockhost@HADOOPKRB</value>
+  </property>
+  <property>
+    <name>hive.server2.authentication.kerberos.keytab</name>
+    <value>/hive.keytab</value>
+  </property>
+
+  <property>
+    <name>hive.metastore.sasl.enabled</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>hive.metastore.kerberos.keytab.file</name>
+    <value>/hive.keytab</value>
+  </property>
+  <property>
+    <name>hive.metastore.kerberos.principal</name>
+    <value>hive/mockhost@HADOOPKRB</value>
+  </property>
+</configuration>

--- a/dev/docker/kerberos-hive/kadm5.acl
+++ b/dev/docker/kerberos-hive/kadm5.acl
@@ -1,0 +1,1 @@
+*/admin@HADOOPKRB    *

--- a/dev/docker/kerberos-hive/kdc.conf
+++ b/dev/docker/kerberos-hive/kdc.conf
@@ -1,0 +1,12 @@
+[kdcdefaults]
+kdc_ports = 88
+kdc_tcp_ports = 88
+[realms]
+HADOOPKRB = {
+  #master_key_type = aes256-cts
+  acl_file = /etc/krb5kdc/kadm5.acl
+  dict_file = /usr/share/dict/words
+  admin_keytab = /var/krb5kdc/kadm5.keytab
+  max_renewable_life = 7d 0h 0m 0s
+  supported_enctypes = aes256-cts:normal aes128-cts:normal des3-hmac-sha1:normal arcfour-hmac:normal des-hmac-sha1:normal des-cbc-md5:normal des-cbc-crc:normal
+}

--- a/dev/docker/kerberos-hive/krb5.conf
+++ b/dev/docker/kerberos-hive/krb5.conf
@@ -1,0 +1,20 @@
+[[logging]
+default = FILE:/var/log/krb5libs.log
+kdc = FILE:/var/log/krb5kdc.log
+admin_server = FILE:/var/log/kadmind.log
+
+[libdefaults]
+default_realm = HADOOPKRB
+default_ccache_name = FILE:/tmp/krb5cc_cli_%{uid}
+dns_lookup_realm = false
+dns_lookup_kdc = false
+ticket_lifetime = 24h
+renew_lifetime = 7d
+forwardable = true
+udp_preference_limit = 1
+
+[realms]
+HADOOPKRB = {
+  kdc = localhost:88
+  admin_server = localhost
+}

--- a/dev/docker/kerberos-hive/mapred-site.xml
+++ b/dev/docker/kerberos-hive/mapred-site.xml
@@ -1,0 +1,26 @@
+<configuration>
+  <property>
+    <name>mapreduce.map.memory.mb</name>
+    <value>3072</value>
+  </property>
+
+  <property>
+    <name>mapreduce.reduce.memory.mb</name>
+    <value>3072</value>
+  </property>
+
+  <property>
+    <name>mapreduce.map.java.opts</name>
+    <value>-Xmx3G</value>
+  </property>
+
+  <property>
+    <name>mapreduce.reduce.java.opts</name>
+    <value>-Xmx3G</value>
+  </property>
+
+  <property>
+    <name>mapred.child.java.opts</name>
+    <value>-Xmx3G -XX:+UseConcMarkSweepGC</value>
+  </property>
+</configuration>

--- a/dev/docker/kerberos-hive/start.sh
+++ b/dev/docker/kerberos-hive/start.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# Copyright 2024 Datastrato Pvt Ltd.
+# This software is licensed under the Apache License version 2.
+#
+
+# start ssh
+HOSTNAME=`hostname`
+service ssh start
+ssh-keyscan localhost > /root/.ssh/known_hosts
+ssh-keyscan 0.0.0.0 >> /root/.ssh/known_hosts
+
+# init the Kerberos database
+echo -e "${PASS}\n${PASS}" | kdb5_util create -s
+
+# start Kerberos related service
+service krb5-kdc start
+service krb5-admin-server start
+
+# create Kerberos principal and keytab files
+FQDN="HADOOPKRB"
+ADMIN="admin"
+PASS="Admin12!"
+KRB5_KTNAME=/etc/admin.keytab
+
+echo -e "${PASS}\n${PASS}" | kadmin.local -q "addprinc ${ADMIN}/admin"
+echo -e "${PASS}\n${PASS}" | kadmin.local -q "addprinc cli@${FQDN}"
+echo -e "${PASS}\n${PASS}" | kadmin.local -q "addprinc hdfs/${HOSTNAME}@${FQDN}"
+echo -e "${PASS}\n${PASS}" | kadmin.local -q "addprinc HTTP/${HOSTNAME}@${FQDN}"
+echo -e "${PASS}\n${PASS}" | kadmin.local -q "addprinc hive/${HOSTNAME}@${FQDN}"
+echo -e "${PASS}\n${PASS}" | kadmin.local -q "addprinc yarn/${HOSTNAME}@${FQDN}"
+kadmin.local -q "ktadd -norandkey -k ${KRB5_KTNAME} cli@${FQDN}"
+kadmin.local -q "ktadd -norandkey -k ${KRB5_KTNAME} hdfs/${HOSTNAME}@${FQDN}"
+kadmin.local -q "ktadd -norandkey -k ${KRB5_KTNAME} HTTP/${HOSTNAME}@${FQDN}"
+kadmin.local -q "ktadd -norandkey -k ${KRB5_KTNAME} yarn/${HOSTNAME}@${FQDN}"
+
+kadmin.local -q "xst -k /hdfs.keytab -norandkey hdfs/${HOSTNAME}@${FQDN}"
+kadmin.local -q "xst -k /hdfs.keytab -norandkey HTTP/${HOSTNAME}@${FQDN}"
+kadmin.local -q "xst -k /yarn.keytab -norandkey yarn/${HOSTNAME}@${FQDN}"
+
+kadmin.local -q "ktadd -norandkey -k ${KRB5_KTNAME} hive/${HOSTNAME}@${FQDN}"
+kadmin.local -q "xst -k /hive.keytab -norandkey hive/${HOSTNAME}@${FQDN}"
+kadmin.local -q "xst -k /cli.keytab -norandkey cli@${FQDN}"
+
+echo -e "${PASS}\n" | kinit hive/${HOSTNAME}
+
+# Update the configuration file
+sed -i "s/mockhost/${HOSTNAME}/g" ${HADOOP_CONF_DIR}/hdfs-site.xml
+sed -i "s/mockhost/${HOSTNAME}/g" ${HADOOP_CONF_DIR}/core-site.xml
+sed -i "s/mockhost/${HOSTNAME}/g" ${HIVE_HOME}/conf/hive-site.xml
+
+# format HDFS
+${HADOOP_HOME}/bin/hdfs namenode -format -nonInteractive
+
+echo "Starting HDFS..."
+echo "Starting NameNode..."
+${HADOOP_HOME}/sbin/hadoop-daemon.sh start namenode
+
+echo "Starting DataNode..."
+${HADOOP_HOME}/sbin/start-secure-dns.sh
+
+# start mysql and create databases/users for hive
+chown -R mysql:mysql /var/lib/mysql
+usermod -d /var/lib/mysql/ mysql
+service mysql start
+
+echo """
+  CREATE USER 'hive'@'localhost' IDENTIFIED BY 'hive';
+  GRANT ALL PRIVILEGES on *.* to 'hive'@'localhost' WITH GRANT OPTION;
+  GRANT ALL on hive.* to 'hive'@'localhost' IDENTIFIED BY 'hive';
+  CREATE USER 'iceberg'@'*' IDENTIFIED BY 'iceberg';
+  GRANT ALL PRIVILEGES on *.* to 'iceberg'@'%' identified by 'iceberg' with grant option;
+  FLUSH PRIVILEGES;
+  CREATE DATABASE hive;
+""" | mysql --user=root --password=${MYSQL_PWD}
+
+# start hive
+${HIVE_HOME}/bin/schematool -initSchema -dbType mysql
+${HIVE_HOME}/bin/hive --service hiveserver2 > /dev/null 2>&1 &
+${HIVE_HOME}/bin/hive --service metastore > /dev/null 2>&1 &
+
+# persist the container
+tail -f /dev/null

--- a/dev/docker/kerberos-hive/yarn-env.sh
+++ b/dev/docker/kerberos-hive/yarn-env.sh
@@ -1,0 +1,122 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# User for YARN daemons
+export HADOOP_YARN_USER=${HADOOP_YARN_USER:-yarn}
+
+# resolve links - $0 may be a softlink
+export YARN_CONF_DIR="${YARN_CONF_DIR:-$HADOOP_YARN_HOME/conf}"
+
+# some Java parameters
+# export JAVA_HOME=/home/y/libexec/jdk1.6.0/
+if [ "$JAVA_HOME" != "" ]; then
+  #echo "run java in $JAVA_HOME"
+  JAVA_HOME=$JAVA_HOME
+fi
+  
+if [ "$JAVA_HOME" = "" ]; then
+  echo "Error: JAVA_HOME is not set."
+  exit 1
+fi
+
+JAVA=$JAVA_HOME/bin/java
+JAVA_HEAP_MAX=-Xmx128m
+
+# For setting YARN specific HEAP sizes please use this
+# Parameter and set appropriately
+# YARN_HEAPSIZE=1000
+YARN_HEAPSIZE=128
+
+# check envvars which might override default args
+if [ "$YARN_HEAPSIZE" != "" ]; then
+  JAVA_HEAP_MAX="-Xmx""$YARN_HEAPSIZE""m"
+fi
+
+# Resource Manager specific parameters
+
+# Specify the max Heapsize for the ResourceManager using a numerical value
+# in the scale of MB. For example, to specify an jvm option of -Xmx1000m, set
+# the value to 1000.
+# This value will be overridden by an Xmx setting specified in either YARN_OPTS
+# and/or YARN_RESOURCEMANAGER_OPTS.
+# If not specified, the default value will be picked from either YARN_HEAPMAX
+# or JAVA_HEAP_MAX with YARN_HEAPMAX as the preferred option of the two.
+#export YARN_RESOURCEMANAGER_HEAPSIZE=1000
+export YARN_RESOURCEMANAGER_HEAPSIZE=128
+
+# Specify the max Heapsize for the timeline server using a numerical value
+# in the scale of MB. For example, to specify an jvm option of -Xmx1000m, set
+# the value to 1000.
+# This value will be overridden by an Xmx setting specified in either YARN_OPTS
+# and/or YARN_TIMELINESERVER_OPTS.
+# If not specified, the default value will be picked from either YARN_HEAPMAX
+# or JAVA_HEAP_MAX with YARN_HEAPMAX as the preferred option of the two.
+#export YARN_TIMELINESERVER_HEAPSIZE=1000
+
+# Specify the JVM options to be used when starting the ResourceManager.
+# These options will be appended to the options specified as YARN_OPTS
+# and therefore may override any similar flags set in YARN_OPTS
+#export YARN_RESOURCEMANAGER_OPTS=
+
+# Node Manager specific parameters
+
+# Specify the max Heapsize for the NodeManager using a numerical value
+# in the scale of MB. For example, to specify an jvm option of -Xmx1000m, set
+# the value to 1000.
+# This value will be overridden by an Xmx setting specified in either YARN_OPTS
+# and/or YARN_NODEMANAGER_OPTS.
+# If not specified, the default value will be picked from either YARN_HEAPMAX
+# or JAVA_HEAP_MAX with YARN_HEAPMAX as the preferred option of the two.
+#export YARN_NODEMANAGER_HEAPSIZE=1000
+export YARN_NODEMANAGER_HEAPSIZE=128
+
+# Specify the JVM options to be used when starting the NodeManager.
+# These options will be appended to the options specified as YARN_OPTS
+# and therefore may override any similar flags set in YARN_OPTS
+#export YARN_NODEMANAGER_OPTS=
+
+# so that filenames w/ spaces are handled correctly in loops below
+IFS=
+
+
+# default log directory & file
+if [ "$YARN_LOG_DIR" = "" ]; then
+  YARN_LOG_DIR="$HADOOP_YARN_HOME/logs"
+fi
+if [ "$YARN_LOGFILE" = "" ]; then
+  YARN_LOGFILE='yarn.log'
+fi
+
+# default policy file for service-level authorization
+if [ "$YARN_POLICYFILE" = "" ]; then
+  YARN_POLICYFILE="hadoop-policy.xml"
+fi
+
+# restore ordinary behaviour
+unset IFS
+
+
+YARN_OPTS="$YARN_OPTS -Dhadoop.log.dir=$YARN_LOG_DIR"
+YARN_OPTS="$YARN_OPTS -Dyarn.log.dir=$YARN_LOG_DIR"
+YARN_OPTS="$YARN_OPTS -Dhadoop.log.file=$YARN_LOGFILE"
+YARN_OPTS="$YARN_OPTS -Dyarn.log.file=$YARN_LOGFILE"
+YARN_OPTS="$YARN_OPTS -Dyarn.home.dir=$YARN_COMMON_HOME"
+YARN_OPTS="$YARN_OPTS -Dyarn.id.str=$YARN_IDENT_STRING"
+YARN_OPTS="$YARN_OPTS -Dhadoop.root.logger=${YARN_ROOT_LOGGER:-INFO,console}"
+YARN_OPTS="$YARN_OPTS -Dyarn.root.logger=${YARN_ROOT_LOGGER:-INFO,console}"
+if [ "x$JAVA_LIBRARY_PATH" != "x" ]; then
+  YARN_OPTS="$YARN_OPTS -Djava.library.path=$JAVA_LIBRARY_PATH"
+fi  
+YARN_OPTS="$YARN_OPTS -Dyarn.policy.file=$YARN_POLICYFILE"

--- a/dev/docker/kerberos-hive/yarn-site.xml
+++ b/dev/docker/kerberos-hive/yarn-site.xml
@@ -1,0 +1,27 @@
+<configuration>
+  <property>
+    <name>yarn.nodemanager.aux-services</name>
+    <value>mapreduce_shuffle</value>
+  </property>
+
+  <property>
+    <name>yarn.nodemanager.pmem-check-enabled</name>
+    <value>false</value>
+  </property>
+
+  <property>
+    <name>yarn.nodemanager.vmem-check-enabled</name>
+    <value>false</value>
+  </property>
+
+  <property>
+    <name>yarn.resourcemanager.principal</name>
+    <value>>yarn/mockhost@HADOOPKRB</value>
+  </property>
+
+  <property>
+    <name>yarn.resourcemanager.keytab</name>
+    <value>>/yarn.keytab</value>
+  </property>
+
+</configuration>

--- a/docs/docker-image-details.md
+++ b/docs/docker-image-details.md
@@ -84,6 +84,16 @@ Changelog
 
 You can use these kinds of Docker images to facilitate integration testing of all catalog and connector modules within Gravitino.
 
+## Gravitino CI Apache Hive image with kerberos enabled
+
+You can use this kind of image to test the catalog of Apache Hive with kerberos enable
+
+Changelog
+
+- gravitino-ci-kerberos-hive:0.1.0
+    - Set up a Hive cluster with kerberos enabled.
+    - Install a KDC server and create a principal for Hive. For more please see [kerberos-hive](../dev/docker/kerberos-hive)
+
 ## Gravitino CI Apache Hive image
 
 You can use this kind of image to test the catalog of Apache Hive.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add all the Docker image files required by Hive with Kerberos enabled.

### Why are the changes needed?

We need to confirm that everything goes smoothly in a Kerberos-enabled Hive cluster.

Fix: #2226 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Test locally. 