### PR TITLE
[#3336] improvement(test): make docker detection failure error messages more clear

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -696,7 +696,7 @@ fun printDockerCheckInfo() {
   println("Docker server status ............................................ [${if (dockerRunning) "running" else "stop"}]")
   if (OperatingSystem.current().isMacOsX()) {
     println("mac-docker-connector status ..................................... [${if (macDockerConnector) "running" else "stop"}]")
-    println("OrbStack status ................................................. [${if (isOrbStack) "yes" else "no"}]")
+    println("OrbStack status ................................................. [${if (dockerRunning && isOrbStack) "yes" else "no"}]")
   }
 
   val docker_it_test = project.extra["docker_it_test"] as? Boolean ?: false

--- a/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
+++ b/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
@@ -51,10 +51,9 @@ public class ContainerSuite implements Closeable {
 
   protected static final CloseableGroup closer = CloseableGroup.create();
 
-  private ContainerSuite() {
-    try {
+  private static void init() {
+    try (DockerClient dockerClient = DockerClientFactory.instance().client()) {
       // Check if docker is available
-      DockerClient dockerClient = DockerClientFactory.instance().client();
       Info info = dockerClient.infoCmd().exec();
       LOG.info("Docker info: {}", info);
 
@@ -70,6 +69,7 @@ public class ContainerSuite implements Closeable {
     if (instance == null) {
       synchronized (ContainerSuite.class) {
         if (instance == null) {
+          init();
           instance = new ContainerSuite();
         }
       }

--- a/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
+++ b/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/container/ContainerSuite.java
@@ -52,8 +52,9 @@ public class ContainerSuite implements Closeable {
   protected static final CloseableGroup closer = CloseableGroup.create();
 
   private static void init() {
-    try (DockerClient dockerClient = DockerClientFactory.instance().client()) {
-      // Check if docker is available
+    try {
+      // Check if docker is available and you should never close the global DockerClient!
+      DockerClient dockerClient = DockerClientFactory.instance().client();
       Info info = dockerClient.infoCmd().exec();
       LOG.info("Docker info: {}", info);
 

--- a/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/util/CloseContainerExtension.java
+++ b/integration-test-common/src/test/java/com/datastrato/gravitino/integration/test/util/CloseContainerExtension.java
@@ -18,6 +18,8 @@ import org.slf4j.LoggerFactory;
 public class CloseContainerExtension implements BeforeAllCallback {
   @Override
   public void beforeAll(ExtensionContext extensionContext) {
+    // Ensure that the container suite is initialized before closing it
+    ContainerSuite.getInstance();
     synchronized (CloseContainerExtension.class) {
       extensionContext
           .getRoot()


### PR DESCRIPTION
### What changes were proposed in this pull request?

 - clarify OrbStack status
 - check the docker env before IT start

### Why are the changes needed?

The previous detection logic was located in the constructor, and when the test failed, it would throw an exception `ExceptionInInitializerError`, causing the original error to be covered.

Fix: #3336 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

Locally, by hand