### PR TITLE
[#3517] improvement(client-python): Add Coverage as python test coverage tool

### DIFF
--- a/clients/client-python/.gitignore
+++ b/clients/client-python/.gitignore
@@ -12,3 +12,18 @@ venv
 dist
 build
 README.md
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/

--- a/clients/client-python/build.gradle.kts
+++ b/clients/client-python/build.gradle.kts
@@ -110,13 +110,19 @@ tasks {
     args = listOf("./gravitino", "./tests")
   }
 
+  val integrationCoverageReport by registering(VenvTask::class){
+    venvExec = "coverage"
+    args = listOf("html")
+    workingDir = projectDir.resolve("./tests/integration")
+  }
+
   val integrationTest by registering(VenvTask::class) {
     doFirst {
       gravitinoServer("start")
     }
 
-    venvExec = "python"
-    args = listOf("-m", "unittest")
+    venvExec = "coverage"
+    args = listOf("run", "--branch", "-m", "unittest")
     workingDir = projectDir.resolve("./tests/integration")
     environment = mapOf(
       "PROJECT_VERSION" to project.version,
@@ -127,12 +133,22 @@ tasks {
     doLast {
       gravitinoServer("stop")
     }
+
+    finalizedBy(integrationCoverageReport)
+  }
+
+  val unitCoverageReport by registering(VenvTask::class){
+    venvExec = "coverage"
+    args = listOf("html")
+    workingDir = projectDir.resolve("./tests/unittests")
   }
 
   val unitTests by registering(VenvTask::class) {
-    venvExec = "python"
-    args = listOf("-m", "unittest")
+    venvExec = "coverage"
+    args = listOf("run", "--branch", "-m", "unittest")
     workingDir = projectDir.resolve("./tests/unittests")
+
+    finalizedBy(unitCoverageReport)
   }
 
   val test by registering(VenvTask::class) {
@@ -175,6 +191,10 @@ tasks {
     delete("build")
     delete("dist")
     delete("gravitino.egg-info")
+    delete("tests/unittests/htmlcov")
+    delete("tests/unittests/.coverage")
+    delete("tests/integration/htmlcov")
+    delete("tests/integration/.coverage")
 
     doLast {
       deleteCacheDir(".pytest_cache")

--- a/clients/client-python/requirements-dev.txt
+++ b/clients/client-python/requirements-dev.txt
@@ -5,3 +5,4 @@ dataclasses-json
 pylint
 black
 twine
+coverage


### PR DESCRIPTION
### What changes were proposed in this pull request?

* Merge test coverage into Gradle tasks
* Generate html report for both unit and integration tests (`htmlcov/index.html` under their folders)

The generated html report is as follows:

Unit Test Covergae:
<img width="1202" alt="image"
src="https://github.com/datastrato/gravitino/assets/55401762/e58d6513-e574-4b25-a8e7-81622bd46431">

Integration Test Coverage:
<img width="1201" alt="image"
src="https://github.com/datastrato/gravitino/assets/55401762/31a37db5-528f-4810-af8e-ca3ec21bc6de">


### Why are the changes needed?

Fix: #3517

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

`./gradlew clients:client-python:test`