### PR TITLE
[#3500] feat(relational): add `ExternalType` data type

### DIFF
--- a/api/src/main/java/com/datastrato/gravitino/rel/types/Type.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/types/Type.java
@@ -78,8 +78,16 @@ public interface Type {
     /** The null type. A null type represents a value that is null. */
     NULL,
 
-    /** The unparsed type. An unparsed type represents an unresolvable type. */
-    UNPARSED
+    /**
+     * The unparsed type. An unparsed type represents an unresolvable type.
+     *
+     * @deprecated This type will be removed, use {@link #EXTERNAL} instead.
+     */
+    @Deprecated
+    UNPARSED,
+
+    /** The external type. An external type represents a type that is not supported by Gravitino. */
+    EXTERNAL
   }
 
   /** The base type of all primitive types. */

--- a/api/src/main/java/com/datastrato/gravitino/rel/types/Type.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/types/Type.java
@@ -78,12 +78,7 @@ public interface Type {
     /** The null type. A null type represents a value that is null. */
     NULL,
 
-    /**
-     * The unparsed type. An unparsed type represents an unresolvable type.
-     *
-     * @deprecated This type will be removed, use {@link #EXTERNAL} instead.
-     */
-    @Deprecated
+    /** The unparsed type. An unparsed type represents an unresolvable type. */
     UNPARSED,
 
     /** The external type. An external type represents a type that is not supported by Gravitino. */

--- a/api/src/main/java/com/datastrato/gravitino/rel/types/Types.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/types/Types.java
@@ -1020,11 +1020,7 @@ public class Types {
   /**
    * Represents a type that is not parsed yet. The parsed type is represented by other types of
    * {@link Types}.
-   *
-   * @deprecated This class is deprecated and will be removed in the future. Please use the {@link
-   *     ExternalType} instead.
    */
-  @Deprecated
   public static class UnparsedType implements Type {
 
     /**

--- a/api/src/main/java/com/datastrato/gravitino/rel/types/Types.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/types/Types.java
@@ -1081,18 +1081,25 @@ public class Types {
     }
   }
 
+  /** Represents a type that is defined in an external catalog. */
   public static class ExternalType implements Type {
     private final String catalogString;
 
-    public static ExternalType of(String stringFormat) {
-      return new ExternalType(stringFormat);
+    /**
+     * Creates a new {@link ExternalType} with the given catalog string.
+     *
+     * @param catalogString The string representation of this type in the catalog.
+     * @return A new {@link ExternalType} with the given catalog string.
+     */
+    public static ExternalType of(String catalogString) {
+      return new ExternalType(catalogString);
     }
 
-    public ExternalType(String catalogString) {
+    private ExternalType(String catalogString) {
       this.catalogString = catalogString;
     }
 
-    /** @return The string representation of this type in the catalog. */
+    /** @return The string representation of this type in external catalog. */
     public String catalogString() {
       return catalogString;
     }

--- a/api/src/main/java/com/datastrato/gravitino/rel/types/Types.java
+++ b/api/src/main/java/com/datastrato/gravitino/rel/types/Types.java
@@ -1020,7 +1020,11 @@ public class Types {
   /**
    * Represents a type that is not parsed yet. The parsed type is represented by other types of
    * {@link Types}.
+   *
+   * @deprecated This class is deprecated and will be removed in the future. Please use the {@link
+   *     ExternalType} instead.
    */
+  @Deprecated
   public static class UnparsedType implements Type {
 
     /**
@@ -1074,6 +1078,55 @@ public class Types {
     @Override
     public String toString() {
       return unparsedType;
+    }
+  }
+
+  public static class ExternalType implements Type {
+    private final String catalogString;
+
+    public static ExternalType of(String stringFormat) {
+      return new ExternalType(stringFormat);
+    }
+
+    public ExternalType(String catalogString) {
+      this.catalogString = catalogString;
+    }
+
+    /** @return The string representation of this type in the catalog. */
+    public String catalogString() {
+      return catalogString;
+    }
+
+    @Override
+    public Name name() {
+      return Name.EXTERNAL;
+    }
+
+    @Override
+    public String simpleString() {
+      return String.format("external(%s)", catalogString);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof ExternalType)) {
+        return false;
+      }
+      ExternalType that = (ExternalType) o;
+      return Objects.equals(catalogString, that.catalogString);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(catalogString);
+    }
+
+    @Override
+    public String toString() {
+      return simpleString();
     }
   }
 

--- a/api/src/test/java/com/datastrato/gravitino/rel/TestTypes.java
+++ b/api/src/test/java/com/datastrato/gravitino/rel/TestTypes.java
@@ -181,7 +181,6 @@ public class TestTypes {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void testUnparsedType() {
     Types.UnparsedType unparsedType = Types.UnparsedType.of("bit");
     Assertions.assertEquals(Type.Name.UNPARSED, unparsedType.name());

--- a/api/src/test/java/com/datastrato/gravitino/rel/TestTypes.java
+++ b/api/src/test/java/com/datastrato/gravitino/rel/TestTypes.java
@@ -181,11 +181,21 @@ public class TestTypes {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testUnparsedType() {
     Types.UnparsedType unparsedType = Types.UnparsedType.of("bit");
     Assertions.assertEquals(Type.Name.UNPARSED, unparsedType.name());
     Assertions.assertEquals("unparsed(bit)", unparsedType.simpleString());
     Assertions.assertEquals("bit", unparsedType.unparsedType());
     Assertions.assertEquals(unparsedType, Types.UnparsedType.of("bit"));
+  }
+
+  @Test
+  public void testExternalType() {
+    Types.ExternalType externalType = Types.ExternalType.of("bit");
+    Assertions.assertEquals(Type.Name.EXTERNAL, externalType.name());
+    Assertions.assertEquals("external(bit)", externalType.simpleString());
+    Assertions.assertEquals("bit", externalType.catalogString());
+    Assertions.assertEquals(externalType, Types.ExternalType.of("bit"));
   }
 }

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/converter/FromHiveType.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/converter/FromHiveType.java
@@ -98,7 +98,7 @@ public class FromHiveType {
               return Types.DecimalType.of(decimalTypeInfo.precision(), decimalTypeInfo.scale());
             }
 
-            return Types.UnparsedType.of(hiveTypeInfo.getQualifiedName());
+            return Types.ExternalType.of(hiveTypeInfo.getQualifiedName());
         }
       case LIST:
         return Types.ListType.nullable(
@@ -127,7 +127,7 @@ public class FromHiveType {
                 .map(FromHiveType::toGravitinoType)
                 .toArray(Type[]::new));
       default:
-        return Types.UnparsedType.of(hiveTypeInfo.getQualifiedName());
+        return Types.ExternalType.of(hiveTypeInfo.getQualifiedName());
     }
   }
 

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/converter/TestTypeConverter.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/converter/TestTypeConverter.java
@@ -73,11 +73,11 @@ public class TestTypeConverter {
                     getPrimitiveTypeInfo(STRING_TYPE_NAME), getPrimitiveTypeInfo(INT_TYPE_NAME)))
             .getTypeName());
     Assertions.assertEquals(
-        Types.UnparsedType.of(USER_DEFINED_TYPE),
+        Types.ExternalType.of(USER_DEFINED_TYPE),
         FromHiveType.toGravitinoType(new UserDefinedTypeInfo()));
     Assertions.assertThrows(
         UnsupportedOperationException.class,
-        () -> ToHiveType.convert(Types.UnparsedType.of(USER_DEFINED_TYPE)));
+        () -> ToHiveType.convert(Types.ExternalType.of(USER_DEFINED_TYPE)));
   }
 
   private void testConverter(String typeName) {

--- a/catalogs/catalog-jdbc-common/src/test/java/com/datastrato/gravitino/catalog/jdbc/converter/SqliteTypeConverter.java
+++ b/catalogs/catalog-jdbc-common/src/test/java/com/datastrato/gravitino/catalog/jdbc/converter/SqliteTypeConverter.java
@@ -28,7 +28,7 @@ public class SqliteTypeConverter extends JdbcTypeConverter<String> {
         .filter(entry -> StringUtils.equalsIgnoreCase(type.getTypeName(), entry.getValue()))
         .map(Map.Entry::getKey)
         .findFirst()
-        .orElse(null);
+        .orElse(Types.ExternalType.of(type.getTypeName()));
   }
 
   @Override

--- a/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/converter/DorisTypeConverter.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/converter/DorisTypeConverter.java
@@ -54,7 +54,7 @@ public class DorisTypeConverter extends JdbcTypeConverter<String> {
       case TEXT:
         return Types.StringType.get();
       default:
-        throw new IllegalArgumentException("Not a supported type: " + typeBean);
+        return Types.ExternalType.of(typeBean.getTypeName());
     }
   }
 

--- a/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/converter/MysqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/converter/MysqlTypeConverter.java
@@ -61,7 +61,7 @@ public class MysqlTypeConverter extends JdbcTypeConverter<String> {
       case BINARY:
         return Types.BinaryType.get();
       default:
-        return Types.UnparsedType.of(typeBean.getTypeName());
+        return Types.ExternalType.of(typeBean.getTypeName());
     }
   }
 
@@ -98,6 +98,8 @@ public class MysqlTypeConverter extends JdbcTypeConverter<String> {
       return type.simpleString();
     } else if (type instanceof Types.BinaryType) {
       return type.simpleString();
+    } else if (type instanceof Types.ExternalType) {
+      return ((Types.ExternalType) type).catalogString();
     }
     throw new IllegalArgumentException(
         String.format("Couldn't convert Gravitino type %s to MySQL type", type.simpleString()));

--- a/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/converter/TestMysqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/converter/TestMysqlTypeConverter.java
@@ -48,10 +48,11 @@ public class TestMysqlTypeConverter {
     checkJdbcTypeToGravitinoType(Types.StringType.get(), TEXT, null, null);
     checkJdbcTypeToGravitinoType(Types.BinaryType.get(), BINARY, null, null);
     checkJdbcTypeToGravitinoType(
-        Types.UnparsedType.of(USER_DEFINED_TYPE), USER_DEFINED_TYPE, null, null);
+        Types.ExternalType.of(USER_DEFINED_TYPE), USER_DEFINED_TYPE, null, null);
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testFromGravitinoType() {
     checkGravitinoTypeToJdbcType(TINYINT, Types.ByteType.get());
     checkGravitinoTypeToJdbcType(INT, Types.IntegerType.get());
@@ -67,6 +68,7 @@ public class TestMysqlTypeConverter {
     checkGravitinoTypeToJdbcType(CHAR + "(20)", Types.FixedCharType.of(20));
     checkGravitinoTypeToJdbcType(TEXT, Types.StringType.get());
     checkGravitinoTypeToJdbcType(BINARY, Types.BinaryType.get());
+    checkGravitinoTypeToJdbcType(USER_DEFINED_TYPE, Types.ExternalType.of(USER_DEFINED_TYPE));
     Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> MYSQL_TYPE_CONVERTER.fromGravitinoType(Types.UnparsedType.of(USER_DEFINED_TYPE)));

--- a/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/converter/TestMysqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/converter/TestMysqlTypeConverter.java
@@ -52,7 +52,6 @@ public class TestMysqlTypeConverter {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void testFromGravitinoType() {
     checkGravitinoTypeToJdbcType(TINYINT, Types.ByteType.get());
     checkGravitinoTypeToJdbcType(INT, Types.IntegerType.get());

--- a/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
@@ -606,7 +606,8 @@ public class CatalogMysqlIT extends AbstractIT {
             + "  decimal_6_2_col decimal(6, 2),\n"
             + "  varchar20_col varchar(20),\n"
             + "  text_col text,\n"
-            + "  binary_col binary\n"
+            + "  binary_col binary,\n"
+            + "  blob_col blob\n"
             + ");\n";
 
     mysqlService.executeQuery(sql);
@@ -658,6 +659,9 @@ public class CatalogMysqlIT extends AbstractIT {
           break;
         case "binary_col":
           Assertions.assertEquals(Types.BinaryType.get(), column.dataType());
+          break;
+        case "blob_col":
+          Assertions.assertEquals(Types.ExternalType.of("BLOB"), column.dataType());
           break;
         default:
           Assertions.fail("Unexpected column name: " + column.name());
@@ -1438,7 +1442,7 @@ public class CatalogMysqlIT extends AbstractIT {
         catalog
             .asTableCatalog()
             .loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, tableName));
-    Assertions.assertEquals(Types.UnparsedType.of("BIT"), loadedTable.columns()[0].dataType());
+    Assertions.assertEquals(Types.ExternalType.of("BIT"), loadedTable.columns()[0].dataType());
   }
 
   @Test

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/converter/PostgreSqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/converter/PostgreSqlTypeConverter.java
@@ -66,7 +66,7 @@ public class PostgreSqlTypeConverter extends JdbcTypeConverter<String> {
       case BYTEA:
         return Types.BinaryType.get();
       default:
-        return Types.UnparsedType.of(typeBean.getTypeName());
+        return Types.ExternalType.of(typeBean.getTypeName());
     }
   }
 
@@ -109,6 +109,8 @@ public class PostgreSqlTypeConverter extends JdbcTypeConverter<String> {
       return BYTEA;
     } else if (type instanceof Types.ListType) {
       return fromGravitinoArrayType((ListType) type);
+    } else if (type instanceof Types.ExternalType) {
+      return ((Types.ExternalType) type).catalogString();
     }
     throw new IllegalArgumentException(
         String.format(

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/converter/TestPostgreSqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/converter/TestPostgreSqlTypeConverter.java
@@ -51,7 +51,7 @@ public class TestPostgreSqlTypeConverter {
     checkJdbcTypeToGravitinoType(Types.StringType.get(), TEXT, null, null);
     checkJdbcTypeToGravitinoType(Types.BinaryType.get(), BYTEA, null, null);
     checkJdbcTypeToGravitinoType(
-        Types.UnparsedType.of(USER_DEFINED_TYPE), USER_DEFINED_TYPE, null, null);
+        Types.ExternalType.of(USER_DEFINED_TYPE), USER_DEFINED_TYPE, null, null);
   }
 
   @Test
@@ -76,6 +76,7 @@ public class TestPostgreSqlTypeConverter {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testFromGravitinoType() {
     checkGravitinoTypeToJdbcType(BOOL, Types.BooleanType.get());
     checkGravitinoTypeToJdbcType(INT_2, Types.ShortType.get());
@@ -91,6 +92,7 @@ public class TestPostgreSqlTypeConverter {
     checkGravitinoTypeToJdbcType(BPCHAR + "(20)", Types.FixedCharType.of(20));
     checkGravitinoTypeToJdbcType(TEXT, Types.StringType.get());
     checkGravitinoTypeToJdbcType(BYTEA, Types.BinaryType.get());
+    checkGravitinoTypeToJdbcType(USER_DEFINED_TYPE, Types.ExternalType.of(USER_DEFINED_TYPE));
     Assertions.assertThrows(
         IllegalArgumentException.class,
         () ->

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/converter/TestPostgreSqlTypeConverter.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/converter/TestPostgreSqlTypeConverter.java
@@ -76,7 +76,6 @@ public class TestPostgreSqlTypeConverter {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void testFromGravitinoType() {
     checkGravitinoTypeToJdbcType(BOOL, Types.BooleanType.get());
     checkGravitinoTypeToJdbcType(INT_2, Types.ShortType.get());

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
@@ -1277,7 +1277,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
         catalog
             .asTableCatalog()
             .loadTable(NameIdentifier.of(metalakeName, catalogName, schemaName, tableName));
-    Assertions.assertEquals(Types.UnparsedType.of("bit"), loadedTable.columns()[0].dataType());
+    Assertions.assertEquals(Types.ExternalType.of("bit"), loadedTable.columns()[0].dataType());
   }
 
   @Test

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/FromIcebergType.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/FromIcebergType.java
@@ -98,8 +98,7 @@ public class FromIcebergType extends TypeUtil.SchemaVisitor<Type> {
         return com.datastrato.gravitino.rel.types.Types.DecimalType.of(
             decimal.precision(), decimal.scale());
       default:
-        throw new UnsupportedOperationException(
-            "Cannot convert unknown type to Gravitino: " + primitive);
+        return com.datastrato.gravitino.rel.types.Types.ExternalType.of(primitive.typeId().name());
     }
   }
 }

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/FromIcebergType.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/FromIcebergType.java
@@ -98,7 +98,8 @@ public class FromIcebergType extends TypeUtil.SchemaVisitor<Type> {
         return com.datastrato.gravitino.rel.types.Types.DecimalType.of(
             decimal.precision(), decimal.scale());
       default:
-        return com.datastrato.gravitino.rel.types.Types.UnparsedType.of(primitive.typeId().name());
+        throw new UnsupportedOperationException(
+            "Cannot convert unknown type to Gravitino: " + primitive);
     }
   }
 }

--- a/common/src/main/java/com/datastrato/gravitino/json/JsonUtils.java
+++ b/common/src/main/java/com/datastrato/gravitino/json/JsonUtils.java
@@ -616,7 +616,6 @@ public class JsonUtils {
    * @param gen JSON generator used to write the type
    * @throws IOException if the type cannot be written
    */
-  @SuppressWarnings("deprecation")
   private static void writeDataType(Type dataType, JsonGenerator gen) throws IOException {
     switch (dataType.name()) {
       case BOOLEAN:
@@ -778,7 +777,6 @@ public class JsonUtils {
     gen.writeEndObject();
   }
 
-  @SuppressWarnings("deprecation")
   private static void writeUnparsedType(Types.UnparsedType unparsedType, JsonGenerator gen)
       throws IOException {
     writeUnparsedType(unparsedType.unparsedType(), gen);
@@ -901,7 +899,6 @@ public class JsonUtils {
     return Types.StructType.Field.of(name, type, nullable, comment);
   }
 
-  @SuppressWarnings("deprecation")
   private static Types.UnparsedType readUnparsedType(JsonNode node) {
     Preconditions.checkArgument(
         node.has(UNPARSED_TYPE), "Cannot parse unparsed type from missing unparsed type: %s", node);

--- a/common/src/main/java/com/datastrato/gravitino/json/JsonUtils.java
+++ b/common/src/main/java/com/datastrato/gravitino/json/JsonUtils.java
@@ -105,6 +105,8 @@ public class JsonUtils {
   private static final String UNION = "union";
   private static final String UNPARSED = "unparsed";
   private static final String UNPARSED_TYPE = "unparsedType";
+  private static final String EXTERNAL = "external";
+  private static final String CATALOG_STRING = "catalogString";
   private static final String FIELDS = "fields";
   private static final String UNION_TYPES = "types";
   private static final String STRUCT_FIELD_NAME = "name";
@@ -614,6 +616,7 @@ public class JsonUtils {
    * @param gen JSON generator used to write the type
    * @throws IOException if the type cannot be written
    */
+  @SuppressWarnings("deprecation")
   private static void writeDataType(Type dataType, JsonGenerator gen) throws IOException {
     switch (dataType.name()) {
       case BOOLEAN:
@@ -653,6 +656,9 @@ public class JsonUtils {
         break;
       case UNPARSED:
         writeUnparsedType((Types.UnparsedType) dataType, gen);
+        break;
+      case EXTERNAL:
+        writeExternalType((Types.ExternalType) dataType, gen);
         break;
       default:
         writeUnparsedType(dataType.simpleString(), gen);
@@ -697,6 +703,10 @@ public class JsonUtils {
 
       if (UNPARSED.equals(type)) {
         return readUnparsedType(node);
+      }
+
+      if (EXTERNAL.equals(type)) {
+        return readExternalType(node);
       }
     }
 
@@ -768,6 +778,7 @@ public class JsonUtils {
     gen.writeEndObject();
   }
 
+  @SuppressWarnings("deprecation")
   private static void writeUnparsedType(Types.UnparsedType unparsedType, JsonGenerator gen)
       throws IOException {
     writeUnparsedType(unparsedType.unparsedType(), gen);
@@ -777,6 +788,14 @@ public class JsonUtils {
     gen.writeStartObject();
     gen.writeStringField(TYPE, UNPARSED);
     gen.writeStringField(UNPARSED_TYPE, unparsedType);
+    gen.writeEndObject();
+  }
+
+  private static void writeExternalType(Types.ExternalType externalType, JsonGenerator gen)
+      throws IOException {
+    gen.writeStartObject();
+    gen.writeStringField(TYPE, EXTERNAL);
+    gen.writeStringField(CATALOG_STRING, externalType.catalogString());
     gen.writeEndObject();
   }
 
@@ -882,11 +901,21 @@ public class JsonUtils {
     return Types.StructType.Field.of(name, type, nullable, comment);
   }
 
+  @SuppressWarnings("deprecation")
   private static Types.UnparsedType readUnparsedType(JsonNode node) {
     Preconditions.checkArgument(
         node.has(UNPARSED_TYPE), "Cannot parse unparsed type from missing unparsed type: %s", node);
 
     return Types.UnparsedType.of(node.get(UNPARSED_TYPE).asText());
+  }
+
+  private static Types.ExternalType readExternalType(JsonNode node) {
+    Preconditions.checkArgument(
+        node.has(CATALOG_STRING),
+        "Cannot parse external type from missing catalogString: %s",
+        node);
+
+    return Types.ExternalType.of(node.get(CATALOG_STRING).asText());
   }
 
   // Nested classes for custom serialization and deserialization

--- a/common/src/test/java/com/datastrato/gravitino/json/TestJsonUtils.java
+++ b/common/src/test/java/com/datastrato/gravitino/json/TestJsonUtils.java
@@ -67,6 +67,7 @@ public class TestJsonUtils {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testTypeSerDe() throws Exception {
     Type type = Types.BooleanType.get();
     String jsonValue = JsonUtils.objectMapper().writeValueAsString(type);
@@ -159,6 +160,12 @@ public class TestJsonUtils {
     jsonValue = JsonUtils.objectMapper().writeValueAsString(type);
     expected =
         "{\n" + "    \"type\": \"unparsed\",\n" + "    \"unparsedType\": \"user-defined\"\n" + "}";
+    Assertions.assertEquals(objectMapper.readTree(expected), objectMapper.readTree(jsonValue));
+
+    type = Types.ExternalType.of("user-defined");
+    jsonValue = JsonUtils.objectMapper().writeValueAsString(type);
+    expected =
+        "{\n" + "    \"type\": \"external\",\n" + "    \"catalogString\": \"user-defined\"\n" + "}";
     Assertions.assertEquals(objectMapper.readTree(expected), objectMapper.readTree(jsonValue));
   }
 

--- a/common/src/test/java/com/datastrato/gravitino/json/TestJsonUtils.java
+++ b/common/src/test/java/com/datastrato/gravitino/json/TestJsonUtils.java
@@ -67,7 +67,6 @@ public class TestJsonUtils {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void testTypeSerDe() throws Exception {
     Type type = Types.BooleanType.get();
     String jsonValue = JsonUtils.objectMapper().writeValueAsString(type);

--- a/docs/apache-hive-catalog.md
+++ b/docs/apache-hive-catalog.md
@@ -122,7 +122,7 @@ The following table lists the data types mapped from the Hive catalog to Graviti
 | `uniontype`                 | `uniontype`         | 0.2.0         |
 
 :::info
-Since 0.5.1, the data types other than listed above are mapped to Gravitino **[External Type](./manage-relational-metadata-using-gravitino.md#external-type)** that represents an unresolvable data type from the Hive catalog.
+Since 0.6.0, the data types other than listed above are mapped to Gravitino **[External Type](./manage-relational-metadata-using-gravitino.md#external-type)** that represents an unresolvable data type from the Hive catalog.
 :::
 
 ### Table properties

--- a/docs/apache-hive-catalog.md
+++ b/docs/apache-hive-catalog.md
@@ -122,7 +122,7 @@ The following table lists the data types mapped from the Hive catalog to Graviti
 | `uniontype`                 | `uniontype`         | 0.2.0         |
 
 :::info
-Since 0.5.0, the data types other than listed above are mapped to Gravitino **[Unparsed Type](./manage-relational-metadata-using-gravitino.md#unparsed-type)** that represents an unresolvable data type from the Hive catalog.
+Since 0.5.1, the data types other than listed above are mapped to Gravitino **[External Type](./manage-relational-metadata-using-gravitino.md#external-type)** that represents an unresolvable data type from the Hive catalog.
 :::
 
 ### Table properties

--- a/docs/jdbc-mysql-catalog.md
+++ b/docs/jdbc-mysql-catalog.md
@@ -106,7 +106,7 @@ Refer to [Manage Relational Metadata Using Gravitino](./manage-relational-metada
 
 :::info
 MySQL doesn't support Gravitino `Boolean` `Fixed` `Struct` `List` `Map` `Timestamp_tz` `IntervalDay` `IntervalYear` `Union` `UUID` type.
-Meanwhile, the data types other than listed above are mapped to Gravitino **[Unparsed Type](./manage-relational-metadata-using-gravitino.md#unparsed-type)** that represents an unresolvable data type since 0.5.0.
+Meanwhile, the data types other than listed above are mapped to Gravitino **[External Type](./manage-relational-metadata-using-gravitino.md#external-type)** that represents an unresolvable data type since 0.5.1.
 :::
 
 #### Table column auto-increment

--- a/docs/jdbc-mysql-catalog.md
+++ b/docs/jdbc-mysql-catalog.md
@@ -106,7 +106,7 @@ Refer to [Manage Relational Metadata Using Gravitino](./manage-relational-metada
 
 :::info
 MySQL doesn't support Gravitino `Boolean` `Fixed` `Struct` `List` `Map` `Timestamp_tz` `IntervalDay` `IntervalYear` `Union` `UUID` type.
-Meanwhile, the data types other than listed above are mapped to Gravitino **[External Type](./manage-relational-metadata-using-gravitino.md#external-type)** that represents an unresolvable data type since 0.5.1.
+Meanwhile, the data types other than listed above are mapped to Gravitino **[External Type](./manage-relational-metadata-using-gravitino.md#external-type)** that represents an unresolvable data type since 0.6.0.
 :::
 
 #### Table column auto-increment

--- a/docs/jdbc-postgresql-catalog.md
+++ b/docs/jdbc-postgresql-catalog.md
@@ -111,7 +111,7 @@ Please refer to [Manage Relational Metadata Using Gravitino](./manage-relational
 
 :::info
 PostgreSQL doesn't support Gravitino `Fixed` `Struct` `Map` `IntervalDay` `IntervalYear` `Union` `UUID` type.
-Meanwhile, the data types other than listed above are mapped to Gravitino **[Unparsed Type](./manage-relational-metadata-using-gravitino.md#unparsed-type)** that represents an unresolvable data type since 0.5.0.
+Meanwhile, the data types other than listed above are mapped to Gravitino **[External Type](./manage-relational-metadata-using-gravitino.md#external-type)** that represents an unresolvable data type since 0.5.1.
 :::
 
 #### Table column auto-increment

--- a/docs/jdbc-postgresql-catalog.md
+++ b/docs/jdbc-postgresql-catalog.md
@@ -111,7 +111,7 @@ Please refer to [Manage Relational Metadata Using Gravitino](./manage-relational
 
 :::info
 PostgreSQL doesn't support Gravitino `Fixed` `Struct` `Map` `IntervalDay` `IntervalYear` `Union` `UUID` type.
-Meanwhile, the data types other than listed above are mapped to Gravitino **[External Type](./manage-relational-metadata-using-gravitino.md#external-type)** that represents an unresolvable data type since 0.5.1.
+Meanwhile, the data types other than listed above are mapped to Gravitino **[External Type](./manage-relational-metadata-using-gravitino.md#external-type)** that represents an unresolvable data type since 0.6.0.
 :::
 
 #### Table column auto-increment

--- a/docs/lakehouse-iceberg-catalog.md
+++ b/docs/lakehouse-iceberg-catalog.md
@@ -220,7 +220,7 @@ Apache Iceberg doesn't support Gravitino `EvenDistribution` type.
 
 :::info
 Apache Iceberg doesn't support Gravitino `Varchar` `Fixedchar` `Byte` `Short` `Union` type.
-Meanwhile, the data types other than listed above are mapped to Gravitino **[Unparsed Type](./manage-relational-metadata-using-gravitino.md#unparsed-type)** that represents an unresolvable data type since 0.5.0.
+Meanwhile, the data types other than listed above are mapped to Gravitino **[External Type](./manage-relational-metadata-using-gravitino.md#external-type)** that represents an unresolvable data type since 0.5.1.
 :::
 
 ### Table properties

--- a/docs/lakehouse-iceberg-catalog.md
+++ b/docs/lakehouse-iceberg-catalog.md
@@ -220,7 +220,7 @@ Apache Iceberg doesn't support Gravitino `EvenDistribution` type.
 
 :::info
 Apache Iceberg doesn't support Gravitino `Varchar` `Fixedchar` `Byte` `Short` `Union` type.
-Meanwhile, the data types other than listed above are mapped to Gravitino **[External Type](./manage-relational-metadata-using-gravitino.md#external-type)** that represents an unresolvable data type since 0.5.1.
+Meanwhile, the data types other than listed above are mapped to Gravitino **[External Type](./manage-relational-metadata-using-gravitino.md#external-type)** that represents an unresolvable data type since 0.6.0.
 :::
 
 ### Table properties

--- a/docs/manage-relational-metadata-using-gravitino.md
+++ b/docs/manage-relational-metadata-using-gravitino.md
@@ -724,7 +724,36 @@ The following types that Gravitino supports:
 
 The related java doc is [here](pathname:///docs/0.5.0/api/java/com/datastrato/gravitino/rel/types/Type.html).
 
-##### Unparsed type
+##### External type
+
+External type is a special type of column type, when you need to use a data type that is not in the Gravitino type
+system, and you explicitly know its string representation in an external catalog (usually used in JDBC catalogs), then
+you can use the ExternalType to represent the type. Similarly, if the original type is unsolvable, it will be
+represented by ExternalType.
+The following shows the data structure of an external type in JSON and Java, enabling easy retrieval of its string value.
+
+<Tabs>
+  <TabItem value="Json" label="Json">
+
+```json
+{
+  "type": "external",
+  "catalogString": "user-defined"
+}
+```
+
+  </TabItem>
+  <TabItem value="java" label="Java">
+
+```java
+// The result of the following type is a string "user-defined"
+String typeString = ((ExternalType) type).catalogString();
+```
+
+  </TabItem>
+</Tabs>
+
+##### ~~Unparsed type~~ (Deprecated, please use `Types.UnparsedType.get()` instead)
 
 Unparsed type is a special type of column type, currently serves exclusively for presenting the data type of a column when it's unsolvable.
 The following shows the data structure of an unparsed type in JSON and Java, enabling easy retrieval of its value.
@@ -834,7 +863,7 @@ tableCatalog.loadTable(NameIdentifier.of("metalake", "hive_catalog", "schema", "
 </Tabs>
 
 :::note
-- When Gravitino loads a table from a catalog with various data types, if Gravitino is unable to parse the data type, it will use an **[Unparsed Type](#unparsed-type)** to preserve the original data type, ensuring that the table can be loaded successfully.
+- When Gravitino loads a table from a catalog with various data types, if Gravitino is unable to parse the data type, it will use an **[External Type](#external-type)** to preserve the original data type, ensuring that the table can be loaded successfully.
 - When Gravitino loads a table from a catalog that supports default value, if Gravitino is unable to parse the default value, it will use an **[Unparsed Expression](./expression.md#unparsed-expression)** to preserve the original default value, ensuring that the table can be loaded successfully.
 :::
 

--- a/docs/manage-relational-metadata-using-gravitino.md
+++ b/docs/manage-relational-metadata-using-gravitino.md
@@ -753,9 +753,11 @@ String typeString = ((ExternalType) type).catalogString();
   </TabItem>
 </Tabs>
 
-##### ~~Unparsed type~~ (Deprecated, please use `Types.UnparsedType.get()` instead)
+##### Unparsed type
 
-Unparsed type is a special type of column type, currently serves exclusively for presenting the data type of a column when it's unsolvable.
+Unparsed type is a special type of column type, it used to address compatibility issues in type serialization and
+deserialization between the server and client. For instance, if a new column type is introduced on the Gravitino server
+that the client does not recognize, it will be treated as an unparsed type on the client side.
 The following shows the data structure of an unparsed type in JSON and Java, enabling easy retrieval of its value.
 
 <Tabs>
@@ -764,7 +766,7 @@ The following shows the data structure of an unparsed type in JSON and Java, ena
 ```json
 {
   "type": "unparsed",
-  "unparsedType": "user-defined"
+  "unparsedType": "unknown-type"
 }
 ```
 
@@ -772,7 +774,7 @@ The following shows the data structure of an unparsed type in JSON and Java, ena
   <TabItem value="java" label="Java">
 
 ```java
-// The result of the following type is a string "user-defined"
+// The result of the following type is a string "unknown-type"
 String unparsedValue = ((UnparsedType) type).unparsedType();
 ```
 

--- a/docs/open-api/datatype.yaml
+++ b/docs/open-api/datatype.yaml
@@ -167,7 +167,6 @@ components:
 
     UnparsedType:
       type: object
-      description: Deprecated. Use `ExternalType` instead.
       required:
         - type
         - unparsedType
@@ -182,7 +181,7 @@ components:
       example: {
         "type": "unparsed",
         "unparsedType": [
-          "user-defined"
+          "unknown-type"
         ]
       }
 

--- a/docs/open-api/datatype.yaml
+++ b/docs/open-api/datatype.yaml
@@ -167,6 +167,7 @@ components:
 
     UnparsedType:
       type: object
+      description: Deprecated. Use `ExternalType` instead.
       required:
         - type
         - unparsedType
@@ -184,3 +185,21 @@ components:
           "user-defined"
         ]
       }
+
+  ExternalType:
+    type: object
+    required:
+      - type
+      - catalogString
+    properties:
+      type:
+        type: string
+        enum:
+          - "external"
+      catalogString:
+        type: string
+        description: The string representation of this type in the catalog
+    example: {
+      "type": "external",
+      "externalType": "user-defined"
+    }


### PR DESCRIPTION
### What changes were proposed in this pull request?

 - introduce externalType so that users can use external types when creating JDBC tables
 - deprecated `unparsedType`
 - add docs for externalType

### Why are the changes needed?

Fix: #3500 

### Does this PR introduce _any_ user-facing change?

yes, `unparsedType` is deprecated, please use `externalType` instead

### How was this patch tested?

tests added
