### PR TITLE
[#2921] fix(catalog-lakehouse-iceberg): Add width param to bucket and truncate functions in Gravitino SortOrder

### DIFF
--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/FromIcebergSortOrder.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/FromIcebergSortOrder.java
@@ -6,6 +6,7 @@ package com.datastrato.gravitino.catalog.lakehouse.iceberg.converter;
 
 import com.datastrato.gravitino.rel.expressions.FunctionExpression;
 import com.datastrato.gravitino.rel.expressions.NamedReference;
+import com.datastrato.gravitino.rel.expressions.literals.Literals;
 import com.datastrato.gravitino.rel.expressions.sorts.NullOrdering;
 import com.datastrato.gravitino.rel.expressions.sorts.SortOrder;
 import com.datastrato.gravitino.rel.expressions.sorts.SortOrders;
@@ -38,13 +39,13 @@ public class FromIcebergSortOrder implements SortOrderVisitor<SortOrder> {
   @Override
   public SortOrder bucket(
       String sourceName, int id, int width, SortDirection direction, NullOrder nullOrder) {
-    return functionSortOrder("bucket", id, direction, nullOrder);
+    return functionSortOrder("bucket", width, id, direction, nullOrder);
   }
 
   @Override
   public SortOrder truncate(
       String sourceName, int id, int width, SortDirection direction, NullOrder nullOrder) {
-    return functionSortOrder("truncate", id, direction, nullOrder);
+    return functionSortOrder("truncate", width, id, direction, nullOrder);
   }
 
   @Override
@@ -76,6 +77,15 @@ public class FromIcebergSortOrder implements SortOrderVisitor<SortOrder> {
       String name, int id, SortDirection direction, NullOrder nullOrder) {
     return SortOrders.of(
         FunctionExpression.of(name, NamedReference.field(idToName.get(id))),
+        toGravitino(direction),
+        toGravitino(nullOrder));
+  }
+
+  private SortOrder functionSortOrder(
+      String name, int width, int id, SortDirection direction, NullOrder nullOrder) {
+    return SortOrders.of(
+        FunctionExpression.of(
+            name, Literals.integerLiteral(width), NamedReference.field(idToName.get(id))),
         toGravitino(direction),
         toGravitino(nullOrder));
   }

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/ToIcebergSortOrder.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/ToIcebergSortOrder.java
@@ -11,6 +11,7 @@ import com.datastrato.gravitino.rel.expressions.literals.Literal;
 import com.datastrato.gravitino.rel.expressions.sorts.NullOrdering;
 import com.datastrato.gravitino.rel.expressions.sorts.SortDirection;
 import com.datastrato.gravitino.rel.expressions.sorts.SortOrder;
+import com.datastrato.gravitino.rel.types.Types;
 import com.google.common.base.Preconditions;
 import java.util.Locale;
 import org.apache.commons.lang3.ArrayUtils;
@@ -58,9 +59,10 @@ public class ToIcebergSortOrder {
 
             Expression firstArg = sortFunc.arguments()[0];
             Preconditions.checkArgument(
-                firstArg instanceof Literal && ((Literal<?>) firstArg).value() instanceof Integer,
+                firstArg instanceof Literal
+                    && ((Literal<?>) firstArg).dataType() instanceof Types.IntegerType,
                 "Bucket sort's first argument must be a integer literal");
-            int numBuckets = (Integer) ((Literal<?>) firstArg).value();
+            int numBuckets = Integer.parseInt(String.valueOf(((Literal<?>) firstArg).value()));
 
             Expression secondArg = sortFunc.arguments()[1];
             Preconditions.checkArgument(
@@ -77,9 +79,10 @@ public class ToIcebergSortOrder {
 
             firstArg = sortFunc.arguments()[0];
             Preconditions.checkArgument(
-                firstArg instanceof Literal && ((Literal<?>) firstArg).value() instanceof Integer,
+                firstArg instanceof Literal
+                    && ((Literal<?>) firstArg).dataType() instanceof Types.IntegerType,
                 "Truncate sort's first argument must be a integer literal");
-            int width = (Integer) ((Literal<?>) firstArg).value();
+            int width = Integer.parseInt(String.valueOf(((Literal<?>) firstArg).value()));
 
             secondArg = sortFunc.arguments()[1];
             Preconditions.checkArgument(

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergTable.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergTable.java
@@ -21,9 +21,11 @@ import com.datastrato.gravitino.rel.Column;
 import com.datastrato.gravitino.rel.Table;
 import com.datastrato.gravitino.rel.TableCatalog;
 import com.datastrato.gravitino.rel.TableChange;
+import com.datastrato.gravitino.rel.expressions.FunctionExpression;
 import com.datastrato.gravitino.rel.expressions.NamedReference;
 import com.datastrato.gravitino.rel.expressions.distributions.Distribution;
 import com.datastrato.gravitino.rel.expressions.distributions.Distributions;
+import com.datastrato.gravitino.rel.expressions.literals.Literals;
 import com.datastrato.gravitino.rel.expressions.sorts.NullOrdering;
 import com.datastrato.gravitino.rel.expressions.sorts.SortDirection;
 import com.datastrato.gravitino.rel.expressions.sorts.SortOrder;
@@ -54,6 +56,7 @@ public class TestIcebergTable {
   private static final String ICEBERG_SCHEMA_NAME = "test_schema";
   private static final String ICEBERG_COMMENT = "test_comment";
   private static IcebergCatalog icebergCatalog;
+  private static IcebergCatalogOperations icebergCatalogOperations;
   private static IcebergSchema icebergSchema;
   private static final NameIdentifier schemaIdent =
       NameIdentifier.of(META_LAKE_NAME, ICEBERG_CATALOG_NAME, ICEBERG_SCHEMA_NAME);
@@ -66,14 +69,13 @@ public class TestIcebergTable {
 
   @AfterEach
   private void resetSchema() {
-    TableCatalog tableCatalog = icebergCatalog.asTableCatalog();
     NameIdentifier[] nameIdentifiers =
-        tableCatalog.listTables(
+        icebergCatalogOperations.listTables(
             Namespace.of(ArrayUtils.add(schemaIdent.namespace().levels(), schemaIdent.name())));
     if (ArrayUtils.isNotEmpty(nameIdentifiers)) {
-      Arrays.stream(nameIdentifiers).forEach(tableCatalog::dropTable);
+      Arrays.stream(nameIdentifiers).forEach(icebergCatalogOperations::dropTable);
     }
-    icebergCatalog.asSchemas().dropSchema(schemaIdent, false);
+    icebergCatalogOperations.dropSchema(schemaIdent, false);
     initIcebergSchema();
   }
 
@@ -82,9 +84,7 @@ public class TestIcebergTable {
     properties.put("key1", "val1");
     properties.put("key2", "val2");
 
-    icebergSchema =
-        (IcebergSchema)
-            icebergCatalog.asSchemas().createSchema(schemaIdent, ICEBERG_COMMENT, properties);
+    icebergSchema = icebergCatalogOperations.createSchema(schemaIdent, ICEBERG_COMMENT, properties);
   }
 
   private static void initIcebergCatalog() {
@@ -92,6 +92,7 @@ public class TestIcebergTable {
 
     Map<String, String> conf = Maps.newHashMap();
     icebergCatalog = new IcebergCatalog().withCatalogConf(conf).withCatalogEntity(entity);
+    icebergCatalogOperations = (IcebergCatalogOperations) icebergCatalog.ops();
   }
 
   private static CatalogEntity createDefaultCatalogEntity() {
@@ -113,7 +114,17 @@ public class TestIcebergTable {
   private SortOrder[] createSortOrder() {
     return new SortOrder[] {
       SortOrders.of(
-          NamedReference.field("col_2"), SortDirection.DESCENDING, NullOrdering.NULLS_FIRST)
+          NamedReference.field("col_2"), SortDirection.DESCENDING, NullOrdering.NULLS_FIRST),
+      SortOrders.of(
+          FunctionExpression.of(
+              "bucket", Literals.integerLiteral(10), NamedReference.field("col_1")),
+          SortDirection.DESCENDING,
+          NullOrdering.NULLS_FIRST),
+      SortOrders.of(
+          FunctionExpression.of(
+              "truncate", Literals.integerLiteral(1), NamedReference.field("col_1")),
+          SortDirection.DESCENDING,
+          NullOrdering.NULLS_FIRST)
     };
   }
 
@@ -163,22 +174,20 @@ public class TestIcebergTable {
 
     SortOrder[] sortOrders = createSortOrder();
     Table table =
-        icebergCatalog
-            .asTableCatalog()
-            .createTable(
-                tableIdentifier,
-                columns,
-                ICEBERG_COMMENT,
-                properties,
-                new Transform[0],
-                Distributions.NONE,
-                sortOrders);
+        icebergCatalogOperations.createTable(
+            tableIdentifier,
+            columns,
+            ICEBERG_COMMENT,
+            properties,
+            new Transform[0],
+            Distributions.NONE,
+            sortOrders);
     Assertions.assertEquals(tableIdentifier.name(), table.name());
     Assertions.assertEquals(ICEBERG_COMMENT, table.comment());
     Assertions.assertEquals("val1", table.properties().get("key1"));
     Assertions.assertEquals("val2", table.properties().get("key2"));
 
-    Table loadedTable = icebergCatalog.asTableCatalog().loadTable(tableIdentifier);
+    Table loadedTable = icebergCatalogOperations.loadTable(tableIdentifier);
 
     Assertions.assertEquals("val1", loadedTable.properties().get("key1"));
     Assertions.assertEquals("val2", loadedTable.properties().get("key2"));
@@ -186,21 +195,22 @@ public class TestIcebergTable {
     Assertions.assertFalse(loadedTable.columns()[1].nullable());
     Assertions.assertFalse(loadedTable.columns()[2].nullable());
 
-    Assertions.assertTrue(icebergCatalog.asTableCatalog().tableExists(tableIdentifier));
-    NameIdentifier[] tableIdents =
-        icebergCatalog.asTableCatalog().listTables(tableIdentifier.namespace());
+    Assertions.assertTrue(icebergCatalogOperations.tableExists(tableIdentifier));
+    NameIdentifier[] tableIdents = icebergCatalogOperations.listTables(tableIdentifier.namespace());
     Assertions.assertTrue(Arrays.asList(tableIdents).contains(tableIdentifier));
 
     Assertions.assertEquals(sortOrders.length, loadedTable.sortOrder().length);
     for (int i = 0; i < loadedTable.sortOrder().length; i++) {
       Assertions.assertEquals(sortOrders[i].direction(), loadedTable.sortOrder()[i].direction());
       Assertions.assertEquals(
+          (sortOrders[i]).nullOrdering(), loadedTable.sortOrder()[i].nullOrdering());
+      Assertions.assertEquals(
           (sortOrders[i]).expression(), loadedTable.sortOrder()[i].expression());
     }
     // Compare sort and order
 
     // Test exception
-    TableCatalog tableCatalog = icebergCatalog.asTableCatalog();
+    TableCatalog tableCatalog = icebergCatalogOperations;
     Throwable exception =
         Assertions.assertThrows(
             TableAlreadyExistsException.class,
@@ -245,28 +255,26 @@ public class TestIcebergTable {
         };
 
     Table table =
-        icebergCatalog
-            .asTableCatalog()
-            .createTable(tableIdentifier, columns, ICEBERG_COMMENT, properties, partitions);
+        icebergCatalogOperations.createTable(
+            tableIdentifier, columns, ICEBERG_COMMENT, properties, partitions);
     Assertions.assertEquals(tableIdentifier.name(), table.name());
     Assertions.assertEquals(ICEBERG_COMMENT, table.comment());
     Assertions.assertEquals("val1", table.properties().get("key1"));
     Assertions.assertEquals("val2", table.properties().get("key2"));
     Assertions.assertArrayEquals(partitions, table.partitioning());
 
-    Table loadedTable = icebergCatalog.asTableCatalog().loadTable(tableIdentifier);
+    Table loadedTable = icebergCatalogOperations.loadTable(tableIdentifier);
 
     Assertions.assertEquals("val1", loadedTable.properties().get("key1"));
     Assertions.assertEquals("val2", loadedTable.properties().get("key2"));
     Assertions.assertArrayEquals(partitions, loadedTable.partitioning());
 
-    Assertions.assertTrue(icebergCatalog.asTableCatalog().tableExists(tableIdentifier));
-    NameIdentifier[] tableIdents =
-        icebergCatalog.asTableCatalog().listTables(tableIdentifier.namespace());
+    Assertions.assertTrue(icebergCatalogOperations.tableExists(tableIdentifier));
+    NameIdentifier[] tableIdents = icebergCatalogOperations.listTables(tableIdentifier.namespace());
     Assertions.assertTrue(Arrays.asList(tableIdents).contains(tableIdentifier));
 
     // Test exception
-    TableCatalog tableCatalog = icebergCatalog.asTableCatalog();
+    TableCatalog tableCatalog = icebergCatalogOperations;
     Transform[] partitions1 = new Transform[] {day(col2.name())};
     Throwable exception =
         Assertions.assertThrows(
@@ -319,26 +327,24 @@ public class TestIcebergTable {
             .build();
     Column[] columns = new Column[] {col1, col2};
 
-    icebergCatalog
-        .asTableCatalog()
-        .createTable(
-            tableIdentifier,
-            columns,
-            ICEBERG_COMMENT,
-            properties,
-            new Transform[0],
-            Distributions.NONE,
-            new SortOrder[0]);
+    icebergCatalogOperations.createTable(
+        tableIdentifier,
+        columns,
+        ICEBERG_COMMENT,
+        properties,
+        new Transform[0],
+        Distributions.NONE,
+        new SortOrder[0]);
 
-    Assertions.assertTrue(icebergCatalog.asTableCatalog().tableExists(tableIdentifier));
-    icebergCatalog.asTableCatalog().dropTable(tableIdentifier);
-    Assertions.assertFalse(icebergCatalog.asTableCatalog().tableExists(tableIdentifier));
+    Assertions.assertTrue(icebergCatalogOperations.tableExists(tableIdentifier));
+    icebergCatalogOperations.dropTable(tableIdentifier);
+    Assertions.assertFalse(icebergCatalogOperations.tableExists(tableIdentifier));
   }
 
   @Test
   public void testListTableException() {
     Namespace tableNs = Namespace.of("metalake", icebergCatalog.name(), "not_exist_db");
-    TableCatalog tableCatalog = icebergCatalog.asTableCatalog();
+    TableCatalog tableCatalog = icebergCatalogOperations;
     Throwable exception =
         Assertions.assertThrows(
             NoSuchSchemaException.class, () -> tableCatalog.listTables(tableNs));
@@ -373,66 +379,68 @@ public class TestIcebergTable {
     SortOrder[] sortOrders = createSortOrder();
 
     Table createdTable =
-        icebergCatalog
-            .asTableCatalog()
-            .createTable(
-                tableIdentifier,
-                columns,
-                ICEBERG_COMMENT,
-                properties,
-                new Transform[0],
-                distribution,
-                sortOrders);
-    Assertions.assertTrue(icebergCatalog.asTableCatalog().tableExists(tableIdentifier));
+        icebergCatalogOperations.createTable(
+            tableIdentifier,
+            columns,
+            ICEBERG_COMMENT,
+            properties,
+            new Transform[0],
+            distribution,
+            sortOrders);
+    Assertions.assertTrue(icebergCatalogOperations.tableExists(tableIdentifier));
 
-    TableCatalog tableCatalog = icebergCatalog.asTableCatalog();
     TableChange update = TableChange.updateComment(ICEBERG_COMMENT + "_new");
     TableChange rename = TableChange.rename("test_iceberg_table_new");
     Throwable exception =
         Assertions.assertThrows(
             IllegalArgumentException.class,
-            () -> tableCatalog.alterTable(tableIdentifier, update, rename));
+            () -> icebergCatalogOperations.alterTable(tableIdentifier, update, rename));
     Assertions.assertTrue(
         exception.getMessage().contains("The operation to change the table name cannot"));
 
     // test alter
-    icebergCatalog
-        .asTableCatalog()
-        .alterTable(
-            tableIdentifier,
-            TableChange.updateComment(ICEBERG_COMMENT + "_new"),
-            TableChange.removeProperty("key1"),
-            TableChange.setProperty("key2", "val2_new"),
-            // columns current format: [col_1:I8:comment, col_2:DATE:comment]
-            TableChange.addColumn(new String[] {"col_3"}, Types.StringType.get()),
-            // columns current format: [col_1:I8:comment, col_2:DATE:comment, col_3:STRING:null]
-            TableChange.renameColumn(new String[] {"col_2"}, "col_2_new"),
-            // columns current format: [col_1:I8:comment, col_2_new:DATE:comment, col_3:STRING:null]
-            TableChange.updateColumnComment(new String[] {"col_1"}, ICEBERG_COMMENT + "_new"),
-            // columns current format: [col_1:I8:comment_new, col_2_new:DATE:comment,
-            // col_3:STRING:null]
-            TableChange.updateColumnType(new String[] {"col_1"}, Types.IntegerType.get()),
-            // columns current format: [col_1:I32:comment_new, col_2_new:DATE:comment,
-            // col_3:STRING:null]
-            TableChange.updateColumnPosition(
-                new String[] {"col_2"}, TableChange.ColumnPosition.first())
-            // columns current: [col_2_new:DATE:comment, col_1:I32:comment_new, col_3:STRING:null]
-            );
+    icebergCatalogOperations.alterTable(
+        tableIdentifier,
+        TableChange.updateComment(ICEBERG_COMMENT + "_new"),
+        TableChange.removeProperty("key1"),
+        TableChange.setProperty("key2", "val2_new"),
+        // columns current format: [col_1:I8:comment, col_2:DATE:comment]
+        TableChange.addColumn(new String[] {"col_3"}, Types.StringType.get()),
+        // columns current format: [col_1:I8:comment, col_2:DATE:comment, col_3:STRING:null]
+        TableChange.renameColumn(new String[] {"col_2"}, "col_2_new"),
+        // columns current format: [col_1:I8:comment, col_2_new:DATE:comment, col_3:STRING:null]
+        TableChange.updateColumnComment(new String[] {"col_1"}, ICEBERG_COMMENT + "_new"),
+        // columns current format: [col_1:I8:comment_new, col_2_new:DATE:comment,
+        // col_3:STRING:null]
+        TableChange.updateColumnType(new String[] {"col_1"}, Types.IntegerType.get()),
+        // columns current format: [col_1:I32:comment_new, col_2_new:DATE:comment,
+        // col_3:STRING:null]
+        TableChange.updateColumnPosition(new String[] {"col_2"}, TableChange.ColumnPosition.first())
+        // columns current: [col_2_new:DATE:comment, col_1:I32:comment_new, col_3:STRING:null]
+        );
 
-    icebergCatalog
-        .asTableCatalog()
-        .alterTable(tableIdentifier, TableChange.rename("test_iceberg_table_new"));
+    icebergCatalogOperations.alterTable(
+        tableIdentifier, TableChange.rename("test_iceberg_table_new"));
 
     Table alteredTable =
-        icebergCatalog
-            .asTableCatalog()
-            .loadTable(NameIdentifier.of(tableIdentifier.namespace(), "test_iceberg_table_new"));
+        icebergCatalogOperations.loadTable(
+            NameIdentifier.of(tableIdentifier.namespace(), "test_iceberg_table_new"));
 
     Assertions.assertEquals(ICEBERG_COMMENT + "_new", alteredTable.comment());
     Assertions.assertFalse(alteredTable.properties().containsKey("key1"));
     Assertions.assertEquals("val2_new", alteredTable.properties().get("key2"));
 
+    sortOrders[0] =
+        SortOrders.of(
+            NamedReference.field("col_2_new"), SortDirection.DESCENDING, NullOrdering.NULLS_FIRST);
     Assertions.assertEquals(sortOrders.length, alteredTable.sortOrder().length);
+    for (int i = 0; i < alteredTable.sortOrder().length; i++) {
+      Assertions.assertEquals(sortOrders[i].direction(), alteredTable.sortOrder()[i].direction());
+      Assertions.assertEquals(
+          (sortOrders[i]).nullOrdering(), alteredTable.sortOrder()[i].nullOrdering());
+      Assertions.assertEquals(
+          (sortOrders[i]).expression(), alteredTable.sortOrder()[i].expression());
+    }
 
     Column[] expected =
         new Column[] {
@@ -455,17 +463,14 @@ public class TestIcebergTable {
     Assertions.assertArrayEquals(expected, alteredTable.columns());
 
     // test delete column change
-    icebergCatalog
-        .asTableCatalog()
-        .alterTable(
-            NameIdentifier.of(tableIdentifier.namespace(), "test_iceberg_table_new"),
-            TableChange.deleteColumn(new String[] {"col_1"}, false));
+    icebergCatalogOperations.alterTable(
+        NameIdentifier.of(tableIdentifier.namespace(), "test_iceberg_table_new"),
+        TableChange.deleteColumn(new String[] {"col_3"}, false));
     Table alteredTable1 =
-        icebergCatalog
-            .asTableCatalog()
-            .loadTable(NameIdentifier.of(tableIdentifier.namespace(), "test_iceberg_table_new"));
+        icebergCatalogOperations.loadTable(
+            NameIdentifier.of(tableIdentifier.namespace(), "test_iceberg_table_new"));
     expected =
-        Arrays.stream(expected).filter(c -> !"col_1".equals(c.name())).toArray(Column[]::new);
+        Arrays.stream(expected).filter(c -> !"col_3".equals(c.name())).toArray(Column[]::new);
     Assertions.assertArrayEquals(expected, alteredTable1.columns());
 
     Assertions.assertNotNull(alteredTable.partitioning());

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/TestToIcebergSortOrder.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/TestToIcebergSortOrder.java
@@ -25,10 +25,12 @@ public class TestToIcebergSortOrder extends TestBaseConvert {
   @Test
   public void testToSortOrder() {
     SortOrder[] sortOrders = createSortOrder("col_1", "col_2", "col_3", "col_4", "col_5");
-    sortOrders = ArrayUtils.add(sortOrders, createFunctionSortOrder("day", "col_6"));
-    sortOrders = ArrayUtils.add(sortOrders, createFunctionSortOrder("hour", "col_7"));
-    sortOrders = ArrayUtils.add(sortOrders, createFunctionSortOrder("month", "col_8"));
-    sortOrders = ArrayUtils.add(sortOrders, createFunctionSortOrder("year", "col_9"));
+    sortOrders = ArrayUtils.add(sortOrders, createSortOrder("day", "col_6"));
+    sortOrders = ArrayUtils.add(sortOrders, createSortOrder("hour", "col_7"));
+    sortOrders = ArrayUtils.add(sortOrders, createSortOrder("month", "col_8"));
+    sortOrders = ArrayUtils.add(sortOrders, createSortOrder("year", "col_9"));
+    sortOrders = ArrayUtils.add(sortOrders, createSortOrder("bucket", 10, "col_10"));
+    sortOrders = ArrayUtils.add(sortOrders, createSortOrder("truncate", 2, "col_11"));
 
     Types.NestedField[] nestedFields =
         createNestedField("col_1", "col_2", "col_3", "col_4", "col_5");
@@ -40,6 +42,10 @@ public class TestToIcebergSortOrder extends TestBaseConvert {
         ArrayUtils.add(nestedFields, createNestedField(8, "col_8", Types.DateType.get()));
     nestedFields =
         ArrayUtils.add(nestedFields, createNestedField(9, "col_9", Types.DateType.get()));
+    nestedFields =
+        ArrayUtils.add(nestedFields, createNestedField(10, "col_10", Types.IntegerType.get()));
+    nestedFields =
+        ArrayUtils.add(nestedFields, createNestedField(11, "col_11", Types.StringType.get()));
     Schema schema = new Schema(nestedFields);
     org.apache.iceberg.SortOrder icebergSortOrder =
         ToIcebergSortOrder.toSortOrder(schema, sortOrders);
@@ -58,14 +64,6 @@ public class TestToIcebergSortOrder extends TestBaseConvert {
       String colName = idToName.get(sortField.sourceId());
       Assertions.assertTrue(sortOrderByName.containsKey(colName));
       SortOrder sortOrder = sortOrderByName.get(colName);
-      if (colName.equals("col_6")
-          || colName.equals("col_7")
-          || colName.equals("col_8")
-          || colName.equals("col_9")) {
-        Assertions.assertFalse(sortField.transform().isIdentity());
-      } else {
-        Assertions.assertTrue(sortField.transform().isIdentity());
-      }
       Assertions.assertEquals(
           sortOrder.direction() == SortDirection.ASCENDING
               ? org.apache.iceberg.SortDirection.ASC
@@ -76,6 +74,10 @@ public class TestToIcebergSortOrder extends TestBaseConvert {
               ? NullOrder.NULLS_FIRST
               : NullOrder.NULLS_LAST,
           sortField.nullOrder());
+      String icebergSortOrderString = getIcebergTransfromString(sortField, schema);
+      String gravitinoSortOrderString =
+          getGravitinoSortOrderExpressionString(sortOrder.expression());
+      Assertions.assertEquals(icebergSortOrderString, gravitinoSortOrderString);
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add width param to bucket and truncate functions in Gravitino SortOrder.
for example:
change `bucket([id]) `to `bucket(10, id)`
change `truncate([name]) `to `truncate(2, name)`


### Why are the changes needed?

SortOrder in Iceberg supports `FunctionExpression`, such as `year,
month, bucket, truncate, etc`.
`truncate` and `bucket` functions both have two parameters, such as
`bucket(10, col1), truncate(2, col2)`.

However, in gravitino, when converting an iceberg sortorder with
`bucket` or `truncate` to gravitino sortOrder, there is only one
parameter in `bucket` and `truncate` functions.

This picture shows the details of the parameters of the `bucket` and
`truncate` functions in gravitino sortorder, we can test it in
`com.datastrato.gravitino.catalog.lakehouse.iceberg.converter.TestFromIcebergSortOrder#testFromSortOrder`


![image](https://github.com/datastrato/gravitino/assets/94670132/06fd65f5-7d33-4197-8871-dda02fd70a26)

And if we want to convert the gravitino sortOrder with `bucket` or
`truncate` to iceberg sortOrder, we will get the following error as the
first param is missing.
```
java.lang.IllegalArgumentException: Bucket sort should have 2 arguments

    at com.google.common.base.Preconditions.checkArgument(Preconditions.java:143)
    at com.datastrato.gravitino.catalog.lakehouse.iceberg.converter.ToIcebergSortOrder.toSortOrder(ToIcebergSortOrder.java:56)
    at com.datastrato.gravitino.catalog.lakehouse.iceberg.converter.TestFromIcebergSortOrder.testFromSortOrder(TestFromIcebergSortOrder.java:86)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:725)
    at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
```


Fix: https://github.com/datastrato/gravitino/issues/2921

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
New UTs and ITs.