### PR TITLE
[#3058] improvement(client-python): Correct type specification of create_fileset function

### DIFF
--- a/clients/client-python/gravitino/catalog/fileset_catalog.py
+++ b/clients/client-python/gravitino/catalog/fileset_catalog.py
@@ -92,7 +92,7 @@ class FilesetCatalog(BaseSchemaCatalog):
         self,
         ident: NameIdentifier,
         comment: str,
-        type: Catalog.Type,
+        type: Fileset.Type,
         storage_location: str,
         properties: Dict[str, str],
     ) -> Fileset:


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

* Change the suggest type of `type` from `Catalog.Type` to `Fileset.Type`

### Why are the changes needed?

Fix: #3508 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

`./gradlew :clients:client-python:test`
