### PR TITLE
[#2962] feat(catalog-lakehouse-iceberg): Add reserved properties to Iceberg Table Properties in Gravitino

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -232,6 +232,8 @@
    ./catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/miniHMS/ScriptRunner.java
    ./catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestCachedClientPool.java
    ./catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/web/IcebergExceptionMapper.java
+   ./catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/DescribeIcebergSortOrderVisitor.java
+   ./catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/utils/IcebergTablePropertiesUtil.java
    ./clients/client-java/src/main/java/com/datastrato/gravitino/client/HTTPClient.java
    ./clients/client-java/src/main/java/com/datastrato/gravitino/client/RESTClient.java
    ./clients/client-java/src/test/java/com/datastrato/gravitino/client/TestHTTPClient.java

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergTable.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergTable.java
@@ -5,7 +5,6 @@
 package com.datastrato.gravitino.catalog.lakehouse.iceberg;
 
 import static com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergTablePropertiesMetadata.DISTRIBUTION_MODE;
-import static com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergTablePropertiesMetadata.LOCATION;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 
 import com.datastrato.gravitino.catalog.lakehouse.iceberg.converter.ConvertUtil;
@@ -13,6 +12,7 @@ import com.datastrato.gravitino.catalog.lakehouse.iceberg.converter.FromIcebergP
 import com.datastrato.gravitino.catalog.lakehouse.iceberg.converter.FromIcebergSortOrder;
 import com.datastrato.gravitino.catalog.lakehouse.iceberg.converter.ToIcebergPartitionSpec;
 import com.datastrato.gravitino.catalog.lakehouse.iceberg.converter.ToIcebergSortOrder;
+import com.datastrato.gravitino.catalog.lakehouse.iceberg.utils.IcebergTablePropertiesUtil;
 import com.datastrato.gravitino.connector.BaseTable;
 import com.datastrato.gravitino.connector.TableOperations;
 import com.datastrato.gravitino.meta.AuditInfo;
@@ -134,7 +134,7 @@ public class IcebergTable extends BaseTable {
    */
   public static IcebergTable fromIcebergTable(TableMetadata table, String tableName) {
     Map<String, String> properties = new HashMap<>(table.properties());
-    properties.put(LOCATION, table.location());
+    properties.putAll(IcebergTablePropertiesUtil.buildReservedProperties(table));
     Schema schema = table.schema();
     Transform[] partitionSpec = FromIcebergPartitionSpec.fromPartitionSpec(table.spec(), schema);
     SortOrder[] sortOrder = FromIcebergSortOrder.fromSortOrder(table.sortOrder());

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergTablePropertiesMetadata.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergTablePropertiesMetadata.java
@@ -24,7 +24,8 @@ public class IcebergTablePropertiesMetadata extends BasePropertiesMetadata {
   public static final String SORT_ORDER = "sort-order";
   public static final String IDENTIFIER_FIELDS = "identifier-fields";
   public static final String PROVIDER = "provider";
-
+  public static final String FORMAT = "format";
+  public static final String FORMAT_VERSION = "format-version";
   public static final String DISTRIBUTION_MODE = TableProperties.WRITE_DISTRIBUTION_MODE;
 
   private static final Map<String, PropertyEntry<?>> PROPERTIES_METADATA;
@@ -36,6 +37,7 @@ public class IcebergTablePropertiesMetadata extends BasePropertiesMetadata {
             stringReservedPropertyEntry(CREATOR, "The table creator", false),
             stringImmutablePropertyEntry(
                 LOCATION, "Iceberg location for table storage", false, null, false, false),
+            stringImmutablePropertyEntry(FORMAT, "The table format", false, null, false, false),
             stringReservedPropertyEntry(
                 CURRENT_SNAPSHOT_ID,
                 "The snapshot represents the current state of the table",
@@ -49,6 +51,8 @@ public class IcebergTablePropertiesMetadata extends BasePropertiesMetadata {
             stringReservedPropertyEntry(
                 IDENTIFIER_FIELDS, "The identifier field(s) for defining the table", false),
             stringReservedPropertyEntry(DISTRIBUTION_MODE, "Write distribution mode", false),
+            stringImmutablePropertyEntry(
+                FORMAT_VERSION, "The Iceberg table format version, ", false, null, false, false),
             stringImmutablePropertyEntry(
                 PROVIDER,
                 "Iceberg provider for Iceberg table fileFormat, such as parquet, orc, avro, iceberg",

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/DescribeIcebergSortOrderVisitor.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/converter/DescribeIcebergSortOrderVisitor.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.datastrato.gravitino.catalog.lakehouse.iceberg.converter;
+
+import org.apache.iceberg.NullOrder;
+import org.apache.iceberg.transforms.SortOrderVisitor;
+
+/**
+ * Convert expressions of Iceberg SortOrders to function string.
+ *
+ * <p>Referred from org/apache/iceberg/spark/Spark3Util/DescribeSortOrderVisitor.java
+ */
+public class DescribeIcebergSortOrderVisitor implements SortOrderVisitor<String> {
+  public static final DescribeIcebergSortOrderVisitor INSTANCE =
+      new DescribeIcebergSortOrderVisitor();
+
+  private DescribeIcebergSortOrderVisitor() {}
+
+  @Override
+  public String field(
+      String sourceName,
+      int sourceId,
+      org.apache.iceberg.SortDirection direction,
+      NullOrder nullOrder) {
+    return String.format("%s %s %s", sourceName, direction, nullOrder);
+  }
+
+  @Override
+  public String bucket(
+      String sourceName,
+      int sourceId,
+      int numBuckets,
+      org.apache.iceberg.SortDirection direction,
+      NullOrder nullOrder) {
+    return String.format("bucket(%s, %s) %s %s", numBuckets, sourceName, direction, nullOrder);
+  }
+
+  @Override
+  public String truncate(
+      String sourceName,
+      int sourceId,
+      int width,
+      org.apache.iceberg.SortDirection direction,
+      NullOrder nullOrder) {
+    return String.format("truncate(%s, %s) %s %s", sourceName, width, direction, nullOrder);
+  }
+
+  @Override
+  public String year(
+      String sourceName,
+      int sourceId,
+      org.apache.iceberg.SortDirection direction,
+      NullOrder nullOrder) {
+    return String.format("years(%s) %s %s", sourceName, direction, nullOrder);
+  }
+
+  @Override
+  public String month(
+      String sourceName,
+      int sourceId,
+      org.apache.iceberg.SortDirection direction,
+      NullOrder nullOrder) {
+    return String.format("months(%s) %s %s", sourceName, direction, nullOrder);
+  }
+
+  @Override
+  public String day(
+      String sourceName,
+      int sourceId,
+      org.apache.iceberg.SortDirection direction,
+      NullOrder nullOrder) {
+    return String.format("days(%s) %s %s", sourceName, direction, nullOrder);
+  }
+
+  @Override
+  public String hour(
+      String sourceName,
+      int sourceId,
+      org.apache.iceberg.SortDirection direction,
+      NullOrder nullOrder) {
+    return String.format("hours(%s) %s %s", sourceName, direction, nullOrder);
+  }
+
+  @Override
+  public String unknown(
+      String sourceName,
+      int sourceId,
+      String transform,
+      org.apache.iceberg.SortDirection direction,
+      NullOrder nullOrder) {
+    return String.format("%s(%s) %s %s", transform, sourceName, direction, nullOrder);
+  }
+}

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/utils/IcebergTablePropertiesUtil.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/utils/IcebergTablePropertiesUtil.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.datastrato.gravitino.catalog.lakehouse.iceberg.utils;
+
+import static com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergTable.DEFAULT_ICEBERG_PROVIDER;
+import static com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergTablePropertiesMetadata.CURRENT_SNAPSHOT_ID;
+import static com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergTablePropertiesMetadata.FORMAT;
+import static com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergTablePropertiesMetadata.FORMAT_VERSION;
+import static com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergTablePropertiesMetadata.IDENTIFIER_FIELDS;
+import static com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergTablePropertiesMetadata.LOCATION;
+import static com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergTablePropertiesMetadata.PROVIDER;
+import static com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergTablePropertiesMetadata.SORT_ORDER;
+
+import com.datastrato.gravitino.catalog.lakehouse.iceberg.converter.DescribeIcebergSortOrderVisitor;
+import com.google.common.base.Joiner;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.transforms.SortOrderVisitor;
+
+/** Referred from org/apache/iceberg/spark/source/SparkTable.java#properties() */
+public class IcebergTablePropertiesUtil {
+
+  public static Map<String, String> buildReservedProperties(TableMetadata table) {
+    Map<String, String> properties = new HashMap<>();
+    String fileFormat =
+        table
+            .properties()
+            .getOrDefault(
+                TableProperties.DEFAULT_FILE_FORMAT, TableProperties.DEFAULT_FILE_FORMAT_DEFAULT);
+    properties.put(FORMAT, String.join("/", DEFAULT_ICEBERG_PROVIDER, fileFormat));
+    properties.put(PROVIDER, DEFAULT_ICEBERG_PROVIDER);
+    String currentSnapshotId =
+        table.currentSnapshot() != null
+            ? String.valueOf(table.currentSnapshot().snapshotId())
+            : "none";
+    properties.put(CURRENT_SNAPSHOT_ID, currentSnapshotId);
+    properties.put(LOCATION, table.location());
+
+    properties.put(FORMAT_VERSION, String.valueOf(table.formatVersion()));
+
+    if (!table.sortOrder().isUnsorted()) {
+      properties.put(SORT_ORDER, describeIcebergSortOrder(table.sortOrder()));
+    }
+
+    Set<String> identifierFields = table.schema().identifierFieldNames();
+    if (!identifierFields.isEmpty()) {
+      properties.put(IDENTIFIER_FIELDS, "[" + String.join(",", identifierFields) + "]");
+    }
+
+    return properties;
+  }
+
+  private static String describeIcebergSortOrder(org.apache.iceberg.SortOrder sortOrder) {
+    return Joiner.on(", ")
+        .join(SortOrderVisitor.visit(sortOrder, DescribeIcebergSortOrderVisitor.INSTANCE));
+  }
+
+  private IcebergTablePropertiesUtil() {}
+}

--- a/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/iceberg/IcebergPropertiesConstants.java
+++ b/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/iceberg/IcebergPropertiesConstants.java
@@ -6,6 +6,7 @@
 package com.datastrato.gravitino.spark.connector.iceberg;
 
 import com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergCatalogPropertiesMetadata;
+import com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergTablePropertiesMetadata;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
@@ -50,6 +51,29 @@ public class IcebergPropertiesConstants {
   public static final String ICEBERG_CATALOG_BACKEND_REST = CatalogUtil.ICEBERG_CATALOG_TYPE_REST;
 
   static final String GRAVITINO_ICEBERG_CATALOG_BACKEND_REST = "rest";
+
+  @VisibleForTesting
+  public static final String ICEBERG_LOCATION = IcebergTablePropertiesMetadata.LOCATION;
+
+  @VisibleForTesting
+  public static final String ICEBERG_CURRENT_SNAPSHOT_ID =
+      IcebergTablePropertiesMetadata.CURRENT_SNAPSHOT_ID;
+
+  @VisibleForTesting
+  public static final String ICEBERG_SORT_ORDER = IcebergTablePropertiesMetadata.SORT_ORDER;
+
+  @VisibleForTesting
+  public static final String ICEBERG_IDENTIFIER_FIELDS =
+      IcebergTablePropertiesMetadata.IDENTIFIER_FIELDS;
+
+  @VisibleForTesting
+  public static final String ICEBERG_PROVIDER = IcebergTablePropertiesMetadata.PROVIDER;
+
+  @VisibleForTesting
+  public static final String ICEBERG_FILE_FORMAT = IcebergTablePropertiesMetadata.FORMAT;
+
+  @VisibleForTesting
+  public static final String ICEBERG_FORMAT_VERSION = IcebergTablePropertiesMetadata.FORMAT_VERSION;
 
   private IcebergPropertiesConstants() {}
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add reserved properties to Table properties when load an Iceberg table, such as:

```
provider,
format,
current-snapshot-id,
location,
format-version,
sort-order,
identifier-fields
```

### Why are the changes needed?
for example, when execute `desc extended IcebergTableName`，it will get some information from the result properties of this Iceberg table, so it should contain the above properties.

Fix: https://github.com/datastrato/gravitino/issues/2962

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
New UTs and ITs.