### PR TITLE
[#3396] feat(spark-connector): remove iceberg runtime from spark-connector jar

### DIFF
--- a/docs/spark-connector/spark-catalog-iceberg.md
+++ b/docs/spark-connector/spark-catalog-iceberg.md
@@ -6,6 +6,8 @@ license: "Copyright 2024 Datastrato Pvt Ltd.
 This software is licensed under the Apache License version 2."
 ---
 
+The Gravitino Spark connector offers the capability to read and write Iceberg tables, with the metadata managed by the Gravitino server. To enable the use of the Iceberg catalog within the Spark connector, you must set the configuration `spark.sql.gravitino.enableIcebergSupport` to `true` and download Iceberg Spark runtime jar to Spark classpath.
+
 ## Capabilities
 
 #### Support DML and DDL operations:

--- a/docs/spark-connector/spark-connector.md
+++ b/docs/spark-connector/spark-connector.md
@@ -27,11 +27,12 @@ The Gravitino Spark connector leverages the Spark DataSourceV2 interface to faci
 1. [Build](../how-to-build.md) or download the Gravitino spark connector jar, and place it to the classpath of Spark.
 2. Configure the Spark session to use the Gravitino spark connector.
 
-| Property                     | Type   | Default Value | Description                                                                                         | Required | Since Version |
-|------------------------------|--------|---------------|-----------------------------------------------------------------------------------------------------|----------|---------------|
-| spark.plugins                | string | (none)        | Gravitino spark plugin name, `com.datastrato.gravitino.spark.connector.plugin.GravitinoSparkPlugin` | Yes      | 0.5.0         |
-| spark.sql.gravitino.metalake | string | (none)        | The metalake name that spark connector used to request to Gravitino.                                | Yes      | 0.5.0         |
-| spark.sql.gravitino.uri      | string | (none)        | The uri of Gravitino server address.                                                                | Yes      | 0.5.0         |
+| Property                                 | Type   | Default Value | Description                                                                                         | Required | Since Version |
+|------------------------------------------|--------|---------------|-----------------------------------------------------------------------------------------------------|----------|---------------|
+| spark.plugins                            | string | (none)        | Gravitino spark plugin name, `com.datastrato.gravitino.spark.connector.plugin.GravitinoSparkPlugin` | Yes      | 0.5.0         |
+| spark.sql.gravitino.metalake             | string | (none)        | The metalake name that spark connector used to request to Gravitino.                                | Yes      | 0.5.0         |
+| spark.sql.gravitino.uri                  | string | (none)        | The uri of Gravitino server address.                                                                | Yes      | 0.5.0         |
+| spark.sql.gravitino.enableIcebergSupport | string | `false`       | Set to `true` to use Iceberg catalog.                                                               | No       | 0.5.1         |
 
 ```shell
 ./bin/spark-sql -v \

--- a/spark-connector/spark-connector-runtime/build.gradle.kts
+++ b/spark-connector/spark-connector-runtime/build.gradle.kts
@@ -13,14 +13,11 @@ plugins {
 val scalaVersion: String = project.properties["scalaVersion"] as? String ?: extra["defaultScalaVersion"].toString()
 val sparkVersion: String = libs.versions.spark.get()
 val sparkMajorVersion: String = sparkVersion.substringBeforeLast(".")
-val icebergVersion: String = libs.versions.iceberg.get()
 val baseName = "${rootProject.name}-spark-connector-runtime-${sparkMajorVersion}_$scalaVersion"
 
 dependencies {
   implementation(project(":clients:client-java-runtime", configuration = "shadow"))
   implementation(project(":spark-connector:spark-connector"))
-
-  implementation("org.apache.iceberg:iceberg-spark-runtime-${sparkMajorVersion}_$scalaVersion:$icebergVersion")
 }
 
 tasks.withType<ShadowJar>(ShadowJar::class.java) {

--- a/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/GravitinoSparkConfig.java
+++ b/spark-connector/spark-connector/src/main/java/com/datastrato/gravitino/spark/connector/GravitinoSparkConfig.java
@@ -10,6 +10,8 @@ public class GravitinoSparkConfig {
   private static final String GRAVITINO_PREFIX = "spark.sql.gravitino.";
   public static final String GRAVITINO_URI = GRAVITINO_PREFIX + "uri";
   public static final String GRAVITINO_METALAKE = GRAVITINO_PREFIX + "metalake";
+  public static final String GRAVITINO_ENABLE_ICEBERG_SUPPORT =
+      GRAVITINO_PREFIX + "enableIcebergSupport";
   public static final String GRAVITINO_HIVE_METASTORE_URI = "metastore.uris";
   public static final String SPARK_HIVE_METASTORE_URI = "hive.metastore.uris";
 

--- a/spark-connector/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/integration/test/SparkEnvIT.java
+++ b/spark-connector/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/integration/test/SparkEnvIT.java
@@ -183,6 +183,7 @@ public abstract class SparkEnvIT extends SparkUtilIT {
             .config("spark.plugins", GravitinoSparkPlugin.class.getName())
             .config(GravitinoSparkConfig.GRAVITINO_URI, gravitinoUri)
             .config(GravitinoSparkConfig.GRAVITINO_METALAKE, metalakeName)
+            .config(GravitinoSparkConfig.GRAVITINO_ENABLE_ICEBERG_SUPPORT, "true")
             .config("hive.exec.dynamic.partition.mode", "nonstrict")
             .config("spark.sql.warehouse.dir", warehouse)
             .config("spark.sql.session.timeZone", TIME_ZONE_UTC)

--- a/spark-connector/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/plugin/TestGravitinoDriverPlugin.java
+++ b/spark-connector/spark-connector/src/test/java/com/datastrato/gravitino/spark/connector/plugin/TestGravitinoDriverPlugin.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+
+package com.datastrato.gravitino.spark.connector.plugin;
+
+import org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestGravitinoDriverPlugin {
+
+  @Test
+  void testIcebergExtensionName() {
+    Assertions.assertEquals(
+        IcebergSparkSessionExtensions.class.getName(),
+        GravitinoDriverPlugin.ICEBERG_SPARK_EXTENSIONS);
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
remove iceberg runtime from spark-connector jar

### Why are the changes needed?

Fix: #3396 

### Does this PR introduce _any_ user-facing change?
yes add document

### How was this patch tested?
set `enableIcebergSupport` == true,  could use Iceberg catalog with extra iceberg-runtime jars. had tested iceberg 1.4,1.3,1.5 jars
not set `enableIcebergSupport`, could only use hive catalog.
