### PR TITLE
[#3202] improvement(core): add name spec for catalog and metalake

### DIFF
--- a/catalogs/catalog-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/integration/test/CatalogKafkaIT.java
+++ b/catalogs/catalog-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/integration/test/CatalogKafkaIT.java
@@ -114,7 +114,7 @@ public class CatalogKafkaIT extends AbstractIT {
   @Test
   public void testCatalog() throws ExecutionException, InterruptedException {
     // test create catalog
-    String catalogName = GravitinoITUtils.genRandomName("test-catalog");
+    String catalogName = GravitinoITUtils.genRandomName("test_catalog");
     String comment = "test catalog";
     Map<String, String> properties =
         ImmutableMap.of(BOOTSTRAP_SERVERS, kafkaBootstrapServers, "key1", "value1");
@@ -150,7 +150,7 @@ public class CatalogKafkaIT extends AbstractIT {
 
   @Test
   public void testCatalogException() {
-    String catalogName = GravitinoITUtils.genRandomName("test-catalog");
+    String catalogName = GravitinoITUtils.genRandomName("test_catalog");
     Exception exception =
         Assertions.assertThrows(
             IllegalArgumentException.class,

--- a/clients/client-python/tests/integration/test_fileset_catalog.py
+++ b/clients/client-python/tests/integration/test_fileset_catalog.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 class TestFilesetCatalog(IntegrationTestEnv):
-    metalake_name: str = "TestFilesetCatalog-metalake" + str(randint(1, 10000))
+    metalake_name: str = "TestFilesetCatalog_metalake" + str(randint(1, 10000))
     catalog_name: str = "catalog"
     catalog_location_prop: str = "location"  # Fileset Catalog must set `location`
     catalog_provider: str = "hadoop"

--- a/clients/client-python/tests/integration/test_metalake.py
+++ b/clients/client-python/tests/integration/test_metalake.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class TestMetalake(IntegrationTestEnv):
-    metalake_name: str = "TestMetalake-metalake"
+    metalake_name: str = "TestMetalake_metalake"
     metalake_new_name = metalake_name + "_new"
 
     metalake_comment: str = "metalake_comment"

--- a/clients/client-python/tests/integration/test_schema.py
+++ b/clients/client-python/tests/integration/test_schema.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 class TestSchema(IntegrationTestEnv):
-    metalake_name: str = "TestSchema-metalake" + str(randint(1, 10000))
+    metalake_name: str = "TestSchema_metalake" + str(randint(1, 10000))
 
     catalog_name: str = "testCatalog"
     catalog_location_prop: str = "location"  # Fileset Catalog must set `location`

--- a/core/src/main/java/com/datastrato/gravitino/GravitinoEnv.java
+++ b/core/src/main/java/com/datastrato/gravitino/GravitinoEnv.java
@@ -8,6 +8,7 @@ import com.datastrato.gravitino.authorization.AccessControlManager;
 import com.datastrato.gravitino.auxiliary.AuxiliaryServiceManager;
 import com.datastrato.gravitino.catalog.CatalogDispatcher;
 import com.datastrato.gravitino.catalog.CatalogManager;
+import com.datastrato.gravitino.catalog.CatalogNormalizeDispatcher;
 import com.datastrato.gravitino.catalog.FilesetDispatcher;
 import com.datastrato.gravitino.catalog.FilesetNormalizeDispatcher;
 import com.datastrato.gravitino.catalog.FilesetOperationDispatcher;
@@ -34,6 +35,7 @@ import com.datastrato.gravitino.listener.TopicEventDispatcher;
 import com.datastrato.gravitino.lock.LockManager;
 import com.datastrato.gravitino.metalake.MetalakeDispatcher;
 import com.datastrato.gravitino.metalake.MetalakeManager;
+import com.datastrato.gravitino.metalake.MetalakeNormalizeDispatcher;
 import com.datastrato.gravitino.metrics.MetricsSystem;
 import com.datastrato.gravitino.metrics.source.JVMMetricsSource;
 import com.datastrato.gravitino.storage.IdGenerator;
@@ -156,11 +158,15 @@ public class GravitinoEnv {
 
     // Create and initialize metalake related modules
     MetalakeManager metalakeManager = new MetalakeManager(entityStore, idGenerator);
-    this.metalakeDispatcher = new MetalakeEventDispatcher(eventBus, metalakeManager);
+    MetalakeNormalizeDispatcher metalakeNormalizeDispatcher =
+        new MetalakeNormalizeDispatcher(metalakeManager);
+    this.metalakeDispatcher = new MetalakeEventDispatcher(eventBus, metalakeNormalizeDispatcher);
 
     // Create and initialize Catalog related modules
     this.catalogManager = new CatalogManager(config, entityStore, idGenerator);
-    this.catalogDispatcher = new CatalogEventDispatcher(eventBus, catalogManager);
+    CatalogNormalizeDispatcher catalogNormalizeDispatcher =
+        new CatalogNormalizeDispatcher(catalogManager);
+    this.catalogDispatcher = new CatalogEventDispatcher(eventBus, catalogNormalizeDispatcher);
 
     SchemaOperationDispatcher schemaOperationDispatcher =
         new SchemaOperationDispatcher(catalogManager, entityStore, idGenerator);

--- a/core/src/main/java/com/datastrato/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/CatalogManager.java
@@ -321,15 +321,6 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
       String comment,
       Map<String, String> properties)
       throws NoSuchMetalakeException, CatalogAlreadyExistsException {
-
-    if (Entity.SYSTEM_CATALOG_RESERVED_NAME.equals(ident.name())) {
-      throw new IllegalArgumentException("Can't create a catalog with with reserved name `system`");
-    }
-
-    if (Entity.SECURABLE_ENTITY_RESERVED_NAME.equals(ident.name())) {
-      throw new IllegalArgumentException("Can't create a catalog with with reserved name `*`");
-    }
-
     // load catalog-related configuration from catalog-specific configuration file
     Map<String, String> newProperties = Optional.ofNullable(properties).orElse(Maps.newHashMap());
     Map<String, String> catalogSpecificConfig = loadCatalogSpecificConfig(newProperties, provider);

--- a/core/src/main/java/com/datastrato/gravitino/catalog/CatalogNormalizeDispatcher.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/CatalogNormalizeDispatcher.java
@@ -25,10 +25,10 @@ public class CatalogNormalizeDispatcher implements CatalogDispatcher {
   /**
    * Regular expression explanation:
    *
-   * <p>^[a-zA-Z_] - Starts with a letter, digit, or underscore
+   * <p>^\w - Starts with a letter, digit, or underscore
    *
-   * <p>[a-zA-Z0-9_]{0,63} - Followed by 0 to 63 characters (making the total length at most 64) of
-   * letters (both cases), digits, underscores
+   * <p>[\w]{0,63} - Followed by 0 to 63 characters (making the total length at most 64) of letters
+   * (both cases), digits, underscores
    *
    * <p>$ - End of the string
    */

--- a/core/src/main/java/com/datastrato/gravitino/catalog/CatalogNormalizeDispatcher.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/CatalogNormalizeDispatcher.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.catalog;
+
+import static com.datastrato.gravitino.Entity.SECURABLE_ENTITY_RESERVED_NAME;
+import static com.datastrato.gravitino.Entity.SYSTEM_CATALOG_RESERVED_NAME;
+
+import com.datastrato.gravitino.Catalog;
+import com.datastrato.gravitino.CatalogChange;
+import com.datastrato.gravitino.NameIdentifier;
+import com.datastrato.gravitino.Namespace;
+import com.datastrato.gravitino.exceptions.CatalogAlreadyExistsException;
+import com.datastrato.gravitino.exceptions.NoSuchCatalogException;
+import com.datastrato.gravitino.exceptions.NoSuchMetalakeException;
+import com.google.common.collect.ImmutableSet;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+
+public class CatalogNormalizeDispatcher implements CatalogDispatcher {
+  private static final Set<String> RESERVED_WORDS =
+      ImmutableSet.of(SECURABLE_ENTITY_RESERVED_NAME, SYSTEM_CATALOG_RESERVED_NAME);
+  /**
+   * Regular expression explanation:
+   *
+   * <p>^[a-zA-Z_] - Starts with a letter, digit, or underscore
+   *
+   * <p>[a-zA-Z0-9_]{0,63} - Followed by 0 to 63 characters (making the total length at most 64) of
+   * letters (both cases), digits, underscores
+   *
+   * <p>$ - End of the string
+   */
+  private static final String CATALOG_NAME_PATTERN = "^\\w[\\w]{0,63}$";
+
+  private final CatalogDispatcher dispatcher;
+
+  public CatalogNormalizeDispatcher(CatalogDispatcher dispatcher) {
+    this.dispatcher = dispatcher;
+  }
+
+  @Override
+  public NameIdentifier[] listCatalogs(Namespace namespace) throws NoSuchMetalakeException {
+    return dispatcher.listCatalogs(namespace);
+  }
+
+  @Override
+  public Catalog[] listCatalogsInfo(Namespace namespace) throws NoSuchMetalakeException {
+    return dispatcher.listCatalogsInfo(namespace);
+  }
+
+  @Override
+  public Catalog loadCatalog(NameIdentifier ident) throws NoSuchCatalogException {
+    return dispatcher.loadCatalog(ident);
+  }
+
+  @Override
+  public boolean catalogExists(NameIdentifier ident) {
+    return dispatcher.catalogExists(ident);
+  }
+
+  @Override
+  public Catalog createCatalog(
+      NameIdentifier ident,
+      Catalog.Type type,
+      String provider,
+      String comment,
+      Map<String, String> properties)
+      throws NoSuchMetalakeException, CatalogAlreadyExistsException {
+    validateCatalogName(ident.name());
+    return dispatcher.createCatalog(ident, type, provider, comment, properties);
+  }
+
+  @Override
+  public Catalog alterCatalog(NameIdentifier ident, CatalogChange... changes)
+      throws NoSuchCatalogException, IllegalArgumentException {
+    Arrays.stream(changes)
+        .forEach(
+            c -> {
+              if (c instanceof CatalogChange.RenameCatalog) {
+                validateCatalogName(((CatalogChange.RenameCatalog) c).getNewName());
+              }
+            });
+    return dispatcher.alterCatalog(ident, changes);
+  }
+
+  @Override
+  public boolean dropCatalog(NameIdentifier ident) {
+    return dispatcher.dropCatalog(ident);
+  }
+
+  private void validateCatalogName(String name) throws IllegalArgumentException {
+    if (RESERVED_WORDS.contains(name.toLowerCase())) {
+      throw new IllegalArgumentException("The catalog name '" + name + "' is reserved.");
+    }
+
+    if (!name.matches(CATALOG_NAME_PATTERN)) {
+      throw new IllegalArgumentException("The catalog name '" + name + "' is illegal.");
+    }
+  }
+}

--- a/core/src/main/java/com/datastrato/gravitino/connector/capability/Capability.java
+++ b/core/src/main/java/com/datastrato/gravitino/connector/capability/Capability.java
@@ -87,10 +87,10 @@ public interface Capability {
     /**
      * Regular expression explanation:
      *
-     * <p>^[a-zA-Z_] - Starts with a letter, digit, or underscore
+     * <p>^\w - Starts with a letter, digit, or underscore
      *
-     * <p>[a-zA-Z0-9_/=-]{0,63} - Followed by 0 to 63 characters (making the total length at most
-     * 64) of letters (both cases), digits, underscores, slashes, hyphens, or equals signs
+     * <p>[\w/=-]{0,63} - Followed by 0 to 63 characters (making the total length at most 64) of
+     * letters (both cases), digits, underscores, slashes, hyphens, or equals signs
      *
      * <p>$ - End of the string
      */

--- a/core/src/main/java/com/datastrato/gravitino/metalake/MetalakeManager.java
+++ b/core/src/main/java/com/datastrato/gravitino/metalake/MetalakeManager.java
@@ -4,7 +4,6 @@
  */
 package com.datastrato.gravitino.metalake;
 
-import com.datastrato.gravitino.Entity;
 import com.datastrato.gravitino.Entity.EntityType;
 import com.datastrato.gravitino.EntityAlreadyExistsException;
 import com.datastrato.gravitino.EntityStore;
@@ -104,11 +103,6 @@ public class MetalakeManager implements MetalakeDispatcher {
       throws MetalakeAlreadyExistsException {
     long uid = idGenerator.nextId();
     StringIdentifier stringId = StringIdentifier.fromId(uid);
-
-    if (Entity.SYSTEM_METALAKE_RESERVED_NAME.equals(ident.name())) {
-      throw new IllegalArgumentException(
-          "Can't create a metalake with with reserved name `system`");
-    }
 
     BaseMetalake metalake =
         BaseMetalake.builder()

--- a/core/src/main/java/com/datastrato/gravitino/metalake/MetalakeNormalizeDispatcher.java
+++ b/core/src/main/java/com/datastrato/gravitino/metalake/MetalakeNormalizeDispatcher.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.metalake;
+
+import static com.datastrato.gravitino.Entity.SYSTEM_METALAKE_RESERVED_NAME;
+
+import com.datastrato.gravitino.Metalake;
+import com.datastrato.gravitino.MetalakeChange;
+import com.datastrato.gravitino.NameIdentifier;
+import com.datastrato.gravitino.exceptions.MetalakeAlreadyExistsException;
+import com.datastrato.gravitino.exceptions.NoSuchMetalakeException;
+import com.google.common.collect.ImmutableSet;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+
+public class MetalakeNormalizeDispatcher implements MetalakeDispatcher {
+  private static final Set<String> RESERVED_WORDS = ImmutableSet.of(SYSTEM_METALAKE_RESERVED_NAME);
+  /**
+   * Regular expression explanation:
+   *
+   * <p>^[a-zA-Z_] - Starts with a letter, digit, or underscore
+   *
+   * <p>[a-zA-Z0-9_]{0,63} - Followed by 0 to 63 characters (making the total length at most 64) of
+   * letters (both cases), digits, underscores
+   *
+   * <p>$ - End of the string
+   */
+  private static final String METALAKE_NAME_PATTERN = "^\\w[\\w]{0,63}$";
+
+  private final MetalakeDispatcher dispatcher;
+
+  public MetalakeNormalizeDispatcher(MetalakeDispatcher dispatcher) {
+    this.dispatcher = dispatcher;
+  }
+
+  @Override
+  public Metalake[] listMetalakes() {
+    return dispatcher.listMetalakes();
+  }
+
+  @Override
+  public Metalake loadMetalake(NameIdentifier ident) throws NoSuchMetalakeException {
+    return dispatcher.loadMetalake(ident);
+  }
+
+  @Override
+  public boolean metalakeExists(NameIdentifier ident) {
+    return dispatcher.metalakeExists(ident);
+  }
+
+  @Override
+  public Metalake createMetalake(
+      NameIdentifier ident, String comment, Map<String, String> properties)
+      throws MetalakeAlreadyExistsException {
+    validateMetalakeName(ident.name());
+    return dispatcher.createMetalake(ident, comment, properties);
+  }
+
+  @Override
+  public Metalake alterMetalake(NameIdentifier ident, MetalakeChange... changes)
+      throws NoSuchMetalakeException, IllegalArgumentException {
+    Arrays.stream(changes)
+        .forEach(
+            change -> {
+              if (change instanceof MetalakeChange.RenameMetalake) {
+                validateMetalakeName(((MetalakeChange.RenameMetalake) change).getNewName());
+              }
+            });
+    return dispatcher.alterMetalake(ident, changes);
+  }
+
+  @Override
+  public boolean dropMetalake(NameIdentifier ident) {
+    // For compatibility reasons, we only validate the metalake name when creating and altering a
+    // metalake.
+    return dispatcher.dropMetalake(ident);
+  }
+
+  private void validateMetalakeName(String name) {
+    if (RESERVED_WORDS.contains(name)) {
+      throw new IllegalArgumentException("The metalake name '" + name + "' is reserved.");
+    }
+    if (!name.matches(METALAKE_NAME_PATTERN)) {
+      throw new IllegalArgumentException("The metalake name '" + name + "' is illegal.");
+    }
+  }
+}

--- a/core/src/main/java/com/datastrato/gravitino/metalake/MetalakeNormalizeDispatcher.java
+++ b/core/src/main/java/com/datastrato/gravitino/metalake/MetalakeNormalizeDispatcher.java
@@ -21,10 +21,10 @@ public class MetalakeNormalizeDispatcher implements MetalakeDispatcher {
   /**
    * Regular expression explanation:
    *
-   * <p>^[a-zA-Z_] - Starts with a letter, digit, or underscore
+   * <p>^[\w] - Starts with a letter, digit, or underscore
    *
-   * <p>[a-zA-Z0-9_]{0,63} - Followed by 0 to 63 characters (making the total length at most 64) of
-   * letters (both cases), digits, underscores
+   * <p>[\w]{0,63} - Followed by 0 to 63 characters (making the total length at most 64) of letters
+   * (both cases), digits, underscores
    *
    * <p>$ - End of the string
    */

--- a/core/src/test/java/com/datastrato/gravitino/catalog/TestCatalogNormalizeDispatcher.java
+++ b/core/src/test/java/com/datastrato/gravitino/catalog/TestCatalogNormalizeDispatcher.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.catalog;
+
+import static com.datastrato.gravitino.Catalog.Type.RELATIONAL;
+import static com.datastrato.gravitino.Entity.SECURABLE_ENTITY_RESERVED_NAME;
+
+import com.datastrato.gravitino.CatalogChange;
+import com.datastrato.gravitino.Config;
+import com.datastrato.gravitino.Configs;
+import com.datastrato.gravitino.EntityStore;
+import com.datastrato.gravitino.NameIdentifier;
+import com.datastrato.gravitino.meta.AuditInfo;
+import com.datastrato.gravitino.meta.BaseMetalake;
+import com.datastrato.gravitino.meta.SchemaVersion;
+import com.datastrato.gravitino.storage.RandomIdGenerator;
+import com.datastrato.gravitino.storage.memory.TestMemoryEntityStore;
+import java.io.IOException;
+import java.time.Instant;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class TestCatalogNormalizeDispatcher {
+  private static CatalogNormalizeDispatcher catalogNormalizeDispatcher;
+  private static CatalogManager catalogManager;
+  private static EntityStore entityStore;
+  private static final String metalake = "metalake";
+  private static final BaseMetalake metalakeEntity =
+      BaseMetalake.builder()
+          .withId(1L)
+          .withName(metalake)
+          .withAuditInfo(
+              AuditInfo.builder().withCreator("test").withCreateTime(Instant.now()).build())
+          .withVersion(SchemaVersion.V_0_1)
+          .build();
+
+  @BeforeAll
+  public static void setUp() throws IOException {
+    Config config = new Config(false) {};
+    config.set(Configs.CATALOG_LOAD_ISOLATED, false);
+
+    entityStore = new TestMemoryEntityStore.InMemoryEntityStore();
+    entityStore.initialize(config);
+    entityStore.setSerDe(null);
+
+    entityStore.put(metalakeEntity, true);
+
+    catalogManager = new CatalogManager(config, entityStore, new RandomIdGenerator());
+    catalogManager = Mockito.spy(catalogManager);
+    catalogNormalizeDispatcher = new CatalogNormalizeDispatcher(catalogManager);
+  }
+
+  @BeforeEach
+  @AfterEach
+  void reset() throws IOException {
+    ((TestMemoryEntityStore.InMemoryEntityStore) entityStore).clear();
+    entityStore.put(metalakeEntity, true);
+  }
+
+  @AfterAll
+  public static void tearDown() throws Exception {
+    if (entityStore != null) {
+      entityStore.close();
+      entityStore = null;
+    }
+
+    if (catalogManager != null) {
+      catalogManager.close();
+      catalogManager = null;
+    }
+  }
+
+  @Test
+  public void testNameSpc() {
+    NameIdentifier catalogIdent1 = NameIdentifier.of(metalake, SECURABLE_ENTITY_RESERVED_NAME);
+    Exception exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                catalogNormalizeDispatcher.createCatalog(
+                    catalogIdent1, RELATIONAL, "test", null, null));
+    Assertions.assertEquals("The catalog name '*' is reserved.", exception.getMessage());
+
+    NameIdentifier catalogIdent2 = NameIdentifier.of(metalake, "a-b");
+    exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                catalogNormalizeDispatcher.createCatalog(
+                    catalogIdent2, RELATIONAL, "test", null, null));
+    Assertions.assertEquals("The catalog name 'a-b' is illegal.", exception.getMessage());
+
+    exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                catalogNormalizeDispatcher.alterCatalog(
+                    catalogIdent2, CatalogChange.rename("a-b")));
+    Assertions.assertEquals("The catalog name 'a-b' is illegal.", exception.getMessage());
+  }
+}

--- a/core/src/test/java/com/datastrato/gravitino/catalog/TestCatalogNormalizeDispatcher.java
+++ b/core/src/test/java/com/datastrato/gravitino/catalog/TestCatalogNormalizeDispatcher.java
@@ -78,7 +78,7 @@ public class TestCatalogNormalizeDispatcher {
   }
 
   @Test
-  public void testNameSpc() {
+  public void testNameSpec() {
     // Test for valid names
     String[] legalNames = {"catalog", "_catalog", "1_catalog", "_", "1"};
     for (String legalName : legalNames) {

--- a/core/src/test/java/com/datastrato/gravitino/metalake/TestMetalakeNormalizeDispatcher.java
+++ b/core/src/test/java/com/datastrato/gravitino/metalake/TestMetalakeNormalizeDispatcher.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.metalake;
+
+import static com.datastrato.gravitino.Entity.SYSTEM_METALAKE_RESERVED_NAME;
+
+import com.datastrato.gravitino.Config;
+import com.datastrato.gravitino.EntityStore;
+import com.datastrato.gravitino.MetalakeChange;
+import com.datastrato.gravitino.NameIdentifier;
+import com.datastrato.gravitino.storage.RandomIdGenerator;
+import com.datastrato.gravitino.storage.memory.TestMemoryEntityStore;
+import java.io.IOException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class TestMetalakeNormalizeDispatcher {
+  private static MetalakeNormalizeDispatcher metalakeNormalizeDispatcher;
+  private static EntityStore entityStore;
+
+  @BeforeAll
+  public static void setUp() {
+    Config config = new Config(false) {};
+
+    entityStore = new TestMemoryEntityStore.InMemoryEntityStore();
+    entityStore.initialize(config);
+    entityStore.setSerDe(null);
+
+    MetalakeManager metalakeManager = new MetalakeManager(entityStore, new RandomIdGenerator());
+    metalakeNormalizeDispatcher = new MetalakeNormalizeDispatcher(metalakeManager);
+  }
+
+  @AfterAll
+  public static void tearDown() throws IOException {
+    if (entityStore != null) {
+      entityStore.close();
+      entityStore = null;
+    }
+  }
+
+  @Test
+  public void testNameSpc() {
+    NameIdentifier metalakeIdent1 = NameIdentifier.of(SYSTEM_METALAKE_RESERVED_NAME);
+    Exception exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> metalakeNormalizeDispatcher.createMetalake(metalakeIdent1, null, null));
+    Assertions.assertEquals("The metalake name 'system' is reserved.", exception.getMessage());
+
+    NameIdentifier metalakeIdent2 = NameIdentifier.of("a-b");
+    exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> metalakeNormalizeDispatcher.createMetalake(metalakeIdent2, null, null));
+    Assertions.assertEquals("The metalake name 'a-b' is illegal.", exception.getMessage());
+
+    exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                metalakeNormalizeDispatcher.alterMetalake(
+                    metalakeIdent2, MetalakeChange.rename("a-b")));
+    Assertions.assertEquals("The metalake name 'a-b' is illegal.", exception.getMessage());
+  }
+}

--- a/core/src/test/java/com/datastrato/gravitino/metalake/TestMetalakeNormalizeDispatcher.java
+++ b/core/src/test/java/com/datastrato/gravitino/metalake/TestMetalakeNormalizeDispatcher.java
@@ -43,7 +43,7 @@ public class TestMetalakeNormalizeDispatcher {
   }
 
   @Test
-  public void testNameSpc() {
+  public void testNameSpec() {
     // Test for valid names
     String[] legalNames = {"metalake", "_metalake", "1_metalake", "_", "1"};
     for (String legalName : legalNames) {

--- a/core/src/test/java/com/datastrato/gravitino/metalake/TestMetalakeNormalizeDispatcher.java
+++ b/core/src/test/java/com/datastrato/gravitino/metalake/TestMetalakeNormalizeDispatcher.java
@@ -8,7 +8,7 @@ import static com.datastrato.gravitino.Entity.SYSTEM_METALAKE_RESERVED_NAME;
 
 import com.datastrato.gravitino.Config;
 import com.datastrato.gravitino.EntityStore;
-import com.datastrato.gravitino.MetalakeChange;
+import com.datastrato.gravitino.Metalake;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.storage.RandomIdGenerator;
 import com.datastrato.gravitino.storage.memory.TestMemoryEntityStore;
@@ -44,6 +44,15 @@ public class TestMetalakeNormalizeDispatcher {
 
   @Test
   public void testNameSpc() {
+    // Test for valid names
+    String[] legalNames = {"metalake", "_metalake", "1_metalake", "_", "1"};
+    for (String legalName : legalNames) {
+      NameIdentifier metalakeIdent = NameIdentifier.of(legalName);
+      Metalake metalake = metalakeNormalizeDispatcher.createMetalake(metalakeIdent, null, null);
+      Assertions.assertEquals(legalName, metalake.name());
+    }
+
+    // Test for illegal and reserved names
     NameIdentifier metalakeIdent1 = NameIdentifier.of(SYSTEM_METALAKE_RESERVED_NAME);
     Exception exception =
         Assertions.assertThrows(
@@ -51,19 +60,45 @@ public class TestMetalakeNormalizeDispatcher {
             () -> metalakeNormalizeDispatcher.createMetalake(metalakeIdent1, null, null));
     Assertions.assertEquals("The metalake name 'system' is reserved.", exception.getMessage());
 
-    NameIdentifier metalakeIdent2 = NameIdentifier.of("a-b");
-    exception =
-        Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () -> metalakeNormalizeDispatcher.createMetalake(metalakeIdent2, null, null));
-    Assertions.assertEquals("The metalake name 'a-b' is illegal.", exception.getMessage());
-
-    exception =
-        Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                metalakeNormalizeDispatcher.alterMetalake(
-                    metalakeIdent2, MetalakeChange.rename("a-b")));
-    Assertions.assertEquals("The metalake name 'a-b' is illegal.", exception.getMessage());
+    String[] illegalNames = {
+      "metalake-xxx",
+      "metalake/xxx",
+      "metalake.xxx",
+      "metalake@xxx",
+      "metalake#xxx",
+      "metalake$xxx",
+      "metalake%xxx",
+      "metalake^xxx",
+      "metalake&xxx",
+      "metalake*xxx",
+      "metalake+xxx",
+      "metalake=xxx",
+      "metalake|xxx",
+      "metalake\\xxx",
+      "metalake`xxx",
+      "metalake~xxx",
+      "metalake!xxx",
+      "metalake\"xxx",
+      "metalake'xxx",
+      "metalake<xxx",
+      "metalake>xxx",
+      "metalake,xxx",
+      "metalake?xxx",
+      "metalake:xxx",
+      "metalake;xxx",
+      "metalake[xxx",
+      "metalake]xxx",
+      "metalake{xxx",
+      "metalake}xxx"
+    };
+    for (String illegalName : illegalNames) {
+      NameIdentifier metalakeIdent = NameIdentifier.of(illegalName);
+      exception =
+          Assertions.assertThrows(
+              IllegalArgumentException.class,
+              () -> metalakeNormalizeDispatcher.createMetalake(metalakeIdent, null, null));
+      Assertions.assertEquals(
+          "The metalake name '" + illegalName + "' is illegal.", exception.getMessage());
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

 - Check name spec when creating and renaming catalogs or metalakes

### Why are the changes needed?

Fix: #3202 

### Does this PR introduce _any_ user-facing change?

yes, catalogs and metadata lakes have a much stricter name specification.

### How was this patch tested?

tests added
