### PR TITLE
[#3564] fix(client): spark connector failed to start in real spark3.3 envriment 

### DIFF
--- a/clients/client-java-runtime/build.gradle.kts
+++ b/clients/client-java-runtime/build.gradle.kts
@@ -24,7 +24,7 @@ tasks.withType<ShadowJar>(ShadowJar::class.java) {
   relocate("com.fasterxml", "com.datastrato.gravitino.shaded.com.fasterxml")
   relocate("org.apache.httpcomponents", "com.datastrato.gravitino.shaded.org.apache.httpcomponents")
   relocate("org.apache.commons", "com.datastrato.gravitino.shaded.org.apache.commons")
-  relocate("org.apache.logging.slf4j", "com.datastrato.gravitino.shaded.org.apache.logging.slf4j")
+  relocate("org.apache.logging", "com.datastrato.gravitino.shaded.org.apache.logging")
   relocate("org.antlr", "com.datastrato.gravitino.shaded.org.antlr")
 }
 

--- a/core/src/main/java/com/datastrato/gravitino/connector/PropertyEntry.java
+++ b/core/src/main/java/com/datastrato/gravitino/connector/PropertyEntry.java
@@ -11,7 +11,7 @@ import com.google.common.base.Preconditions;
 import java.util.EnumSet;
 import java.util.function.Function;
 import lombok.Getter;
-import org.apache.logging.log4j.util.Strings;
+import org.apache.commons.lang3.StringUtils;
 
 @Getter
 public final class PropertyEntry<T> {
@@ -51,9 +51,9 @@ public final class PropertyEntry<T> {
       Function<T, String> encoder,
       boolean hidden,
       boolean reserved) {
-    Preconditions.checkArgument(Strings.isNotBlank(name), "name cannot be null or empty");
+    Preconditions.checkArgument(StringUtils.isNotBlank(name), "name cannot be null or empty");
     Preconditions.checkArgument(
-        Strings.isNotBlank(description), "description cannot be null or empty");
+        StringUtils.isNotBlank(description), "description cannot be null or empty");
     Preconditions.checkArgument(javaType != null, "javaType cannot be null");
     Preconditions.checkArgument(decoder != null, "decoder cannot be null");
     Preconditions.checkArgument(encoder != null, "encoder cannot be null");

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/metadata/GravitinoCatalog.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/metadata/GravitinoCatalog.java
@@ -11,7 +11,7 @@ import com.datastrato.gravitino.NameIdentifier;
 import io.trino.spi.TrinoException;
 import java.time.Instant;
 import java.util.Map;
-import org.apache.logging.log4j.util.Strings;
+import org.apache.commons.lang3.StringUtils;
 
 /** Help Gravitino connector access CatalogMetadata from gravitino client. */
 public class GravitinoCatalog {
@@ -46,7 +46,7 @@ public class GravitinoCatalog {
 
   public String getRequiredProperty(String name) throws Exception {
     String value = catalog.properties().getOrDefault(name, "");
-    if (Strings.isBlank(value)) {
+    if (StringUtils.isBlank(value)) {
       throw new TrinoException(GRAVITINO_MISSING_CONFIG, "Missing required config: " + name);
     }
     return value;


### PR DESCRIPTION
### What changes were proposed in this pull request?
relocate `org.apache.logging.log4j` in `clients-java-runtime`

### Why are the changes needed?
Fix: #3564 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
1. existing UTs
2. start spark connector in spark 3.3 envriment