### PR TITLE
[#3561] improvement(client-python): Fix redefined-builtin Pylint rule for client-python

### DIFF
--- a/clients/client-python/gravitino/api/catalog_change.py
+++ b/clients/client-python/gravitino/api/catalog_change.py
@@ -37,29 +37,29 @@ class CatalogChange(ABC):
         return CatalogChange.UpdateCatalogComment(new_comment)
 
     @staticmethod
-    def set_property(property, value):
+    def set_property(catalog_property, value):
         """Creates a new catalog change to set the property and value for the catalog.
 
         Args:
-            property: The property name to set.
+            catalog_property: The property name to set.
             value: The value to set the property to.
 
         Returns:
             The catalog change.
         """
-        return CatalogChange.SetProperty(property, value)
+        return CatalogChange.SetProperty(catalog_property, value)
 
     @staticmethod
-    def remove_property(property):
+    def remove_property(catalog_property):
         """Creates a new catalog change to remove a property from the catalog.
 
         Args:
-            property: The property name to remove.
+            catalog_property: The property name to remove.
 
         Returns:
             The catalog change.
         """
-        return CatalogChange.RemoveProperty(property)
+        return CatalogChange.RemoveProperty(catalog_property)
 
     class RenameCatalog:
         """A catalog change to rename the catalog."""
@@ -156,8 +156,8 @@ class CatalogChange(ABC):
     class SetProperty:
         """A catalog change to set the property and value for the catalog."""
 
-        def __init__(self, property, value):
-            self.property = property
+        def __init__(self, catalog_property, value):
+            self.property = catalog_property
             self.value = value
 
         def property(self):
@@ -211,8 +211,8 @@ class CatalogChange(ABC):
     class RemoveProperty:
         """A catalog change to remove a property from the catalog."""
 
-        def __init__(self, property):
-            self._property = property
+        def __init__(self, catalog_property):
+            self._property = catalog_property
 
         def get_property(self):
             """Retrieves the name of the property to be removed from the catalog.

--- a/clients/client-python/gravitino/api/fileset_change.py
+++ b/clients/client-python/gravitino/api/fileset_change.py
@@ -39,29 +39,29 @@ class FilesetChange(ABC):
         return FilesetChange.UpdateFilesetComment(new_comment)
 
     @staticmethod
-    def set_property(property, value):
+    def set_property(fileset_property, value):
         """Creates a new fileset change to set the property and value for the fileset.
 
         Args:
-            property: The property name to set.
+            fileset_property: The property name to set.
             value: The value to set the property to.
 
         Returns:
              The fileset change.
         """
-        return FilesetChange.SetProperty(property, value)
+        return FilesetChange.SetProperty(fileset_property, value)
 
     @staticmethod
-    def remove_property(property):
+    def remove_property(fileset_property):
         """Creates a new fileset change to remove a property from the fileset.
 
         Args:
-            property: The property name to remove.
+            fileset_property: The property name to remove.
 
         Returns:
             The fileset change.
         """
-        return FilesetChange.RemoveProperty(property)
+        return FilesetChange.RemoveProperty(fileset_property)
 
     class RenameFileset:
         """A fileset change to rename the fileset."""
@@ -165,8 +165,8 @@ class FilesetChange(ABC):
         _property: str = field(metadata=config(field_name="property"))
         _value: str = field(metadata=config(field_name="value"))
 
-        def __init__(self, property: str, value: str):
-            self._property = property
+        def __init__(self, fileset_property: str, value: str):
+            self._property = fileset_property
             self._value = value
 
         def property(self):
@@ -222,8 +222,8 @@ class FilesetChange(ABC):
 
         _property: str = field(metadata=config(field_name="property"))
 
-        def __init__(self, property: str):
-            self._property = property
+        def __init__(self, fileset_property: str):
+            self._property = fileset_property
 
         def property(self):
             """Retrieves the name of the property to be removed from the fileset.

--- a/clients/client-python/gravitino/api/metalake_change.py
+++ b/clients/client-python/gravitino/api/metalake_change.py
@@ -39,29 +39,29 @@ class MetalakeChange:
         return MetalakeChange.UpdateMetalakeComment(new_comment)
 
     @staticmethod
-    def set_property(property: str, value: str) -> "SetProperty":
+    def set_property(metalake_property: str, value: str) -> "SetProperty":
         """Creates a new metalake change to set a property and value pair for the metalake.
 
         Args:
-            property: The property name to set.
+            metalake_property: The property name to set.
             value: The value to set the property to.
 
         Returns:
              The metalake change.
         """
-        return MetalakeChange.SetProperty(property, value)
+        return MetalakeChange.SetProperty(metalake_property, value)
 
     @staticmethod
-    def remove_property(property: str) -> "RemoveProperty":
+    def remove_property(metalake_property: str) -> "RemoveProperty":
         """Creates a new metalake change to remove a property from the metalake.
 
         Args:
-            property: The property name to remove.
+            metalake_property: The property name to remove.
 
         Returns:
             The metalake change.
         """
-        return MetalakeChange.RemoveProperty(property)
+        return MetalakeChange.RemoveProperty(metalake_property)
 
     @dataclass(frozen=True)
     class RenameMetalake:

--- a/clients/client-python/gravitino/api/schema_change.py
+++ b/clients/client-python/gravitino/api/schema_change.py
@@ -13,29 +13,29 @@ class SchemaChange(ABC):
     """NamespaceChange class to set the property and value pairs for the namespace."""
 
     @staticmethod
-    def set_property(property: str, value: str):
+    def set_property(schema_property: str, value: str):
         """SchemaChange class to set the property and value pairs for the schema.
 
         Args:
-            property: The property name to set.
+            schema_property: The property name to set.
             value: The value to set the property to.
 
         Returns:
              The SchemaChange object.
         """
-        return SchemaChange.SetProperty(property, value)
+        return SchemaChange.SetProperty(schema_property, value)
 
     @staticmethod
-    def remove_property(property: str):
+    def remove_property(schema_property: str):
         """SchemaChange class to remove a property from the schema.
 
         Args:
-            property: The property name to remove.
+            schema_property: The property name to remove.
 
         Returns:
             The SchemaChange object.
         """
-        return SchemaChange.RemoveProperty(property)
+        return SchemaChange.RemoveProperty(schema_property)
 
     class SetProperty:
         """SchemaChange class to set the property and value pairs for the schema."""
@@ -43,8 +43,8 @@ class SchemaChange(ABC):
         _property: str = field(metadata=config(field_name="property"))
         _value: str = field(metadata=config(field_name="value"))
 
-        def __init__(self, property: str, value: str):
-            self._property = property
+        def __init__(self, schema_property: str, value: str):
+            self._property = schema_property
             self._value = value
 
         def property(self):
@@ -100,8 +100,8 @@ class SchemaChange(ABC):
 
         _property: str = field(metadata=config(field_name="property"))
 
-        def __init__(self, property: str):
-            self._property = property
+        def __init__(self, schema_property: str):
+            self._property = schema_property
 
         def property(self):
             """Retrieves the name of the property to be removed.

--- a/clients/client-python/gravitino/catalog/base_schema_catalog.py
+++ b/clients/client-python/gravitino/catalog/base_schema_catalog.py
@@ -38,7 +38,7 @@ class BaseSchemaCatalog(CatalogDTO, SupportsSchemas):
     def __init__(
         self,
         name: str = None,
-        type: Catalog.Type = Catalog.Type.UNSUPPORTED,
+        catalog_type: Catalog.Type = Catalog.Type.UNSUPPORTED,
         provider: str = None,
         comment: str = None,
         properties: Dict[str, str] = None,
@@ -47,7 +47,7 @@ class BaseSchemaCatalog(CatalogDTO, SupportsSchemas):
     ):
         super().__init__(
             _name=name,
-            _type=type,
+            _type=catalog_type,
             _provider=provider,
             _comment=comment,
             _properties=properties,

--- a/clients/client-python/gravitino/catalog/fileset_catalog.py
+++ b/clients/client-python/gravitino/catalog/fileset_catalog.py
@@ -41,7 +41,9 @@ class FilesetCatalog(BaseSchemaCatalog):
         rest_client: HTTPClient = None,
     ):
 
-        super().__init__(name, catalog_type, provider, comment, properties, audit, rest_client)
+        super().__init__(
+            name, catalog_type, provider, comment, properties, audit, rest_client
+        )
 
     def as_fileset_catalog(self):
         return self

--- a/clients/client-python/gravitino/catalog/fileset_catalog.py
+++ b/clients/client-python/gravitino/catalog/fileset_catalog.py
@@ -33,7 +33,7 @@ class FilesetCatalog(BaseSchemaCatalog):
     def __init__(
         self,
         name: str = None,
-        type: Catalog.Type = Catalog.Type.UNSUPPORTED,
+        catalog_type: Catalog.Type = Catalog.Type.UNSUPPORTED,
         provider: str = None,
         comment: str = None,
         properties: Dict[str, str] = None,
@@ -41,7 +41,7 @@ class FilesetCatalog(BaseSchemaCatalog):
         rest_client: HTTPClient = None,
     ):
 
-        super().__init__(name, type, provider, comment, properties, audit, rest_client)
+        super().__init__(name, catalog_type, provider, comment, properties, audit, rest_client)
 
     def as_fileset_catalog(self):
         return self
@@ -92,7 +92,7 @@ class FilesetCatalog(BaseSchemaCatalog):
         self,
         ident: NameIdentifier,
         comment: str,
-        type: Fileset.Type,
+        fileset_type: Fileset.Type,
         storage_location: str,
         properties: Dict[str, str],
     ) -> Fileset:
@@ -106,7 +106,7 @@ class FilesetCatalog(BaseSchemaCatalog):
         Args:
             ident: A fileset identifier.
             comment: The comment of the fileset.
-            type: The type of the fileset.
+            fileset_type: The type of the fileset.
             storage_location: The storage location of the fileset.
             properties: The properties of the fileset.
 
@@ -122,7 +122,7 @@ class FilesetCatalog(BaseSchemaCatalog):
         req = FilesetCreateRequest(
             name=ident.name(),
             comment=comment,
-            type=type,
+            type=fileset_type,
             storage_location=storage_location,
             properties=properties,
         )

--- a/clients/client-python/gravitino/catalog/fileset_catalog.py
+++ b/clients/client-python/gravitino/catalog/fileset_catalog.py
@@ -122,7 +122,7 @@ class FilesetCatalog(BaseSchemaCatalog):
         req = FilesetCreateRequest(
             name=ident.name(),
             comment=comment,
-            type=fileset_type,
+            fileset_type=fileset_type,
             storage_location=storage_location,
             properties=properties,
         )

--- a/clients/client-python/gravitino/client/gravitino_client.py
+++ b/clients/client-python/gravitino/client/gravitino_client.py
@@ -71,13 +71,13 @@ class GravitinoClient(GravitinoClientBase):
     def create_catalog(
         self,
         ident: NameIdentifier,
-        type: Catalog.Type,
+        catalog_type: Catalog.Type,
         provider: str,
         comment: str,
         properties: Dict[str, str],
     ) -> Catalog:
         return self.get_metalake().create_catalog(
-            ident, type, provider, comment, properties
+            ident, catalog_type, provider, comment, properties
         )
 
     def alter_catalog(self, ident: NameIdentifier, *changes: CatalogChange):

--- a/clients/client-python/gravitino/client/gravitino_metalake.py
+++ b/clients/client-python/gravitino/client/gravitino_metalake.py
@@ -122,16 +122,16 @@ class GravitinoMetalake(MetalakeDTO):
     def create_catalog(
         self,
         ident: NameIdentifier,
-        type: Catalog.Type,
+        catalog_type: Catalog.Type,
         provider: str,
         comment: str,
         properties: Dict[str, str],
     ) -> Catalog:
-        """Create a new catalog with specified identifier, type, comment and properties.
+        """Create a new catalog with specified identifier, catalog type, comment and properties.
 
         Args:
             ident: The identifier of the catalog.
-            type: The type of the catalog.
+            catalog_type: The type of the catalog.
             provider: The provider of the catalog.
             comment: The comment of the catalog.
             properties: The properties of the catalog.
@@ -147,7 +147,7 @@ class GravitinoMetalake(MetalakeDTO):
 
         catalog_create_request = CatalogCreateRequest(
             name=ident.name(),
-            type=type,
+            catalog_type=catalog_type,
             provider=provider,
             comment=comment,
             properties=properties,

--- a/clients/client-python/gravitino/dto/catalog_dto.py
+++ b/clients/client-python/gravitino/dto/catalog_dto.py
@@ -26,14 +26,14 @@ class CatalogDTO(Catalog):
     def builder(
         self,
         name: str = None,
-        type: Catalog.Type = Catalog.Type.UNSUPPORTED,
+        catalog_type: Catalog.Type = Catalog.Type.UNSUPPORTED,
         provider: str = None,
         comment: str = None,
         properties: Dict[str, str] = None,
         audit: AuditDTO = None,
     ):
         self._name = name
-        self._type = type
+        self._type = catalog_type
         self._provider = provider
         self._comment = comment
         self._properties = properties

--- a/clients/client-python/gravitino/dto/dto_converters.py
+++ b/clients/client-python/gravitino/dto/dto_converters.py
@@ -41,7 +41,7 @@ class DTOConverters:
         if catalog.type() == Catalog.Type.FILESET:
             return FilesetCatalog(
                 name=catalog.name(),
-                type=catalog.type(),
+                catalog_type=catalog.type(),
                 provider=catalog.provider(),
                 comment=catalog.comment(),
                 properties=catalog.properties(),

--- a/clients/client-python/gravitino/dto/requests/catalog_create_request.py
+++ b/clients/client-python/gravitino/dto/requests/catalog_create_request.py
@@ -27,13 +27,13 @@ class CatalogCreateRequest(RESTRequest):
     def __init__(
         self,
         name: str = None,
-        type: Catalog.Type = Catalog.Type.UNSUPPORTED,
+        catalog_type: Catalog.Type = Catalog.Type.UNSUPPORTED,
         provider: str = None,
         comment: str = None,
         properties: Dict[str, str] = None,
     ):
         self._name = name
-        self._type = type
+        self._type = catalog_type
         self._provider = provider
         self._comment = comment
         self._properties = properties

--- a/clients/client-python/gravitino/dto/requests/catalog_create_request.py
+++ b/clients/client-python/gravitino/dto/requests/catalog_create_request.py
@@ -45,7 +45,9 @@ class CatalogCreateRequest(RESTRequest):
             IllegalArgumentException if name or type are not set.
         """
         assert self._name is not None, '"name" field is required and cannot be empty'
-        assert self._type is not None, '"type" field is required and cannot be empty'
+        assert (
+            self._type is not None
+        ), '"catalog_type" field is required and cannot be empty'
         assert (
             self._provider is not None
         ), '"provider" field is required and cannot be empty'

--- a/clients/client-python/gravitino/dto/requests/catalog_update_request.py
+++ b/clients/client-python/gravitino/dto/requests/catalog_update_request.py
@@ -17,8 +17,8 @@ from gravitino.rest.rest_message import RESTRequest
 class CatalogUpdateRequestBase(RESTRequest):
     _type: str = field(metadata=config(field_name="@type"))
 
-    def __init__(self, type: str):
-        self._type = type
+    def __init__(self, action_type: str):
+        self._type = action_type
 
     @abstractmethod
     def catalog_change(self):

--- a/clients/client-python/gravitino/dto/requests/fileset_create_request.py
+++ b/clients/client-python/gravitino/dto/requests/fileset_create_request.py
@@ -30,13 +30,13 @@ class FilesetCreateRequest(RESTRequest):
         self,
         name: str,
         comment: Optional[str] = None,
-        type: Fileset.Type = None,
+        fileset_type: Fileset.Type = None,
         storage_location: Optional[str] = None,
         properties: Optional[Dict[str, str]] = None,
     ):
         self._name = name
         self._comment = comment
-        self._type = type
+        self._type = fileset_type
         self._storage_location = storage_location
         self._properties = properties
 

--- a/clients/client-python/gravitino/dto/requests/fileset_update_request.py
+++ b/clients/client-python/gravitino/dto/requests/fileset_update_request.py
@@ -16,8 +16,8 @@ from gravitino.rest.rest_message import RESTRequest
 class FilesetUpdateRequestBase(RESTRequest):
     _type: str = field(metadata=config(field_name="@type"))
 
-    def __init__(self, type: str):
-        self._type = type
+    def __init__(self, action_type: str):
+        self._type = action_type
 
     @abstractmethod
     def fileset_change(self):

--- a/clients/client-python/gravitino/dto/requests/fileset_update_request.py
+++ b/clients/client-python/gravitino/dto/requests/fileset_update_request.py
@@ -101,7 +101,9 @@ class FilesetUpdateRequest:
                  IllegalArgumentException if fileset_property or value are not set.
             """
             if not self._property:
-                raise ValueError('"fileset_property" field is required and cannot be empty')
+                raise ValueError(
+                    '"fileset_property" field is required and cannot be empty'
+                )
             if not self._value:
                 raise ValueError('"value" field is required and cannot be empty')
 
@@ -126,7 +128,9 @@ class FilesetUpdateRequest:
                  IllegalArgumentException if fileset_property is not set.
             """
             if not self._property:
-                raise ValueError('"fileset_property" field is required and cannot be empty')
+                raise ValueError(
+                    '"fileset_property" field is required and cannot be empty'
+                )
 
         def fileset_change(self):
             return FilesetChange.remove_property(self._property)

--- a/clients/client-python/gravitino/dto/requests/fileset_update_request.py
+++ b/clients/client-python/gravitino/dto/requests/fileset_update_request.py
@@ -89,19 +89,19 @@ class FilesetUpdateRequest:
         _value: str = field(metadata=config(field_name="value"))
         """The value of the property."""
 
-        def __init__(self, property: str, value: str):
+        def __init__(self, fileset_property: str, value: str):
             super().__init__("setProperty")
-            self._property = property
+            self._property = fileset_property
             self._value = value
 
         def validate(self):
             """Validates the fields of the request.
 
             Raises:
-                 IllegalArgumentException if property or value are not set.
+                 IllegalArgumentException if fileset_property or value are not set.
             """
             if not self._property:
-                raise ValueError('"property" field is required and cannot be empty')
+                raise ValueError('"fileset_property" field is required and cannot be empty')
             if not self._value:
                 raise ValueError('"value" field is required and cannot be empty')
 
@@ -115,18 +115,18 @@ class FilesetUpdateRequest:
         _property: str = field(metadata=config(field_name="property"))
         """The property to remove."""
 
-        def __init__(self, property: str):
+        def __init__(self, fileset_property: str):
             super().__init__("removeProperty")
-            self._property = property
+            self._property = fileset_property
 
         def validate(self):
             """Validates the fields of the request.
 
             Raises:
-                 IllegalArgumentException if property is not set.
+                 IllegalArgumentException if fileset_property is not set.
             """
             if not self._property:
-                raise ValueError('"property" field is required and cannot be empty')
+                raise ValueError('"fileset_property" field is required and cannot be empty')
 
         def fileset_change(self):
             return FilesetChange.remove_property(self._property)

--- a/clients/client-python/gravitino/dto/requests/metalake_update_request.py
+++ b/clients/client-python/gravitino/dto/requests/metalake_update_request.py
@@ -83,19 +83,19 @@ class MetalakeUpdateRequest:
         _value: str = field(metadata=config(field_name="value"))
         """The value of the property."""
 
-        def __init__(self, property: str, value: str):
+        def __init__(self, metalake_property: str, value: str):
             super().__init__("setProperty")
-            self._property = property
+            self._property = metalake_property
             self._value = value
 
         def validate(self):
             """Validates the fields of the request.
 
             Raises:
-                 IllegalArgumentException if property or value are not set.
+                 IllegalArgumentException if metalake_property or value are not set.
             """
             if not self._property:
-                raise ValueError('"property" field is required and cannot be empty')
+                raise ValueError('"metalake_property" field is required and cannot be empty')
             if not self._value:
                 raise ValueError('"value" field is required and cannot be empty')
 
@@ -109,18 +109,18 @@ class MetalakeUpdateRequest:
         _property: str = field(metadata=config(field_name="property"))
         """The property to remove."""
 
-        def __init__(self, property: str):
+        def __init__(self, metalake_property: str):
             super().__init__("removeProperty")
-            self._property = property
+            self._property = metalake_property
 
         def validate(self):
             """Validates the fields of the request.
 
             Raises:
-                 IllegalArgumentException if property is not set.
+                 IllegalArgumentException if metalake_property is not set.
             """
             if not self._property:
-                raise ValueError('"property" field is required and cannot be empty')
+                raise ValueError('"metalake_property" field is required and cannot be empty')
 
         def metalake_change(self):
             return MetalakeChange.remove_property(self._property)

--- a/clients/client-python/gravitino/dto/requests/metalake_update_request.py
+++ b/clients/client-python/gravitino/dto/requests/metalake_update_request.py
@@ -16,8 +16,8 @@ from gravitino.rest.rest_message import RESTRequest
 class MetalakeUpdateRequestBase(RESTRequest):
     _type: str = field(metadata=config(field_name="@type"))
 
-    def __init__(self, type: str):
-        self._type = type
+    def __init__(self, action_type: str):
+        self._type = action_type
 
     @abstractmethod
     def metalake_change(self):

--- a/clients/client-python/gravitino/dto/requests/metalake_update_request.py
+++ b/clients/client-python/gravitino/dto/requests/metalake_update_request.py
@@ -95,7 +95,9 @@ class MetalakeUpdateRequest:
                  IllegalArgumentException if metalake_property or value are not set.
             """
             if not self._property:
-                raise ValueError('"metalake_property" field is required and cannot be empty')
+                raise ValueError(
+                    '"metalake_property" field is required and cannot be empty'
+                )
             if not self._value:
                 raise ValueError('"value" field is required and cannot be empty')
 
@@ -120,7 +122,9 @@ class MetalakeUpdateRequest:
                  IllegalArgumentException if metalake_property is not set.
             """
             if not self._property:
-                raise ValueError('"metalake_property" field is required and cannot be empty')
+                raise ValueError(
+                    '"metalake_property" field is required and cannot be empty'
+                )
 
         def metalake_change(self):
             return MetalakeChange.remove_property(self._property)

--- a/clients/client-python/gravitino/dto/requests/schema_update_request.py
+++ b/clients/client-python/gravitino/dto/requests/schema_update_request.py
@@ -38,19 +38,19 @@ class SchemaUpdateRequest:
         _value: str = field(metadata=config(field_name="value"))
         """The value of the property."""
 
-        def __init__(self, property: str, value: str):
+        def __init__(self, schema_property: str, value: str):
             super().__init__("setProperty")
-            self._property = property
+            self._property = schema_property
             self._value = value
 
         def validate(self):
             """Validates the fields of the request.
 
             Raises:
-                 IllegalArgumentException if property or value are not set.
+                 IllegalArgumentException if schema_property or value are not set.
             """
             if not self._property:
-                raise ValueError('"property" field is required and cannot be empty')
+                raise ValueError('"schema_property" field is required and cannot be empty')
             if not self._value:
                 raise ValueError('"value" field is required and cannot be empty')
 
@@ -64,18 +64,18 @@ class SchemaUpdateRequest:
         _property: str = field(metadata=config(field_name="property"))
         """The property to remove."""
 
-        def __init__(self, property: str):
+        def __init__(self, schema_property: str):
             super().__init__("removeProperty")
-            self._property = property
+            self._property = schema_property
 
         def validate(self):
             """Validates the fields of the request.
 
             Raises:
-                 IllegalArgumentException if property is not set.
+                 IllegalArgumentException if schema_property is not set.
             """
             if not self._property:
-                raise ValueError('"property" field is required and cannot be empty')
+                raise ValueError('"schema_property" field is required and cannot be empty')
 
         def schema_change(self):
             return SchemaChange.remove_property(self._property)

--- a/clients/client-python/gravitino/dto/requests/schema_update_request.py
+++ b/clients/client-python/gravitino/dto/requests/schema_update_request.py
@@ -50,7 +50,9 @@ class SchemaUpdateRequest:
                  IllegalArgumentException if schema_property or value are not set.
             """
             if not self._property:
-                raise ValueError('"schema_property" field is required and cannot be empty')
+                raise ValueError(
+                    '"schema_property" field is required and cannot be empty'
+                )
             if not self._value:
                 raise ValueError('"value" field is required and cannot be empty')
 
@@ -75,7 +77,9 @@ class SchemaUpdateRequest:
                  IllegalArgumentException if schema_property is not set.
             """
             if not self._property:
-                raise ValueError('"schema_property" field is required and cannot be empty')
+                raise ValueError(
+                    '"schema_property" field is required and cannot be empty'
+                )
 
         def schema_change(self):
             return SchemaChange.remove_property(self._property)

--- a/clients/client-python/gravitino/dto/requests/schema_update_request.py
+++ b/clients/client-python/gravitino/dto/requests/schema_update_request.py
@@ -16,8 +16,8 @@ from gravitino.rest.rest_message import RESTRequest
 class SchemaUpdateRequestBase(RESTRequest):
     _type: str = field(metadata=config(field_name="@type"))
 
-    def __init__(self, type: str):
-        self._type = type
+    def __init__(self, action_type: str):
+        self._type = action_type
 
     @abstractmethod
     def schema_change(self):

--- a/clients/client-python/pylintrc
+++ b/clients/client-python/pylintrc
@@ -23,7 +23,6 @@ disable=missing-class-docstring,
         fixme,          
         unnecessary-pass,               
         missing-timeout,                #TODO-fix
-        redefined-builtin,              #TODO-fix
         broad-exception-caught,         #TODO-fix    
         duplicate-code,                 #TODO-fix
         method-hidden,                  #TODO-fix

--- a/clients/client-python/tests/integration/test_fileset_catalog.py
+++ b/clients/client-python/tests/integration/test_fileset_catalog.py
@@ -111,7 +111,7 @@ class TestFilesetCatalog(IntegrationTestEnv):
         )
         catalog = self.gravitino_client.create_catalog(
             ident=self.catalog_ident,
-            type=Catalog.Type.FILESET,
+            catalog_type=Catalog.Type.FILESET,
             provider=self.catalog_provider,
             comment="",
             properties={self.catalog_location_prop: "/tmp/test1"},
@@ -124,7 +124,7 @@ class TestFilesetCatalog(IntegrationTestEnv):
         catalog = self.gravitino_client.load_catalog(ident=self.catalog_ident)
         return catalog.as_fileset_catalog().create_fileset(
             ident=self.fileset_ident,
-            type=Fileset.Type.MANAGED,
+            fileset_type=Fileset.Type.MANAGED,
             comment=self.fileset_comment,
             storage_location=self.fileset_location,
             properties=self.fileset_properties,

--- a/clients/client-python/tests/integration/test_schema.py
+++ b/clients/client-python/tests/integration/test_schema.py
@@ -72,7 +72,7 @@ class TestSchema(IntegrationTestEnv):
         )
         self.gravitino_client.create_catalog(
             ident=self.catalog_ident,
-            type=Catalog.Type.FILESET,
+            catalog_type=Catalog.Type.FILESET,
             provider=self.catalog_provider,
             comment="",
             properties={self.catalog_location_prop: "/tmp/test_schema"},


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

* Replace varaible names `type` and `property`, which is Python functions and keywords, with more readable and custom variable names

### Why are the changes needed?

Fix: #3561 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

`./gradlew clients:client-python:test`
