### PR TITLE
[#3521] fix(client-python): Fix `hash()` function with multiple variables issue in `name_identitifer`

### DIFF
--- a/clients/client-python/gravitino/name_identifier.py
+++ b/clients/client-python/gravitino/name_identifier.py
@@ -276,7 +276,7 @@ class NameIdentifier(DataClassJsonMixin):
         return self._namespace == other._namespace and self._name == other._name
 
     def __hash__(self):
-        return hash(self._namespace, self._name)
+        return hash((self._namespace, self._name))
 
     def __str__(self):
         if self.has_namespace():

--- a/clients/client-python/tests/unittests/test_name_identifier.py
+++ b/clients/client-python/tests/unittests/test_name_identifier.py
@@ -1,0 +1,22 @@
+"""
+Copyright 2024 Datastrato Pvt Ltd.
+This software is licensed under the Apache License version 2.
+"""
+
+import unittest
+
+from gravitino import NameIdentifier
+
+
+class TestNameIdentifier(unittest.TestCase):
+    def test_name_identifier_hash(self):
+        name_identifier1: NameIdentifier = NameIdentifier.of_fileset(
+            "test_metalake", "test_catalog", "test_schema", "test_fileset1"
+        )
+        name_identifier2: NameIdentifier = NameIdentifier.of_fileset(
+            "test_metalake", "test_catalog", "test_schema", "test_fileset2"
+        )
+        identifier_dict = {name_identifier1: "test1", name_identifier2: "test2"}
+
+        self.assertEqual("test1", identifier_dict.get(name_identifier1))
+        self.assertNotEqual("test2", identifier_dict.get(name_identifier1))


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix `hash()` function in `name_identifier`.

### Why are the changes needed?

Fix: #3521 

### How was this patch tested?

Add a ut.
