### PR TITLE
[#3593] fix(web): replace the Alata font family with Roboto whose license is under the Apache Software License 2.0

### DIFF
--- a/web/LICENSE
+++ b/web/LICENSE
@@ -215,6 +215,3 @@
    ./src/types/axios.d.ts
    ./src/lib/enums/httpEnum.ts
    ./src/lib/utils/index.js (parts of)
-
-   Third party SIL Open Font License v1.1 (OFL-1.1)
-   (SIL OPEN FONT LICENSE Version 1.1) The Alata font family (https://github.com/SorkinType/Alata)

--- a/web/src/app/login/page.js
+++ b/web/src/app/login/page.js
@@ -7,7 +7,7 @@
 
 import { useRouter } from 'next/navigation'
 import Image from 'next/image'
-import { Alata } from 'next/font/google'
+import { Roboto } from 'next/font/google'
 
 import { Box, Card, Grid, Button, CardContent, Typography, TextField, FormControl, FormHelperText } from '@mui/material'
 
@@ -19,7 +19,7 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import { useAppDispatch } from '@/lib/hooks/useStore'
 import { loginAction } from '@/lib/store/auth'
 
-const fonts = Alata({ subsets: ['latin'], weight: ['400'], display: 'swap' })
+const fonts = Roboto({ subsets: ['latin'], weight: ['400'], display: 'swap' })
 
 const defaultValues = {
   grant_type: 'client_credentials',

--- a/web/src/app/rootLayout/AppBar.js
+++ b/web/src/app/rootLayout/AppBar.js
@@ -7,7 +7,7 @@
 
 import Link from 'next/link'
 import Image from 'next/image'
-import { Alata } from 'next/font/google'
+import { Roboto } from 'next/font/google'
 
 import { useState, useEffect } from 'react'
 
@@ -32,7 +32,7 @@ import { useRouter } from 'next/navigation'
 import { useAppSelector, useAppDispatch } from '@/lib/hooks/useStore'
 import { fetchMetalakes } from '@/lib/store/metalakes'
 
-const fonts = Alata({ subsets: ['latin'], weight: ['400'], display: 'swap' })
+const fonts = Roboto({ subsets: ['latin'], weight: ['400'], display: 'swap' })
 
 const AppBar = () => {
   const searchParams = useSearchParams()


### PR DESCRIPTION

<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
replace the Alata font family with Roboto
before: 
<img width="228" alt="image" src="https://github.com/datastrato/gravitino/assets/9210625/f6838675-13eb-412d-b6cc-26e603d502c7">
after:
<img width="222" alt="image" src="https://github.com/datastrato/gravitino/assets/9210625/469327b0-159a-4356-9b92-89880ac597db">


### Why are the changes needed?

(Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, describe the bug.)

Fix: #3593

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
N/A
