### PR TITLE
[#3548] fix(dev): Create a new image to add a principal for Gravitino web server and fix several bugs about proxy users

### DIFF
--- a/dev/docker/kerberos-hive/core-site.xml
+++ b/dev/docker/kerberos-hive/core-site.xml
@@ -24,6 +24,42 @@
     <value>*</value>
   </property>
 
+
+  <property>
+    <name>hadoop.proxyuser.hive.users</name>
+    <value>*</value>
+  </property>
+
+  <property>
+    <name>hadoop.proxyuser.cli.hosts</name>
+    <value>*</value>
+  </property>
+
+  <property>
+    <name>hadoop.proxyuser.cli.groups</name>
+    <value>*</value>
+  </property>
+
+  <property>
+    <name>hadoop.proxyuser.cli.users</name>
+    <value>*</value>
+  </property>
+
+  <property>
+    <name>hadoop.proxyuser.hadoop.hosts</name>
+    <value>*</value>
+  </property>
+
+  <property>
+    <name>hadoop.proxyuser.hadoop.groups</name>
+    <value>*</value>
+  </property>
+
+  <property>
+    <name>hadoop.proxyuser.hadoop.users</name>
+    <value>*</value>
+  </property>
+
   <property>
     <name>hadoop.proxyuser.root.groups</name>
     <value>*</value>
@@ -31,6 +67,11 @@
 
   <property>
     <name>hadoop.proxyuser.root.hosts</name>
+    <value>*</value>
+  </property>
+
+  <property>
+    <name>hadoop.proxyuser.root.users</name>
     <value>*</value>
   </property>
 

--- a/dev/docker/kerberos-hive/start.sh
+++ b/dev/docker/kerberos-hive/start.sh
@@ -42,6 +42,13 @@ kadmin.local -q "ktadd -norandkey -k ${KRB5_KTNAME} hive/${HOSTNAME}@${FQDN}"
 kadmin.local -q "xst -k /hive.keytab -norandkey hive/${HOSTNAME}@${FQDN}"
 kadmin.local -q "xst -k /cli.keytab -norandkey cli@${FQDN}"
 
+# For Gravitino web server
+echo -e "${PASS}\n${PASS}" | kadmin.local -q "addprinc gravitino_client@${FQDN}"
+kadmin.local -q "ktadd -norandkey -k /gravitino_client.keytab gravitino_client@${FQDN}"
+
+echo -e "${PASS}\n${PASS}" | kadmin.local -q "addprinc HTTP/localhost@${FQDN}"
+kadmin.local -q "ktadd -norandkey -k /gravitino_server.keytab HTTP/localhost@${FQDN}"
+
 echo -e "${PASS}\n" | kinit hive/${HOSTNAME}
 
 # Update the configuration file

--- a/docs/docker-image-details.md
+++ b/docs/docker-image-details.md
@@ -90,6 +90,10 @@ You can use this kind of image to test the catalog of Apache Hive with kerberos 
 
 Changelog
 
+- gravitino-ci-kerberos-hive:0.1.1
+  - Add a principal for Gravitino web server named 'HTTP/localhost@HADOOPKRB'.
+  - Fix bugs about the configuration of proxy users. 
+
 - gravitino-ci-kerberos-hive:0.1.0
     - Set up a Hive cluster with kerberos enabled.
     - Install a KDC server and create a principal for Hive. For more please see [kerberos-hive](../dev/docker/kerberos-hive)


### PR DESCRIPTION
### What changes were proposed in this pull request?

  - Add a principal for Gravitino web server named 'HTTP/localhost@HADOOPKRB'.
  - Fix bugs about the configuration of proxy users. 

### Why are the changes needed?

To serve user authentication e2e test. 

Fix: #3548 

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

Test locally. 