### PR TITLE
[#3244] refactor(core, catalogs): decouple CatalogOperations and HasPropertyMetadata

### DIFF
--- a/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalog.java
+++ b/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalog.java
@@ -7,6 +7,7 @@ package com.datastrato.gravitino.catalog.hadoop;
 import com.datastrato.gravitino.catalog.hadoop.kerberos.KerberosConfig;
 import com.datastrato.gravitino.connector.BaseCatalog;
 import com.datastrato.gravitino.connector.CatalogOperations;
+import com.datastrato.gravitino.connector.PropertiesMetadata;
 import com.datastrato.gravitino.connector.ProxyPlugin;
 import com.datastrato.gravitino.connector.capability.Capability;
 import com.datastrato.gravitino.file.FilesetCatalog;
@@ -20,6 +21,15 @@ import java.util.Optional;
  * from different Hadoop Compatible File Systems in the same catalog.
  */
 public class HadoopCatalog extends BaseCatalog<HadoopCatalog> {
+
+  static final HadoopCatalogPropertiesMetadata CATALOG_PROPERTIES_META =
+      new HadoopCatalogPropertiesMetadata();
+
+  static final HadoopSchemaPropertiesMetadata SCHEMA_PROPERTIES_META =
+      new HadoopSchemaPropertiesMetadata();
+
+  static final HadoopFilesetPropertiesMetadata FILESET_PROPERTIES_META =
+      new HadoopFilesetPropertiesMetadata();
 
   @Override
   public String shortName() {
@@ -53,5 +63,20 @@ public class HadoopCatalog extends BaseCatalog<HadoopCatalog> {
       return Optional.empty();
     }
     return Optional.of(new HadoopProxyPlugin());
+  }
+
+  @Override
+  public PropertiesMetadata catalogPropertiesMetadata() throws UnsupportedOperationException {
+    return CATALOG_PROPERTIES_META;
+  }
+
+  @Override
+  public PropertiesMetadata schemaPropertiesMetadata() throws UnsupportedOperationException {
+    return SCHEMA_PROPERTIES_META;
+  }
+
+  @Override
+  public PropertiesMetadata filesetPropertiesMetadata() throws UnsupportedOperationException {
+    return FILESET_PROPERTIES_META;
   }
 }

--- a/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/main/java/com/datastrato/gravitino/catalog/hadoop/HadoopCatalogOperations.java
@@ -17,7 +17,7 @@ import com.datastrato.gravitino.catalog.hadoop.kerberos.AuthenticationConfig;
 import com.datastrato.gravitino.catalog.hadoop.kerberos.KerberosClient;
 import com.datastrato.gravitino.connector.CatalogInfo;
 import com.datastrato.gravitino.connector.CatalogOperations;
-import com.datastrato.gravitino.connector.PropertiesMetadata;
+import com.datastrato.gravitino.connector.HasPropertyMetadata;
 import com.datastrato.gravitino.connector.ProxyPlugin;
 import com.datastrato.gravitino.exceptions.AlreadyExistsException;
 import com.datastrato.gravitino.exceptions.FilesetAlreadyExistsException;
@@ -63,16 +63,9 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
 
   private static final Logger LOG = LoggerFactory.getLogger(HadoopCatalogOperations.class);
 
-  private static final HadoopCatalogPropertiesMetadata CATALOG_PROPERTIES_METADATA =
-      new HadoopCatalogPropertiesMetadata();
-
-  private static final HadoopSchemaPropertiesMetadata SCHEMA_PROPERTIES_METADATA =
-      new HadoopSchemaPropertiesMetadata();
-
-  private static final HadoopFilesetPropertiesMetadata FILESET_PROPERTIES_METADATA =
-      new HadoopFilesetPropertiesMetadata();
-
   private final EntityStore store;
+
+  private HasPropertyMetadata propertiesMetadata;
 
   @VisibleForTesting Configuration hadoopConf;
 
@@ -100,7 +93,10 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
   }
 
   @Override
-  public void initialize(Map<String, String> config, CatalogInfo info) throws RuntimeException {
+  public void initialize(
+      Map<String, String> config, CatalogInfo info, HasPropertyMetadata propertiesMetadata)
+      throws RuntimeException {
+    this.propertiesMetadata = propertiesMetadata;
     // Initialize Hadoop Configuration.
     this.conf = config;
     this.hadoopConf = new Configuration();
@@ -116,12 +112,12 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
 
     String catalogLocation =
         (String)
-            CATALOG_PROPERTIES_METADATA.getOrDefault(
-                config, HadoopCatalogPropertiesMetadata.LOCATION);
+            propertiesMetadata
+                .catalogPropertiesMetadata()
+                .getOrDefault(config, HadoopCatalogPropertiesMetadata.LOCATION);
     conf.forEach(hadoopConf::set);
 
     initAuthentication(conf, hadoopConf);
-
     this.catalogStorageLocation = Optional.ofNullable(catalogLocation).map(Path::new);
   }
 
@@ -526,33 +522,6 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
   }
 
   @Override
-  public PropertiesMetadata tablePropertiesMetadata() throws UnsupportedOperationException {
-    throw new UnsupportedOperationException(
-        "Hadoop fileset catalog doesn't support table related operations");
-  }
-
-  @Override
-  public PropertiesMetadata topicPropertiesMetadata() throws UnsupportedOperationException {
-    throw new UnsupportedOperationException(
-        "Hadoop fileset catalog doesn't support topic related operations");
-  }
-
-  @Override
-  public PropertiesMetadata catalogPropertiesMetadata() throws UnsupportedOperationException {
-    return CATALOG_PROPERTIES_METADATA;
-  }
-
-  @Override
-  public PropertiesMetadata schemaPropertiesMetadata() throws UnsupportedOperationException {
-    return SCHEMA_PROPERTIES_METADATA;
-  }
-
-  @Override
-  public PropertiesMetadata filesetPropertiesMetadata() throws UnsupportedOperationException {
-    return FILESET_PROPERTIES_METADATA;
-  }
-
-  @Override
   public void close() throws IOException {}
 
   private SchemaEntity updateSchemaEntity(
@@ -638,8 +607,9 @@ public class HadoopCatalogOperations implements CatalogOperations, SupportsSchem
   private Path getSchemaPath(String name, Map<String, String> properties) {
     String schemaLocation =
         (String)
-            SCHEMA_PROPERTIES_METADATA.getOrDefault(
-                properties, HadoopSchemaPropertiesMetadata.LOCATION);
+            propertiesMetadata
+                .schemaPropertiesMetadata()
+                .getOrDefault(properties, HadoopSchemaPropertiesMetadata.LOCATION);
 
     return Optional.ofNullable(schemaLocation)
         .map(Path::new)

--- a/catalogs/catalog-hadoop/src/test/java/com/datastrato/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
+++ b/catalogs/catalog-hadoop/src/test/java/com/datastrato/gravitino/catalog/hadoop/TestHadoopCatalogOperations.java
@@ -10,6 +10,9 @@ import static com.datastrato.gravitino.Configs.ENTITY_STORE;
 import static com.datastrato.gravitino.Configs.ENTRY_KV_ROCKSDB_BACKEND_PATH;
 import static com.datastrato.gravitino.Configs.STORE_DELETE_AFTER_TIME;
 import static com.datastrato.gravitino.Configs.STORE_TRANSACTION_MAX_SKEW_TIME;
+import static com.datastrato.gravitino.catalog.hadoop.HadoopCatalog.CATALOG_PROPERTIES_META;
+import static com.datastrato.gravitino.catalog.hadoop.HadoopCatalog.FILESET_PROPERTIES_META;
+import static com.datastrato.gravitino.catalog.hadoop.HadoopCatalog.SCHEMA_PROPERTIES_META;
 import static com.datastrato.gravitino.connector.BaseCatalog.CATALOG_BYPASS_PREFIX;
 
 import com.datastrato.gravitino.Config;
@@ -20,6 +23,8 @@ import com.datastrato.gravitino.EntityStoreFactory;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.StringIdentifier;
+import com.datastrato.gravitino.connector.HasPropertyMetadata;
+import com.datastrato.gravitino.connector.PropertiesMetadata;
 import com.datastrato.gravitino.exceptions.NoSuchFilesetException;
 import com.datastrato.gravitino.exceptions.NoSuchSchemaException;
 import com.datastrato.gravitino.exceptions.NonEmptySchemaException;
@@ -63,6 +68,34 @@ public class TestHadoopCatalogOperations {
 
   private static final String TEST_ROOT_PATH = "file:" + UNFORMALIZED_TEST_ROOT_PATH;
 
+  private static final HasPropertyMetadata HADOOP_PROPERTIES_METADATA =
+      new HasPropertyMetadata() {
+        @Override
+        public PropertiesMetadata tablePropertiesMetadata() throws UnsupportedOperationException {
+          throw new UnsupportedOperationException("Does not support table properties");
+        }
+
+        @Override
+        public PropertiesMetadata catalogPropertiesMetadata() throws UnsupportedOperationException {
+          return CATALOG_PROPERTIES_META;
+        }
+
+        @Override
+        public PropertiesMetadata schemaPropertiesMetadata() throws UnsupportedOperationException {
+          return SCHEMA_PROPERTIES_META;
+        }
+
+        @Override
+        public PropertiesMetadata filesetPropertiesMetadata() throws UnsupportedOperationException {
+          return FILESET_PROPERTIES_META;
+        }
+
+        @Override
+        public PropertiesMetadata topicPropertiesMetadata() throws UnsupportedOperationException {
+          throw new UnsupportedOperationException("Does not support topic properties");
+        }
+      };
+
   private static EntityStore store;
 
   private static IdGenerator idGenerator;
@@ -98,13 +131,13 @@ public class TestHadoopCatalogOperations {
   public void testHadoopCatalogConfiguration() {
     Map<String, String> emptyProps = Maps.newHashMap();
     HadoopCatalogOperations ops = new HadoopCatalogOperations(store);
-    ops.initialize(emptyProps, null);
+    ops.initialize(emptyProps, null, HADOOP_PROPERTIES_METADATA);
     Configuration conf = ops.hadoopConf;
     String value = conf.get("fs.defaultFS");
     Assertions.assertEquals("file:///", value);
 
     emptyProps.put(CATALOG_BYPASS_PREFIX + "fs.defaultFS", "hdfs://localhost:9000");
-    ops.initialize(emptyProps, null);
+    ops.initialize(emptyProps, null, HADOOP_PROPERTIES_METADATA);
     Configuration conf1 = ops.hadoopConf;
     String value1 = conf1.get("fs.defaultFS");
     Assertions.assertEquals("hdfs://localhost:9000", value1);
@@ -112,7 +145,7 @@ public class TestHadoopCatalogOperations {
     Assertions.assertFalse(ops.catalogStorageLocation.isPresent());
 
     emptyProps.put(HadoopCatalogPropertiesMetadata.LOCATION, "file:///tmp/catalog");
-    ops.initialize(emptyProps, null);
+    ops.initialize(emptyProps, null, HADOOP_PROPERTIES_METADATA);
     Assertions.assertTrue(ops.catalogStorageLocation.isPresent());
     Path expectedPath = new Path("file:///tmp/catalog");
     Assertions.assertEquals(expectedPath, ops.catalogStorageLocation.get());
@@ -193,7 +226,7 @@ public class TestHadoopCatalogOperations {
     Assertions.assertEquals(name, schema.name());
 
     try (HadoopCatalogOperations ops = new HadoopCatalogOperations(store)) {
-      ops.initialize(Maps.newHashMap(), null);
+      ops.initialize(Maps.newHashMap(), null, HADOOP_PROPERTIES_METADATA);
       Schema schema1 = ops.loadSchema(NameIdentifier.ofSchema("m1", "c1", name));
       Assertions.assertEquals(name, schema1.name());
       Assertions.assertEquals(comment, schema1.comment());
@@ -217,7 +250,7 @@ public class TestHadoopCatalogOperations {
     createSchema(name1, comment1, null, null);
 
     try (HadoopCatalogOperations ops = new HadoopCatalogOperations(store)) {
-      ops.initialize(Maps.newHashMap(), null);
+      ops.initialize(Maps.newHashMap(), null, HADOOP_PROPERTIES_METADATA);
       Set<NameIdentifier> idents =
           Arrays.stream(ops.listSchemas(Namespace.of("m1", "c1"))).collect(Collectors.toSet());
       Assertions.assertTrue(idents.size() >= 2);
@@ -235,7 +268,7 @@ public class TestHadoopCatalogOperations {
     Assertions.assertEquals(name, schema.name());
 
     try (HadoopCatalogOperations ops = new HadoopCatalogOperations(store)) {
-      ops.initialize(Maps.newHashMap(), null);
+      ops.initialize(Maps.newHashMap(), null, HADOOP_PROPERTIES_METADATA);
       Schema schema1 = ops.loadSchema(NameIdentifier.ofSchema("m1", "c1", name));
       Assertions.assertEquals(name, schema1.name());
       Assertions.assertEquals(comment, schema1.comment());
@@ -281,7 +314,10 @@ public class TestHadoopCatalogOperations {
     NameIdentifier id = NameIdentifier.ofSchema("m1", "c1", name);
 
     try (HadoopCatalogOperations ops = new HadoopCatalogOperations(store)) {
-      ops.initialize(ImmutableMap.of(HadoopCatalogPropertiesMetadata.LOCATION, catalogPath), null);
+      ops.initialize(
+          ImmutableMap.of(HadoopCatalogPropertiesMetadata.LOCATION, catalogPath),
+          null,
+          HADOOP_PROPERTIES_METADATA);
       Schema schema1 = ops.loadSchema(id);
       Assertions.assertEquals(name, schema1.name());
       Assertions.assertEquals(comment, schema1.comment());
@@ -335,7 +371,7 @@ public class TestHadoopCatalogOperations {
 
     NameIdentifier schemaIdent = NameIdentifier.ofSchema("m1", "c1", schemaName);
     try (HadoopCatalogOperations ops = new HadoopCatalogOperations(store)) {
-      ops.initialize(catalogProps, null);
+      ops.initialize(catalogProps, null, HADOOP_PROPERTIES_METADATA);
       if (!ops.schemaExists(schemaIdent)) {
         createSchema(schemaName, comment, catalogPath, schemaPath);
       }
@@ -387,7 +423,7 @@ public class TestHadoopCatalogOperations {
             + "location are not set",
         exception.getMessage());
     try (HadoopCatalogOperations ops = new HadoopCatalogOperations(store)) {
-      ops.initialize(Maps.newHashMap(), null);
+      ops.initialize(Maps.newHashMap(), null, HADOOP_PROPERTIES_METADATA);
       Throwable e =
           Assertions.assertThrows(
               NoSuchFilesetException.class, () -> ops.loadFileset(filesetIdent));
@@ -403,7 +439,7 @@ public class TestHadoopCatalogOperations {
         "Storage location must be set for external fileset " + filesetIdent,
         exception1.getMessage());
     try (HadoopCatalogOperations ops = new HadoopCatalogOperations(store)) {
-      ops.initialize(Maps.newHashMap(), null);
+      ops.initialize(Maps.newHashMap(), null, HADOOP_PROPERTIES_METADATA);
       Throwable e =
           Assertions.assertThrows(
               NoSuchFilesetException.class, () -> ops.loadFileset(filesetIdent));
@@ -423,7 +459,7 @@ public class TestHadoopCatalogOperations {
     }
 
     try (HadoopCatalogOperations ops = new HadoopCatalogOperations(store)) {
-      ops.initialize(Maps.newHashMap(), null);
+      ops.initialize(Maps.newHashMap(), null, HADOOP_PROPERTIES_METADATA);
       Set<NameIdentifier> idents =
           Arrays.stream(ops.listFilesets(Namespace.of("m1", "c1", schemaName)))
               .collect(Collectors.toSet());
@@ -454,7 +490,7 @@ public class TestHadoopCatalogOperations {
 
     NameIdentifier schemaIdent = NameIdentifier.ofSchema("m1", "c1", schemaName);
     try (HadoopCatalogOperations ops = new HadoopCatalogOperations(store)) {
-      ops.initialize(catalogProps, null);
+      ops.initialize(catalogProps, null, HADOOP_PROPERTIES_METADATA);
       if (!ops.schemaExists(schemaIdent)) {
         createSchema(schemaName, comment, catalogPath, schemaPath);
       }
@@ -500,7 +536,7 @@ public class TestHadoopCatalogOperations {
     FilesetChange change2 = FilesetChange.removeProperty("k1");
 
     try (HadoopCatalogOperations ops = new HadoopCatalogOperations(store)) {
-      ops.initialize(Maps.newHashMap(), null);
+      ops.initialize(Maps.newHashMap(), null, HADOOP_PROPERTIES_METADATA);
       NameIdentifier filesetIdent = NameIdentifier.of("m1", "c1", schemaName, name);
 
       Fileset fileset1 = ops.alterFileset(filesetIdent, change1);
@@ -565,7 +601,7 @@ public class TestHadoopCatalogOperations {
 
     FilesetChange change1 = FilesetChange.updateComment("comment26_new");
     try (HadoopCatalogOperations ops = new HadoopCatalogOperations(store)) {
-      ops.initialize(Maps.newHashMap(), null);
+      ops.initialize(Maps.newHashMap(), null, HADOOP_PROPERTIES_METADATA);
       NameIdentifier filesetIdent = NameIdentifier.of("m1", "c1", schemaName, name);
 
       Fileset fileset1 = ops.alterFileset(filesetIdent, change1);
@@ -817,7 +853,7 @@ public class TestHadoopCatalogOperations {
     }
 
     try (HadoopCatalogOperations ops = new HadoopCatalogOperations(store)) {
-      ops.initialize(props, null);
+      ops.initialize(props, null, HADOOP_PROPERTIES_METADATA);
 
       NameIdentifier schemaIdent = NameIdentifier.ofSchema("m1", "c1", name);
       Map<String, String> schemaProps = Maps.newHashMap();
@@ -846,7 +882,7 @@ public class TestHadoopCatalogOperations {
     }
 
     try (HadoopCatalogOperations ops = new HadoopCatalogOperations(store)) {
-      ops.initialize(props, null);
+      ops.initialize(props, null, HADOOP_PROPERTIES_METADATA);
 
       NameIdentifier filesetIdent = NameIdentifier.of("m1", "c1", schemaName, name);
       Map<String, String> filesetProps = Maps.newHashMap();

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalog.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalog.java
@@ -6,6 +6,7 @@ package com.datastrato.gravitino.catalog.hive;
 
 import com.datastrato.gravitino.connector.BaseCatalog;
 import com.datastrato.gravitino.connector.CatalogOperations;
+import com.datastrato.gravitino.connector.PropertiesMetadata;
 import com.datastrato.gravitino.connector.ProxyPlugin;
 import com.datastrato.gravitino.connector.capability.Capability;
 import com.datastrato.gravitino.rel.SupportsSchemas;
@@ -15,6 +16,15 @@ import java.util.Optional;
 
 /** Implementation of a Hive catalog in Gravitino. */
 public class HiveCatalog extends BaseCatalog<HiveCatalog> {
+
+  static final HiveCatalogPropertiesMeta CATALOG_PROPERTIES_METADATA =
+      new HiveCatalogPropertiesMeta();
+
+  static final HiveSchemaPropertiesMetadata SCHEMA_PROPERTIES_METADATA =
+      new HiveSchemaPropertiesMetadata();
+
+  static final HiveTablePropertiesMetadata TABLE_PROPERTIES_METADATA =
+      new HiveTablePropertiesMetadata();
 
   /**
    * Returns the short name of the Hive catalog.
@@ -73,5 +83,20 @@ public class HiveCatalog extends BaseCatalog<HiveCatalog> {
       return Optional.empty();
     }
     return Optional.of(new HiveProxyPlugin());
+  }
+
+  @Override
+  public PropertiesMetadata catalogPropertiesMetadata() throws UnsupportedOperationException {
+    return CATALOG_PROPERTIES_METADATA;
+  }
+
+  @Override
+  public PropertiesMetadata schemaPropertiesMetadata() throws UnsupportedOperationException {
+    return SCHEMA_PROPERTIES_METADATA;
+  }
+
+  @Override
+  public PropertiesMetadata tablePropertiesMetadata() throws UnsupportedOperationException {
+    return TABLE_PROPERTIES_METADATA;
   }
 }

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
@@ -20,7 +20,7 @@ import com.datastrato.gravitino.catalog.hive.HiveTablePropertiesMetadata.TableTy
 import com.datastrato.gravitino.catalog.hive.converter.ToHiveType;
 import com.datastrato.gravitino.connector.CatalogInfo;
 import com.datastrato.gravitino.connector.CatalogOperations;
-import com.datastrato.gravitino.connector.PropertiesMetadata;
+import com.datastrato.gravitino.connector.HasPropertyMetadata;
 import com.datastrato.gravitino.connector.ProxyPlugin;
 import com.datastrato.gravitino.exceptions.NoSuchCatalogException;
 import com.datastrato.gravitino.exceptions.NoSuchSchemaException;
@@ -92,11 +92,7 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
 
   private CatalogInfo info;
 
-  private HiveTablePropertiesMetadata tablePropertiesMetadata;
-
-  private HiveCatalogPropertiesMeta catalogPropertiesMetadata;
-
-  private HiveSchemaPropertiesMetadata schemaPropertiesMetadata;
+  private HasPropertyMetadata propertiesMetadata;
 
   private ScheduledThreadPoolExecutor checkTgtExecutor;
   private String kerberosRealm;
@@ -113,14 +109,15 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
    *
    * @param conf The configuration map for the Hive catalog operations.
    * @param info The catalog info associated with this operations instance.
+   * @param propertiesMetadata The properties metadata of Hive catalog.
    * @throws RuntimeException if initialization fails.
    */
   @Override
-  public void initialize(Map<String, String> conf, CatalogInfo info) throws RuntimeException {
+  public void initialize(
+      Map<String, String> conf, CatalogInfo info, HasPropertyMetadata propertiesMetadata)
+      throws RuntimeException {
     this.info = info;
-    this.tablePropertiesMetadata = new HiveTablePropertiesMetadata();
-    this.catalogPropertiesMetadata = new HiveCatalogPropertiesMeta();
-    this.schemaPropertiesMetadata = new HiveSchemaPropertiesMetadata();
+    this.propertiesMetadata = propertiesMetadata;
 
     // Key format like gravitino.bypass.a.b
     Map<String, String> byPassConfig = Maps.newHashMap();
@@ -174,7 +171,9 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
 
         String keytabUri =
             (String)
-                catalogPropertiesMetadata.getOrDefault(conf, HiveCatalogPropertiesMeta.KEY_TAB_URI);
+                propertiesMetadata
+                    .catalogPropertiesMetadata()
+                    .getOrDefault(conf, HiveCatalogPropertiesMeta.KEY_TAB_URI);
         Preconditions.checkArgument(StringUtils.isNotBlank(keytabUri), "Keytab uri can't be blank");
         // TODO: Support to download the file from Kerberos HDFS
         Preconditions.checkArgument(
@@ -182,14 +181,16 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
 
         int fetchKeytabFileTimeout =
             (int)
-                catalogPropertiesMetadata.getOrDefault(
-                    conf, HiveCatalogPropertiesMeta.FETCH_TIMEOUT_SEC);
+                propertiesMetadata
+                    .catalogPropertiesMetadata()
+                    .getOrDefault(conf, HiveCatalogPropertiesMeta.FETCH_TIMEOUT_SEC);
 
         FetchFileUtils.fetchFileFromUri(keytabUri, keytabFile, fetchKeytabFileTimeout, hadoopConf);
 
         hiveConf.setVar(ConfVars.METASTORE_KERBEROS_KEYTAB_FILE, keytabFile.getAbsolutePath());
 
-        String catalogPrincipal = (String) catalogPropertiesMetadata.getOrDefault(conf, PRINCIPAL);
+        String catalogPrincipal =
+            (String) propertiesMetadata.catalogPropertiesMetadata().getOrDefault(conf, PRINCIPAL);
         Preconditions.checkArgument(
             StringUtils.isNotBlank(catalogPrincipal), "The principal can't be blank");
         @SuppressWarnings("null")
@@ -212,8 +213,9 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
 
         int checkInterval =
             (int)
-                catalogPropertiesMetadata.getOrDefault(
-                    conf, HiveCatalogPropertiesMeta.CHECK_INTERVAL_SEC);
+                propertiesMetadata
+                    .catalogPropertiesMetadata()
+                    .getOrDefault(conf, HiveCatalogPropertiesMeta.CHECK_INTERVAL_SEC);
 
         checkTgtExecutor.scheduleAtFixedRate(
             () -> {
@@ -253,12 +255,15 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
 
   @VisibleForTesting
   int getClientPoolSize(Map<String, String> conf) {
-    return (int) catalogPropertiesMetadata.getOrDefault(conf, CLIENT_POOL_SIZE);
+    return (int)
+        propertiesMetadata.catalogPropertiesMetadata().getOrDefault(conf, CLIENT_POOL_SIZE);
   }
 
   long getCacheEvictionInterval(Map<String, String> conf) {
     return (long)
-        catalogPropertiesMetadata.getOrDefault(conf, CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS);
+        propertiesMetadata
+            .catalogPropertiesMetadata()
+            .getOrDefault(conf, CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS);
   }
 
   /** Closes the Hive catalog and releases the associated client pool. */
@@ -695,7 +700,9 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
     validatePartitionForCreate(columns, partitioning);
     validateDistributionAndSort(distribution, sortOrders);
 
-    TableType tableType = (TableType) tablePropertiesMetadata.getOrDefault(properties, TABLE_TYPE);
+    TableType tableType =
+        (TableType)
+            propertiesMetadata.tablePropertiesMetadata().getOrDefault(properties, TABLE_TYPE);
     Preconditions.checkArgument(
         SUPPORT_TABLE_TYPES.contains(tableType.name()),
         "Unsupported table type: " + tableType.name());
@@ -726,7 +733,7 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
               .build();
       clientPool.run(
           c -> {
-            c.createTable(hiveTable.toHiveTable(tablePropertiesMetadata));
+            c.createTable(hiveTable.toHiveTable(propertiesMetadata.tablePropertiesMetadata()));
             return null;
           });
 
@@ -766,7 +773,7 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
       // TODO(@Minghuang): require a table lock to avoid race condition
       HiveTable table = (HiveTable) loadTable(tableIdent);
       org.apache.hadoop.hive.metastore.api.Table alteredHiveTable =
-          table.toHiveTable(tablePropertiesMetadata);
+          table.toHiveTable(propertiesMetadata.tablePropertiesMetadata());
 
       validateColumnChangeForAlter(changes, alteredHiveTable);
 
@@ -1041,33 +1048,6 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
-  }
-
-  @Override
-  public PropertiesMetadata tablePropertiesMetadata() throws UnsupportedOperationException {
-    return tablePropertiesMetadata;
-  }
-
-  @Override
-  public PropertiesMetadata catalogPropertiesMetadata() throws UnsupportedOperationException {
-    return catalogPropertiesMetadata;
-  }
-
-  @Override
-  public PropertiesMetadata schemaPropertiesMetadata() throws UnsupportedOperationException {
-    return schemaPropertiesMetadata;
-  }
-
-  @Override
-  public PropertiesMetadata filesetPropertiesMetadata() throws UnsupportedOperationException {
-    throw new UnsupportedOperationException(
-        "Hive catalog does not support fileset properties metadata");
-  }
-
-  @Override
-  public PropertiesMetadata topicPropertiesMetadata() throws UnsupportedOperationException {
-    throw new UnsupportedOperationException(
-        "Hive catalog does not support topic properties metadata");
   }
 
   CachedClientPool getClientPool() {

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveTable.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveTable.java
@@ -22,6 +22,7 @@ import com.datastrato.gravitino.catalog.hive.HiveTablePropertiesMetadata.TableTy
 import com.datastrato.gravitino.catalog.hive.converter.FromHiveType;
 import com.datastrato.gravitino.catalog.hive.converter.ToHiveType;
 import com.datastrato.gravitino.connector.BaseTable;
+import com.datastrato.gravitino.connector.PropertiesMetadata;
 import com.datastrato.gravitino.connector.TableOperations;
 import com.datastrato.gravitino.meta.AuditInfo;
 import com.datastrato.gravitino.rel.Column;
@@ -184,7 +185,7 @@ public class HiveTable extends BaseTable {
    *
    * @return The converted Table.
    */
-  public Table toHiveTable(HiveTablePropertiesMetadata tablePropertiesMetadata) {
+  public Table toHiveTable(PropertiesMetadata tablePropertiesMetadata) {
     Table hiveTable = new Table();
 
     hiveTable.setTableName(name);
@@ -243,7 +244,7 @@ public class HiveTable extends BaseTable {
   }
 
   private StorageDescriptor buildStorageDescriptor(
-      HiveTablePropertiesMetadata tablePropertiesMetadata, List<FieldSchema> partitionFields) {
+      PropertiesMetadata tablePropertiesMetadata, List<FieldSchema> partitionFields) {
     StorageDescriptor sd = new StorageDescriptor();
     List<String> partitionKeys =
         partitionFields.stream().map(FieldSchema::getName).collect(Collectors.toList());
@@ -291,7 +292,7 @@ public class HiveTable extends BaseTable {
     return sd;
   }
 
-  private SerDeInfo buildSerDeInfo(HiveTablePropertiesMetadata tablePropertiesMetadata) {
+  private SerDeInfo buildSerDeInfo(PropertiesMetadata tablePropertiesMetadata) {
     SerDeInfo serDeInfo = new SerDeInfo();
     serDeInfo.setName(properties().getOrDefault(SERDE_NAME, name()));
 

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveCatalog.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveCatalog.java
@@ -4,11 +4,15 @@
  */
 package com.datastrato.gravitino.catalog.hive;
 
+import static com.datastrato.gravitino.catalog.hive.HiveCatalog.CATALOG_PROPERTIES_METADATA;
+import static com.datastrato.gravitino.catalog.hive.HiveCatalog.SCHEMA_PROPERTIES_METADATA;
+import static com.datastrato.gravitino.catalog.hive.HiveCatalog.TABLE_PROPERTIES_METADATA;
 import static com.datastrato.gravitino.catalog.hive.HiveCatalogPropertiesMeta.METASTORE_URIS;
 
 import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.catalog.PropertiesMetadataHelpers;
 import com.datastrato.gravitino.catalog.hive.miniHMS.MiniHiveMetastoreService;
+import com.datastrato.gravitino.connector.HasPropertyMetadata;
 import com.datastrato.gravitino.connector.PropertiesMetadata;
 import com.datastrato.gravitino.meta.AuditInfo;
 import com.datastrato.gravitino.meta.CatalogEntity;
@@ -22,6 +26,34 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestHiveCatalog extends MiniHiveMetastoreService {
+  public static final HasPropertyMetadata HIVE_PROPERTIES_METADATA =
+      new HasPropertyMetadata() {
+        @Override
+        public PropertiesMetadata tablePropertiesMetadata() throws UnsupportedOperationException {
+          return TABLE_PROPERTIES_METADATA;
+        }
+
+        @Override
+        public PropertiesMetadata catalogPropertiesMetadata() throws UnsupportedOperationException {
+          return CATALOG_PROPERTIES_METADATA;
+        }
+
+        @Override
+        public PropertiesMetadata schemaPropertiesMetadata() throws UnsupportedOperationException {
+          return SCHEMA_PROPERTIES_METADATA;
+        }
+
+        @Override
+        public PropertiesMetadata filesetPropertiesMetadata() throws UnsupportedOperationException {
+          throw new UnsupportedOperationException("Fileset properties are not supported");
+        }
+
+        @Override
+        public PropertiesMetadata topicPropertiesMetadata() throws UnsupportedOperationException {
+          throw new UnsupportedOperationException("Topic properties are not supported");
+        }
+      };
+
   @Test
   public void testListDatabases() throws TException, InterruptedException {
     AuditInfo auditInfo =
@@ -41,7 +73,7 @@ public class TestHiveCatalog extends MiniHiveMetastoreService {
     metastore.hiveConf().forEach(e -> conf.put(e.getKey(), e.getValue()));
 
     try (HiveCatalogOperations ops = new HiveCatalogOperations()) {
-      ops.initialize(conf, entity.toCatalogInfo());
+      ops.initialize(conf, entity.toCatalogInfo(), HIVE_PROPERTIES_METADATA);
       List<String> dbs = ops.clientPool.run(IMetaStoreClient::getAllDatabases);
       Assertions.assertEquals(2, dbs.size());
       Assertions.assertTrue(dbs.contains("default"));
@@ -51,45 +83,29 @@ public class TestHiveCatalog extends MiniHiveMetastoreService {
 
   @Test
   void testCatalogProperty() {
-    AuditInfo auditInfo =
-        AuditInfo.builder().withCreator("creator").withCreateTime(Instant.now()).build();
-
-    CatalogEntity entity =
-        CatalogEntity.builder()
-            .withId(1L)
-            .withName("catalog")
-            .withNamespace(Namespace.of("metalake"))
-            .withType(HiveCatalog.Type.RELATIONAL)
-            .withProvider("hive")
-            .withAuditInfo(auditInfo)
-            .build();
-
-    Map<String, String> conf = Maps.newHashMap();
     Map<String, String> properties = Maps.newHashMap();
+    metastore.hiveConf().forEach(e -> properties.put(e.getKey(), e.getValue()));
+    PropertiesMetadata catalogPropertiesMetadata =
+        HIVE_PROPERTIES_METADATA.catalogPropertiesMetadata();
 
-    metastore.hiveConf().forEach(e -> conf.put(e.getKey(), e.getValue()));
+    Assertions.assertDoesNotThrow(
+        () -> {
+          Map<String, String> map = Maps.newHashMap();
+          map.put(METASTORE_URIS, "/tmp");
+          PropertiesMetadataHelpers.validatePropertyForCreate(catalogPropertiesMetadata, map);
+        });
 
-    try (HiveCatalogOperations ops = new HiveCatalogOperations()) {
-      ops.initialize(conf, entity.toCatalogInfo());
-      PropertiesMetadata metadata = ops.catalogPropertiesMetadata();
+    Throwable throwable =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                PropertiesMetadataHelpers.validatePropertyForCreate(
+                    catalogPropertiesMetadata, properties));
 
-      Assertions.assertDoesNotThrow(
-          () -> {
-            Map<String, String> map = Maps.newHashMap();
-            map.put(METASTORE_URIS, "/tmp");
-            PropertiesMetadataHelpers.validatePropertyForCreate(metadata, map);
-          });
-
-      Throwable throwable =
-          Assertions.assertThrows(
-              IllegalArgumentException.class,
-              () -> PropertiesMetadataHelpers.validatePropertyForCreate(metadata, properties));
-
-      Assertions.assertTrue(
-          throwable
-              .getMessage()
-              .contains(
-                  String.format("Properties are required and must be set: [%s]", METASTORE_URIS)));
-    }
+    Assertions.assertTrue(
+        throwable
+            .getMessage()
+            .contains(
+                String.format("Properties are required and must be set: [%s]", METASTORE_URIS)));
   }
 }

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/TestHiveCatalogOperations.java
@@ -13,6 +13,7 @@ import static com.datastrato.gravitino.catalog.hive.HiveCatalogPropertiesMeta.IM
 import static com.datastrato.gravitino.catalog.hive.HiveCatalogPropertiesMeta.KEY_TAB_URI;
 import static com.datastrato.gravitino.catalog.hive.HiveCatalogPropertiesMeta.METASTORE_URIS;
 import static com.datastrato.gravitino.catalog.hive.HiveCatalogPropertiesMeta.PRINCIPAL;
+import static com.datastrato.gravitino.catalog.hive.TestHiveCatalog.HIVE_PROPERTIES_METADATA;
 import static com.datastrato.gravitino.connector.BaseCatalog.CATALOG_BYPASS_PREFIX;
 
 import com.datastrato.gravitino.Catalog;
@@ -31,43 +32,41 @@ class TestHiveCatalogOperations {
     Map<String, String> maps = Maps.newHashMap();
     maps.put(CLIENT_POOL_SIZE, "10");
     HiveCatalogOperations op = new HiveCatalogOperations();
-    op.initialize(maps, null);
+    op.initialize(maps, null, HIVE_PROPERTIES_METADATA);
     Assertions.assertEquals(10, op.getClientPoolSize(maps));
 
     maps.clear();
     maps.put(CLIENT_POOL_SIZE + "_wrong_mark", "10");
     op = new HiveCatalogOperations();
-    op.initialize(maps, null);
+    op.initialize(maps, null, HIVE_PROPERTIES_METADATA);
     Assertions.assertNotEquals(10, op.getClientPoolSize(maps));
 
     maps.put(CLIENT_POOL_SIZE, "1");
     op = new HiveCatalogOperations();
-    op.initialize(maps, null);
+    op.initialize(maps, null, HIVE_PROPERTIES_METADATA);
     Assertions.assertEquals(1, op.getClientPoolSize(maps));
   }
 
   @Test
-  void testInitialize() throws NoSuchFieldException, IllegalAccessException {
+  void testInitialize() {
     Map<String, String> properties = Maps.newHashMap();
     HiveCatalogOperations hiveCatalogOperations = new HiveCatalogOperations();
-    hiveCatalogOperations.initialize(properties, null);
+    hiveCatalogOperations.initialize(properties, null, HIVE_PROPERTIES_METADATA);
     String v = hiveCatalogOperations.hiveConf.get("mapreduce.job.reduces");
     Assertions.assertEquals("10", v);
 
     // Test If we can override the value in hive-site.xml
     properties.put(CATALOG_BYPASS_PREFIX + "mapreduce.job.reduces", "20");
-    hiveCatalogOperations.initialize(properties, null);
+    hiveCatalogOperations.initialize(properties, null, HIVE_PROPERTIES_METADATA);
     v = hiveCatalogOperations.hiveConf.get("mapreduce.job.reduces");
     Assertions.assertEquals("20", v);
   }
 
   @Test
   void testPropertyMeta() {
-    HiveCatalogOperations hiveCatalogOperations = new HiveCatalogOperations();
-    hiveCatalogOperations.initialize(Maps.newHashMap(), null);
-
     Map<String, PropertyEntry<?>> propertyEntryMap =
-        hiveCatalogOperations.catalogPropertiesMetadata().propertyEntries();
+        HIVE_PROPERTIES_METADATA.catalogPropertiesMetadata().propertyEntries();
+
     Assertions.assertEquals(11, propertyEntryMap.size());
     Assertions.assertTrue(propertyEntryMap.containsKey(METASTORE_URIS));
     Assertions.assertTrue(propertyEntryMap.containsKey(Catalog.PROPERTY_PACKAGE));
@@ -101,7 +100,7 @@ class TestHiveCatalogOperations {
     maps.put(ConfVars.METASTOREURIS.varname, "url2");
     maps.put(CATALOG_BYPASS_PREFIX + ConfVars.METASTOREURIS.varname, "url3");
     HiveCatalogOperations op = new HiveCatalogOperations();
-    op.initialize(maps, null);
+    op.initialize(maps, null, HIVE_PROPERTIES_METADATA);
 
     Assertions.assertEquals("v2", op.hiveConf.get("a.b"));
     Assertions.assertEquals("v4", op.hiveConf.get("c.d"));

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
@@ -31,6 +31,7 @@ import com.datastrato.gravitino.Catalog;
 import com.datastrato.gravitino.CatalogChange;
 import com.datastrato.gravitino.MetalakeChange;
 import com.datastrato.gravitino.NameIdentifier;
+import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.auth.AuthConstants;
 import com.datastrato.gravitino.catalog.hive.HiveCatalogOperations;
 import com.datastrato.gravitino.catalog.hive.HiveClientPool;
@@ -1653,7 +1654,11 @@ public class CatalogHiveIT extends AbstractIT {
 
     Catalog catalog =
         metalake.createCatalog(
-            catalogName, Catalog.Type.RELATIONAL, provider, "comment", properties);
-    catalog.asSchemas().listSchemas();
+            NameIdentifier.ofCatalog(metalakeName, catalogName),
+            Catalog.Type.RELATIONAL,
+            provider,
+            "comment",
+            properties);
+    catalog.asSchemas().listSchemas(Namespace.ofSchema(metalakeName, catalogName));
   }
 }

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
@@ -1651,11 +1651,9 @@ public class CatalogHiveIT extends AbstractIT {
     properties.put(METASTORE_URIS, HIVE_METASTORE_URIS);
     properties.put(BaseCatalog.CATALOG_OPERATION_IMPL, customImpl);
 
-    metalake.createCatalog(
-        NameIdentifier.of(metalakeName, catalogName),
-        Catalog.Type.RELATIONAL,
-        provider,
-        "comment",
-        properties);
+    Catalog catalog =
+        metalake.createCatalog(
+            catalogName, Catalog.Type.RELATIONAL, provider, "comment", properties);
+    catalog.asSchemas().listSchemas();
   }
 }

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalog.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalog.java
@@ -11,6 +11,7 @@ import com.datastrato.gravitino.catalog.jdbc.operation.JdbcDatabaseOperations;
 import com.datastrato.gravitino.catalog.jdbc.operation.JdbcTableOperations;
 import com.datastrato.gravitino.connector.BaseCatalog;
 import com.datastrato.gravitino.connector.CatalogOperations;
+import com.datastrato.gravitino.connector.PropertiesMetadata;
 import com.datastrato.gravitino.connector.PropertyEntry;
 import com.datastrato.gravitino.rel.SupportsSchemas;
 import com.datastrato.gravitino.rel.TableCatalog;
@@ -19,6 +20,20 @@ import java.util.Map;
 
 /** Implementation of an Jdbc catalog in Gravitino. */
 public abstract class JdbcCatalog extends BaseCatalog<JdbcCatalog> {
+
+  private static final JdbcCatalogPropertiesMetadata CATALOG_PROPERTIES_META =
+      new JdbcCatalogPropertiesMetadata();
+
+  private static final JdbcSchemaPropertiesMetadata SCHEMA_PROPERTIES_META =
+      new JdbcSchemaPropertiesMetadata();
+
+  private static final JdbcTablePropertiesMetadata TABLE_PROPERTIES_META =
+      new JdbcTablePropertiesMetadata() {
+        @Override
+        protected Map<String, PropertyEntry<?>> specificPropertyEntries() {
+          return Collections.emptyMap();
+        }
+      };
 
   /**
    * Creates a new instance of {@link JdbcCatalogOperations} with the provided configuration.
@@ -35,7 +50,6 @@ public abstract class JdbcCatalog extends BaseCatalog<JdbcCatalog> {
             jdbcTypeConverter,
             createJdbcDatabaseOperations(),
             createJdbcTableOperations(),
-            createJdbcTablePropertiesMetadata(),
             createJdbcColumnDefaultValueConverter());
     return ops;
   }
@@ -68,17 +82,21 @@ public abstract class JdbcCatalog extends BaseCatalog<JdbcCatalog> {
   /** @return The {@link JdbcTableOperations} to be used by the catalog to manage tables in the */
   protected abstract JdbcTableOperations createJdbcTableOperations();
 
-  /** @return The {@link JdbcTablePropertiesMetadata} to be used by the catalog to manage table */
-  protected JdbcTablePropertiesMetadata createJdbcTablePropertiesMetadata() {
-    return new JdbcTablePropertiesMetadata() {
-
-      @Override
-      protected Map<String, PropertyEntry<?>> specificPropertyEntries() {
-        return Collections.emptyMap();
-      }
-    };
-  }
-
   /** @return The {@link JdbcColumnDefaultValueConverter} to be used by the catalog */
   protected abstract JdbcColumnDefaultValueConverter createJdbcColumnDefaultValueConverter();
+
+  @Override
+  public PropertiesMetadata catalogPropertiesMetadata() throws UnsupportedOperationException {
+    return CATALOG_PROPERTIES_META;
+  }
+
+  @Override
+  public PropertiesMetadata schemaPropertiesMetadata() throws UnsupportedOperationException {
+    return SCHEMA_PROPERTIES_META;
+  }
+
+  @Override
+  public PropertiesMetadata tablePropertiesMetadata() throws UnsupportedOperationException {
+    return TABLE_PROPERTIES_META;
+  }
 }

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
@@ -21,7 +21,6 @@ import com.datastrato.gravitino.catalog.jdbc.utils.DataSourceUtils;
 import com.datastrato.gravitino.connector.CatalogInfo;
 import com.datastrato.gravitino.connector.CatalogOperations;
 import com.datastrato.gravitino.connector.HasPropertyMetadata;
-import com.datastrato.gravitino.connector.SupportsSchemas;
 import com.datastrato.gravitino.exceptions.NoSuchCatalogException;
 import com.datastrato.gravitino.exceptions.NoSuchSchemaException;
 import com.datastrato.gravitino.exceptions.NoSuchTableException;

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/JdbcCatalogOperations.java
@@ -20,7 +20,8 @@ import com.datastrato.gravitino.catalog.jdbc.operation.TableOperation;
 import com.datastrato.gravitino.catalog.jdbc.utils.DataSourceUtils;
 import com.datastrato.gravitino.connector.CatalogInfo;
 import com.datastrato.gravitino.connector.CatalogOperations;
-import com.datastrato.gravitino.connector.PropertiesMetadata;
+import com.datastrato.gravitino.connector.HasPropertyMetadata;
+import com.datastrato.gravitino.connector.SupportsSchemas;
 import com.datastrato.gravitino.exceptions.NoSuchCatalogException;
 import com.datastrato.gravitino.exceptions.NoSuchSchemaException;
 import com.datastrato.gravitino.exceptions.NoSuchTableException;
@@ -71,8 +72,6 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
 
   private JdbcTablePropertiesMetadata jdbcTablePropertiesMetadata;
 
-  private JdbcSchemaPropertiesMetadata jdbcSchemaPropertiesMetadata;
-
   private final JdbcExceptionConverter exceptionConverter;
 
   private final JdbcTypeConverter jdbcTypeConverter;
@@ -92,20 +91,19 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
    * @param jdbcTypeConverter The type converter to be used by the operations.
    * @param databaseOperation The database operations to be used by the operations.
    * @param tableOperation The table operations to be used by the operations.
-   * @param jdbcTablePropertiesMetadata The table properties metadata to be used by the operations.
+   * @param columnDefaultValueConverter The column default value converter to be used by the
+   *     operations.
    */
   public JdbcCatalogOperations(
       JdbcExceptionConverter exceptionConverter,
       JdbcTypeConverter jdbcTypeConverter,
       JdbcDatabaseOperations databaseOperation,
       JdbcTableOperations tableOperation,
-      JdbcTablePropertiesMetadata jdbcTablePropertiesMetadata,
       JdbcColumnDefaultValueConverter columnDefaultValueConverter) {
     this.exceptionConverter = exceptionConverter;
     this.jdbcTypeConverter = jdbcTypeConverter;
     this.databaseOperation = databaseOperation;
     this.tableOperation = tableOperation;
-    this.jdbcTablePropertiesMetadata = jdbcTablePropertiesMetadata;
     this.columnDefaultValueConverter = columnDefaultValueConverter;
   }
 
@@ -117,12 +115,18 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
    * @throws RuntimeException if initialization fails.
    */
   @Override
-  public void initialize(Map<String, String> conf, CatalogInfo info) throws RuntimeException {
+  public void initialize(
+      Map<String, String> conf, CatalogInfo info, HasPropertyMetadata propertiesMetadata)
+      throws RuntimeException {
+    this.jdbcCatalogPropertiesMetadata =
+        (JdbcCatalogPropertiesMetadata) propertiesMetadata.catalogPropertiesMetadata();
+    this.jdbcTablePropertiesMetadata =
+        (JdbcTablePropertiesMetadata) propertiesMetadata.tablePropertiesMetadata();
+
     // Key format like gravitino.bypass.a.b
     Map<String, String> prefixMap = MapUtils.getPrefixMap(conf, CATALOG_BYPASS_PREFIX);
 
     // Hold keys that lie in JDBC_IMMUTABLE_PROPERTIES
-    this.jdbcCatalogPropertiesMetadata = new JdbcCatalogPropertiesMetadata();
     Map<String, String> gravitinoConfig =
         this.jdbcCatalogPropertiesMetadata.transformProperties(conf);
     Map<String, String> resultConf = Maps.newHashMap(prefixMap);
@@ -133,7 +137,6 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
     this.databaseOperation.initialize(dataSource, exceptionConverter, resultConf);
     this.tableOperation.initialize(
         dataSource, exceptionConverter, jdbcTypeConverter, columnDefaultValueConverter, resultConf);
-    this.jdbcSchemaPropertiesMetadata = new JdbcSchemaPropertiesMetadata();
   }
 
   /** Closes the Jdbc catalog and releases the associated client pool. */
@@ -486,33 +489,6 @@ public class JdbcCatalogOperations implements CatalogOperations, SupportsSchemas
   // TODO. We should figure out a better way to get the current user from servlet container.
   private static String currentUser() {
     return System.getProperty("user.name");
-  }
-
-  @Override
-  public PropertiesMetadata tablePropertiesMetadata() throws UnsupportedOperationException {
-    return jdbcTablePropertiesMetadata;
-  }
-
-  @Override
-  public PropertiesMetadata catalogPropertiesMetadata() throws UnsupportedOperationException {
-    return jdbcCatalogPropertiesMetadata;
-  }
-
-  @Override
-  public PropertiesMetadata schemaPropertiesMetadata() throws UnsupportedOperationException {
-    return jdbcSchemaPropertiesMetadata;
-  }
-
-  @Override
-  public PropertiesMetadata filesetPropertiesMetadata() throws UnsupportedOperationException {
-    throw new UnsupportedOperationException(
-        "Jdbc catalog doesn't support fileset related operations");
-  }
-
-  @Override
-  public PropertiesMetadata topicPropertiesMetadata() throws UnsupportedOperationException {
-    throw new UnsupportedOperationException(
-        "Jdbc catalog doesn't support topic related operations");
   }
 
   public void deregisterDriver(Driver driver) throws SQLException {

--- a/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/MySQLProtocolCompatibleCatalogOperations.java
+++ b/catalogs/catalog-jdbc-common/src/main/java/com/datastrato/gravitino/catalog/jdbc/MySQLProtocolCompatibleCatalogOperations.java
@@ -24,14 +24,12 @@ public class MySQLProtocolCompatibleCatalogOperations extends JdbcCatalogOperati
       JdbcTypeConverter jdbcTypeConverter,
       JdbcDatabaseOperations databaseOperation,
       JdbcTableOperations tableOperation,
-      JdbcTablePropertiesMetadata jdbcTablePropertiesMetadata,
       JdbcColumnDefaultValueConverter columnDefaultValueConverter) {
     super(
         exceptionConverter,
         jdbcTypeConverter,
         databaseOperation,
         tableOperation,
-        jdbcTablePropertiesMetadata,
         columnDefaultValueConverter);
   }
 

--- a/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/DorisCatalog.java
+++ b/catalogs/catalog-jdbc-doris/src/main/java/com/datastrato/gravitino/catalog/doris/DorisCatalog.java
@@ -35,7 +35,6 @@ public class DorisCatalog extends JdbcCatalog {
         jdbcTypeConverter,
         createJdbcDatabaseOperations(),
         createJdbcTableOperations(),
-        createJdbcTablePropertiesMetadata(),
         createJdbcColumnDefaultValueConverter());
   }
 

--- a/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/MysqlCatalog.java
+++ b/catalogs/catalog-jdbc-mysql/src/main/java/com/datastrato/gravitino/catalog/mysql/MysqlCatalog.java
@@ -5,7 +5,6 @@
 package com.datastrato.gravitino.catalog.mysql;
 
 import com.datastrato.gravitino.catalog.jdbc.JdbcCatalog;
-import com.datastrato.gravitino.catalog.jdbc.JdbcTablePropertiesMetadata;
 import com.datastrato.gravitino.catalog.jdbc.MySQLProtocolCompatibleCatalogOperations;
 import com.datastrato.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
 import com.datastrato.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
@@ -18,10 +17,14 @@ import com.datastrato.gravitino.catalog.mysql.converter.MysqlTypeConverter;
 import com.datastrato.gravitino.catalog.mysql.operation.MysqlDatabaseOperations;
 import com.datastrato.gravitino.catalog.mysql.operation.MysqlTableOperations;
 import com.datastrato.gravitino.connector.CatalogOperations;
+import com.datastrato.gravitino.connector.PropertiesMetadata;
 import java.util.Map;
 
 /** Implementation of a Mysql catalog in Gravitino. */
 public class MysqlCatalog extends JdbcCatalog {
+
+  private static final MysqlTablePropertiesMetadata TABLE_PROPERTIES_META =
+      new MysqlTablePropertiesMetadata();
 
   @Override
   public String shortName() {
@@ -36,7 +39,6 @@ public class MysqlCatalog extends JdbcCatalog {
         jdbcTypeConverter,
         createJdbcDatabaseOperations(),
         createJdbcTableOperations(),
-        createJdbcTablePropertiesMetadata(),
         createJdbcColumnDefaultValueConverter());
   }
 
@@ -61,12 +63,12 @@ public class MysqlCatalog extends JdbcCatalog {
   }
 
   @Override
-  protected JdbcTablePropertiesMetadata createJdbcTablePropertiesMetadata() {
-    return new MysqlTablePropertiesMetadata();
+  protected JdbcColumnDefaultValueConverter createJdbcColumnDefaultValueConverter() {
+    return new MysqlColumnDefaultValueConverter();
   }
 
   @Override
-  protected JdbcColumnDefaultValueConverter createJdbcColumnDefaultValueConverter() {
-    return new MysqlColumnDefaultValueConverter();
+  public PropertiesMetadata tablePropertiesMetadata() throws UnsupportedOperationException {
+    return TABLE_PROPERTIES_META;
   }
 }

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/PostgreSQLCatalogOperations.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/PostgreSQLCatalogOperations.java
@@ -5,7 +5,6 @@
 package com.datastrato.gravitino.catalog.postgresql;
 
 import com.datastrato.gravitino.catalog.jdbc.JdbcCatalogOperations;
-import com.datastrato.gravitino.catalog.jdbc.JdbcTablePropertiesMetadata;
 import com.datastrato.gravitino.catalog.jdbc.converter.JdbcColumnDefaultValueConverter;
 import com.datastrato.gravitino.catalog.jdbc.converter.JdbcExceptionConverter;
 import com.datastrato.gravitino.catalog.jdbc.converter.JdbcTypeConverter;
@@ -21,14 +20,12 @@ public class PostgreSQLCatalogOperations extends JdbcCatalogOperations {
       JdbcTypeConverter jdbcTypeConverter,
       JdbcDatabaseOperations databaseOperation,
       JdbcTableOperations tableOperation,
-      JdbcTablePropertiesMetadata jdbcTablePropertiesMetadata,
       JdbcColumnDefaultValueConverter columnDefaultValueConverter) {
     super(
         exceptionConverter,
         jdbcTypeConverter,
         databaseOperation,
         tableOperation,
-        jdbcTablePropertiesMetadata,
         columnDefaultValueConverter);
   }
 

--- a/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/PostgreSqlCatalog.java
+++ b/catalogs/catalog-jdbc-postgresql/src/main/java/com/datastrato/gravitino/catalog/postgresql/PostgreSqlCatalog.java
@@ -33,7 +33,6 @@ public class PostgreSqlCatalog extends JdbcCatalog {
         jdbcTypeConverter,
         createJdbcDatabaseOperations(),
         createJdbcTableOperations(),
-        createJdbcTablePropertiesMetadata(),
         createJdbcColumnDefaultValueConverter());
   }
 

--- a/catalogs/catalog-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalog.java
+++ b/catalogs/catalog-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalog.java
@@ -7,6 +7,7 @@ package com.datastrato.gravitino.catalog.kafka;
 
 import com.datastrato.gravitino.connector.BaseCatalog;
 import com.datastrato.gravitino.connector.CatalogOperations;
+import com.datastrato.gravitino.connector.PropertiesMetadata;
 import com.datastrato.gravitino.connector.capability.Capability;
 import com.datastrato.gravitino.messaging.TopicCatalog;
 import com.datastrato.gravitino.rel.SupportsSchemas;
@@ -14,6 +15,13 @@ import java.util.Map;
 
 /** Kafka catalog is a messaging catalog that can manage topics on the Kafka messaging system. */
 public class KafkaCatalog extends BaseCatalog<KafkaCatalog> {
+
+  static final KafkaCatalogPropertiesMetadata CATALOG_PROPERTIES_METADATA =
+      new KafkaCatalogPropertiesMetadata();
+  static final KafkaSchemaPropertiesMetadata SCHEMA_PROPERTIES_METADATA =
+      new KafkaSchemaPropertiesMetadata();
+  static final KafkaTopicPropertiesMetadata TOPIC_PROPERTIES_METADATA =
+      new KafkaTopicPropertiesMetadata();
 
   @Override
   public String shortName() {
@@ -32,12 +40,17 @@ public class KafkaCatalog extends BaseCatalog<KafkaCatalog> {
   }
 
   @Override
-  public SupportsSchemas asSchemas() throws UnsupportedOperationException {
-    return (KafkaCatalogOperations) ops();
+  public PropertiesMetadata catalogPropertiesMetadata() throws UnsupportedOperationException {
+    return CATALOG_PROPERTIES_METADATA;
   }
 
   @Override
-  public TopicCatalog asTopicCatalog() throws UnsupportedOperationException {
-    return (KafkaCatalogOperations) ops();
+  public PropertiesMetadata schemaPropertiesMetadata() throws UnsupportedOperationException {
+    return SCHEMA_PROPERTIES_METADATA;
+  }
+
+  @Override
+  public PropertiesMetadata topicPropertiesMetadata() throws UnsupportedOperationException {
+    return TOPIC_PROPERTIES_METADATA;
   }
 }

--- a/catalogs/catalog-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalog.java
+++ b/catalogs/catalog-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalog.java
@@ -9,8 +9,6 @@ import com.datastrato.gravitino.connector.BaseCatalog;
 import com.datastrato.gravitino.connector.CatalogOperations;
 import com.datastrato.gravitino.connector.PropertiesMetadata;
 import com.datastrato.gravitino.connector.capability.Capability;
-import com.datastrato.gravitino.messaging.TopicCatalog;
-import com.datastrato.gravitino.rel.SupportsSchemas;
 import java.util.Map;
 
 /** Kafka catalog is a messaging catalog that can manage topics on the Kafka messaging system. */

--- a/catalogs/catalog-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
+++ b/catalogs/catalog-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
@@ -21,7 +21,6 @@ import com.datastrato.gravitino.StringIdentifier;
 import com.datastrato.gravitino.connector.CatalogInfo;
 import com.datastrato.gravitino.connector.CatalogOperations;
 import com.datastrato.gravitino.connector.HasPropertyMetadata;
-import com.datastrato.gravitino.connector.SupportsSchemas;
 import com.datastrato.gravitino.exceptions.NoSuchCatalogException;
 import com.datastrato.gravitino.exceptions.NoSuchEntityException;
 import com.datastrato.gravitino.exceptions.NoSuchSchemaException;

--- a/catalogs/catalog-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
+++ b/catalogs/catalog-kafka/src/main/java/com/datastrato/gravitino/catalog/kafka/KafkaCatalogOperations.java
@@ -20,7 +20,8 @@ import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.StringIdentifier;
 import com.datastrato.gravitino.connector.CatalogInfo;
 import com.datastrato.gravitino.connector.CatalogOperations;
-import com.datastrato.gravitino.connector.PropertiesMetadata;
+import com.datastrato.gravitino.connector.HasPropertyMetadata;
+import com.datastrato.gravitino.connector.SupportsSchemas;
 import com.datastrato.gravitino.exceptions.NoSuchCatalogException;
 import com.datastrato.gravitino.exceptions.NoSuchEntityException;
 import com.datastrato.gravitino.exceptions.NoSuchSchemaException;
@@ -80,12 +81,6 @@ import org.slf4j.LoggerFactory;
 public class KafkaCatalogOperations implements CatalogOperations, SupportsSchemas, TopicCatalog {
 
   private static final Logger LOG = LoggerFactory.getLogger(KafkaCatalogOperations.class);
-  private static final KafkaCatalogPropertiesMetadata CATALOG_PROPERTIES_METADATA =
-      new KafkaCatalogPropertiesMetadata();
-  private static final KafkaSchemaPropertiesMetadata SCHEMA_PROPERTIES_METADATA =
-      new KafkaSchemaPropertiesMetadata();
-  private static final KafkaTopicPropertiesMetadata TOPIC_PROPERTIES_METADATA =
-      new KafkaTopicPropertiesMetadata();
   private static final String DEFAULT_SCHEMA_NAME = "default";
   @VisibleForTesting static final String CLIENT_ID_TEMPLATE = "%s-%s.%s";
 
@@ -95,6 +90,7 @@ public class KafkaCatalogOperations implements CatalogOperations, SupportsSchema
   @VisibleForTesting Properties adminClientConfig;
   private CatalogInfo info;
   private AdminClient adminClient;
+  private HasPropertyMetadata propertiesMetadata;
 
   @VisibleForTesting
   KafkaCatalogOperations(EntityStore store, IdGenerator idGenerator) {
@@ -107,7 +103,10 @@ public class KafkaCatalogOperations implements CatalogOperations, SupportsSchema
   }
 
   @Override
-  public void initialize(Map<String, String> config, CatalogInfo info) throws RuntimeException {
+  public void initialize(
+      Map<String, String> config, CatalogInfo info, HasPropertyMetadata propertiesMetadata)
+      throws RuntimeException {
+    this.propertiesMetadata = propertiesMetadata;
     Preconditions.checkArgument(
         config.containsKey(BOOTSTRAP_SERVERS), "Missing configuration: %s", BOOTSTRAP_SERVERS);
     Preconditions.checkArgument(config.containsKey(ID_KEY), "Missing configuration: %s", ID_KEY);
@@ -405,36 +404,11 @@ public class KafkaCatalogOperations implements CatalogOperations, SupportsSchema
   }
 
   @Override
-  public PropertiesMetadata catalogPropertiesMetadata() throws UnsupportedOperationException {
-    return CATALOG_PROPERTIES_METADATA;
-  }
-
-  @Override
-  public PropertiesMetadata schemaPropertiesMetadata() throws UnsupportedOperationException {
-    return SCHEMA_PROPERTIES_METADATA;
-  }
-
-  @Override
-  public PropertiesMetadata topicPropertiesMetadata() throws UnsupportedOperationException {
-    return TOPIC_PROPERTIES_METADATA;
-  }
-
-  @Override
   public void close() throws IOException {
     if (adminClient != null) {
       adminClient.close();
       adminClient = null;
     }
-  }
-
-  @Override
-  public PropertiesMetadata filesetPropertiesMetadata() throws UnsupportedOperationException {
-    throw new UnsupportedOperationException("Kafka catalog does not support fileset operations");
-  }
-
-  @Override
-  public PropertiesMetadata tablePropertiesMetadata() throws UnsupportedOperationException {
-    throw new UnsupportedOperationException("Kafka catalog does not support table operations");
   }
 
   /**
@@ -536,10 +510,16 @@ public class KafkaCatalogOperations implements CatalogOperations, SupportsSchema
   private NewTopic buildNewTopic(NameIdentifier ident, Map<String, String> properties) {
     Optional<Integer> partitionCount =
         Optional.ofNullable(
-            (Integer) TOPIC_PROPERTIES_METADATA.getOrDefault(properties, PARTITION_COUNT));
+            (Integer)
+                propertiesMetadata
+                    .topicPropertiesMetadata()
+                    .getOrDefault(properties, PARTITION_COUNT));
     Optional<Short> replicationFactor =
         Optional.ofNullable(
-            (Short) TOPIC_PROPERTIES_METADATA.getOrDefault(properties, REPLICATION_FACTOR));
+            (Short)
+                propertiesMetadata
+                    .topicPropertiesMetadata()
+                    .getOrDefault(properties, REPLICATION_FACTOR));
     NewTopic newTopic = new NewTopic(ident.name(), partitionCount, replicationFactor);
     return newTopic.configs(buildNewTopicConfigs(properties));
   }

--- a/catalogs/catalog-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/TestKafkaCatalogOperations.java
+++ b/catalogs/catalog-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/TestKafkaCatalogOperations.java
@@ -12,6 +12,9 @@ import static com.datastrato.gravitino.Configs.ENTRY_KV_ROCKSDB_BACKEND_PATH;
 import static com.datastrato.gravitino.Configs.STORE_DELETE_AFTER_TIME;
 import static com.datastrato.gravitino.Configs.STORE_TRANSACTION_MAX_SKEW_TIME;
 import static com.datastrato.gravitino.StringIdentifier.ID_KEY;
+import static com.datastrato.gravitino.catalog.kafka.KafkaCatalog.CATALOG_PROPERTIES_METADATA;
+import static com.datastrato.gravitino.catalog.kafka.KafkaCatalog.SCHEMA_PROPERTIES_METADATA;
+import static com.datastrato.gravitino.catalog.kafka.KafkaCatalog.TOPIC_PROPERTIES_METADATA;
 import static com.datastrato.gravitino.catalog.kafka.KafkaCatalogOperations.CLIENT_ID_TEMPLATE;
 import static com.datastrato.gravitino.catalog.kafka.KafkaCatalogPropertiesMetadata.BOOTSTRAP_SERVERS;
 import static com.datastrato.gravitino.catalog.kafka.KafkaTopicPropertiesMetadata.PARTITION_COUNT;
@@ -25,6 +28,8 @@ import com.datastrato.gravitino.EntityStoreFactory;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.catalog.kafka.embedded.KafkaClusterEmbedded;
+import com.datastrato.gravitino.connector.HasPropertyMetadata;
+import com.datastrato.gravitino.connector.PropertiesMetadata;
 import com.datastrato.gravitino.exceptions.NoSuchSchemaException;
 import com.datastrato.gravitino.exceptions.NoSuchTopicException;
 import com.datastrato.gravitino.exceptions.TopicAlreadyExistsException;
@@ -57,6 +62,33 @@ public class TestKafkaCatalogOperations extends KafkaClusterEmbedded {
   private static final String DEFAULT_SCHEMA_NAME = "default";
   private static final Map<String, String> MOCK_CATALOG_PROPERTIES =
       ImmutableMap.of(BOOTSTRAP_SERVERS, brokerList(), ID_KEY, "gravitino.v1.uid33220758755757000");
+  private static final HasPropertyMetadata KAFKA_PROPERTIES_METADATA =
+      new HasPropertyMetadata() {
+        @Override
+        public PropertiesMetadata tablePropertiesMetadata() throws UnsupportedOperationException {
+          throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public PropertiesMetadata catalogPropertiesMetadata() throws UnsupportedOperationException {
+          return CATALOG_PROPERTIES_METADATA;
+        }
+
+        @Override
+        public PropertiesMetadata schemaPropertiesMetadata() throws UnsupportedOperationException {
+          return SCHEMA_PROPERTIES_METADATA;
+        }
+
+        @Override
+        public PropertiesMetadata filesetPropertiesMetadata() throws UnsupportedOperationException {
+          throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public PropertiesMetadata topicPropertiesMetadata() throws UnsupportedOperationException {
+          return TOPIC_PROPERTIES_METADATA;
+        }
+      };
   private static EntityStore store;
   private static IdGenerator idGenerator;
   private static CatalogEntity kafkaCatalogEntity;
@@ -93,7 +125,8 @@ public class TestKafkaCatalogOperations extends KafkaClusterEmbedded {
             .build();
 
     kafkaCatalogOperations = new KafkaCatalogOperations(store, idGenerator);
-    kafkaCatalogOperations.initialize(MOCK_CATALOG_PROPERTIES, kafkaCatalogEntity.toCatalogInfo());
+    kafkaCatalogOperations.initialize(
+        MOCK_CATALOG_PROPERTIES, kafkaCatalogEntity.toCatalogInfo(), KAFKA_PROPERTIES_METADATA);
   }
 
   @AfterAll
@@ -123,7 +156,8 @@ public class TestKafkaCatalogOperations extends KafkaClusterEmbedded {
     KafkaCatalogOperations ops = new KafkaCatalogOperations(store, idGenerator);
     Assertions.assertNull(ops.adminClientConfig);
 
-    ops.initialize(MOCK_CATALOG_PROPERTIES, catalogEntity.toCatalogInfo());
+    ops.initialize(
+        MOCK_CATALOG_PROPERTIES, catalogEntity.toCatalogInfo(), KAFKA_PROPERTIES_METADATA);
     Assertions.assertNotNull(ops.adminClientConfig);
     Assertions.assertEquals(2, ops.adminClientConfig.size());
     Assertions.assertEquals(
@@ -155,7 +189,8 @@ public class TestKafkaCatalogOperations extends KafkaClusterEmbedded {
                     .build())
             .build();
     KafkaCatalogOperations ops = new KafkaCatalogOperations(store, idGenerator);
-    ops.initialize(MOCK_CATALOG_PROPERTIES, catalogEntity.toCatalogInfo());
+    ops.initialize(
+        MOCK_CATALOG_PROPERTIES, catalogEntity.toCatalogInfo(), KAFKA_PROPERTIES_METADATA);
 
     Assertions.assertNotNull(ops.defaultSchemaIdent);
     Assertions.assertEquals(DEFAULT_SCHEMA_NAME, ops.defaultSchemaIdent.name());

--- a/catalogs/catalog-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/integration/test/CatalogKafkaIT.java
+++ b/catalogs/catalog-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/integration/test/CatalogKafkaIT.java
@@ -154,14 +154,18 @@ public class CatalogKafkaIT extends AbstractIT {
     String catalogName1 = GravitinoITUtils.genRandomName("test_catalog");
     Catalog catalog1 =
         metalake.createCatalog(
-            catalogName1,
+            NameIdentifier.ofCatalog(metalake.name(), catalogName1),
             Catalog.Type.MESSAGING,
             PROVIDER,
             "comment",
             ImmutableMap.of(BOOTSTRAP_SERVERS, "2"));
     Exception exception =
         Assertions.assertThrows(
-            IllegalArgumentException.class, () -> catalog1.asSchemas().listSchemas());
+            IllegalArgumentException.class,
+            () ->
+                catalog1
+                    .asSchemas()
+                    .listSchemas(Namespace.ofSchema(metalake.name(), catalogName1)));
     Assertions.assertTrue(exception.getMessage().contains("Invalid url in bootstrap.servers: 2"));
 
     exception =
@@ -169,7 +173,8 @@ public class CatalogKafkaIT extends AbstractIT {
             IllegalArgumentException.class,
             () ->
                 metalake.createCatalog(
-                    GravitinoITUtils.genRandomName("test_catalog"),
+                    NameIdentifier.ofCatalog(
+                        metalake.name(), GravitinoITUtils.genRandomName("test_catalog")),
                     Catalog.Type.MESSAGING,
                     PROVIDER,
                     "comment",
@@ -183,7 +188,7 @@ public class CatalogKafkaIT extends AbstractIT {
     String catalogName2 = GravitinoITUtils.genRandomName("test_catalog");
     Catalog kafka =
         metalake.createCatalog(
-            catalogName2,
+            NameIdentifier.ofCatalog(metalake.name(), catalogName2),
             Catalog.Type.MESSAGING,
             PROVIDER,
             "comment",

--- a/catalogs/catalog-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/integration/test/CatalogKafkaIT.java
+++ b/catalogs/catalog-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/integration/test/CatalogKafkaIT.java
@@ -151,17 +151,17 @@ public class CatalogKafkaIT extends AbstractIT {
 
   @Test
   public void testCatalogException() {
-    String catalogName = GravitinoITUtils.genRandomName("test_catalog");
+    String catalogName1 = GravitinoITUtils.genRandomName("test_catalog");
+    Catalog catalog1 =
+        metalake.createCatalog(
+            catalogName1,
+            Catalog.Type.MESSAGING,
+            PROVIDER,
+            "comment",
+            ImmutableMap.of(BOOTSTRAP_SERVERS, "2"));
     Exception exception =
         Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                metalake.createCatalog(
-                    NameIdentifier.of(METALAKE_NAME, catalogName),
-                    Catalog.Type.MESSAGING,
-                    PROVIDER,
-                    "comment",
-                    ImmutableMap.of(BOOTSTRAP_SERVERS, "2")));
+            IllegalArgumentException.class, () -> catalog1.asSchemas().listSchemas());
     Assertions.assertTrue(exception.getMessage().contains("Invalid url in bootstrap.servers: 2"));
 
     exception =
@@ -169,18 +169,21 @@ public class CatalogKafkaIT extends AbstractIT {
             IllegalArgumentException.class,
             () ->
                 metalake.createCatalog(
-                    NameIdentifier.of(METALAKE_NAME, catalogName),
+                    GravitinoITUtils.genRandomName("test_catalog"),
                     Catalog.Type.MESSAGING,
                     PROVIDER,
                     "comment",
                     ImmutableMap.of("abc", "2")));
     Assertions.assertTrue(
-        exception.getMessage().contains("Missing configuration: bootstrap.servers"));
+        exception
+            .getMessage()
+            .contains("Properties are required and must be set: [bootstrap.servers]"));
 
     // Test BOOTSTRAP_SERVERS that cannot be linked
+    String catalogName2 = GravitinoITUtils.genRandomName("test_catalog");
     Catalog kafka =
         metalake.createCatalog(
-            NameIdentifier.of(METALAKE_NAME, catalogName),
+            catalogName2,
             Catalog.Type.MESSAGING,
             PROVIDER,
             "comment",
@@ -198,7 +201,7 @@ public class CatalogKafkaIT extends AbstractIT {
                 kafka
                     .asTopicCatalog()
                     .listTopics(
-                        Namespace.ofTopic(METALAKE_NAME, catalogName, DEFAULT_SCHEMA_NAME)));
+                        Namespace.ofTopic(METALAKE_NAME, catalogName2, DEFAULT_SCHEMA_NAME)));
     Assertions.assertTrue(
         exception
             .getMessage()

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalog.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalog.java
@@ -6,6 +6,7 @@ package com.datastrato.gravitino.catalog.lakehouse.iceberg;
 
 import com.datastrato.gravitino.connector.BaseCatalog;
 import com.datastrato.gravitino.connector.CatalogOperations;
+import com.datastrato.gravitino.connector.PropertiesMetadata;
 import com.datastrato.gravitino.connector.capability.Capability;
 import com.datastrato.gravitino.rel.SupportsSchemas;
 import com.datastrato.gravitino.rel.TableCatalog;
@@ -13,6 +14,15 @@ import java.util.Map;
 
 /** Implementation of an Iceberg catalog in Gravitino. */
 public class IcebergCatalog extends BaseCatalog<IcebergCatalog> {
+
+  static final IcebergCatalogPropertiesMetadata CATALOG_PROPERTIES_META =
+      new IcebergCatalogPropertiesMetadata();
+
+  static final IcebergSchemaPropertiesMetadata SCHEMA_PROPERTIES_META =
+      new IcebergSchemaPropertiesMetadata();
+
+  static final IcebergTablePropertiesMetadata TABLE_PROPERTIES_META =
+      new IcebergTablePropertiesMetadata();
 
   /** @return The short name of the catalog. */
   @Override
@@ -37,15 +47,18 @@ public class IcebergCatalog extends BaseCatalog<IcebergCatalog> {
     return new IcebergCatalogCapability();
   }
 
-  /** @return The Iceberg catalog operations as {@link IcebergCatalogOperations}. */
   @Override
-  public SupportsSchemas asSchemas() {
-    return (IcebergCatalogOperations) ops();
+  public PropertiesMetadata tablePropertiesMetadata() throws UnsupportedOperationException {
+    return TABLE_PROPERTIES_META;
   }
 
-  /** @return The Iceberg catalog operations as {@link IcebergCatalogOperations}. */
   @Override
-  public TableCatalog asTableCatalog() {
-    return (IcebergCatalogOperations) ops();
+  public PropertiesMetadata catalogPropertiesMetadata() throws UnsupportedOperationException {
+    return CATALOG_PROPERTIES_META;
+  }
+
+  @Override
+  public PropertiesMetadata schemaPropertiesMetadata() throws UnsupportedOperationException {
+    return SCHEMA_PROPERTIES_META;
   }
 }

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalog.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalog.java
@@ -9,7 +9,6 @@ import com.datastrato.gravitino.connector.CatalogOperations;
 import com.datastrato.gravitino.connector.PropertiesMetadata;
 import com.datastrato.gravitino.connector.capability.Capability;
 import com.datastrato.gravitino.rel.SupportsSchemas;
-import com.datastrato.gravitino.rel.TableCatalog;
 import java.util.Map;
 
 /** Implementation of an Iceberg catalog in Gravitino. */
@@ -40,6 +39,11 @@ public class IcebergCatalog extends BaseCatalog<IcebergCatalog> {
   protected CatalogOperations newOps(Map<String, String> config) {
     IcebergCatalogOperations ops = new IcebergCatalogOperations();
     return ops;
+  }
+
+  @Override
+  public SupportsSchemas asSchemas() {
+    return (SupportsSchemas) ops();
   }
 
   @Override

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
@@ -12,7 +12,8 @@ import com.datastrato.gravitino.catalog.lakehouse.iceberg.ops.IcebergTableOps;
 import com.datastrato.gravitino.catalog.lakehouse.iceberg.ops.IcebergTableOpsHelper;
 import com.datastrato.gravitino.connector.CatalogInfo;
 import com.datastrato.gravitino.connector.CatalogOperations;
-import com.datastrato.gravitino.connector.PropertiesMetadata;
+import com.datastrato.gravitino.connector.HasPropertyMetadata;
+import com.datastrato.gravitino.connector.SupportsSchemas;
 import com.datastrato.gravitino.exceptions.NoSuchCatalogException;
 import com.datastrato.gravitino.exceptions.NoSuchSchemaException;
 import com.datastrato.gravitino.exceptions.NoSuchTableException;
@@ -66,12 +67,6 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
 
   @VisibleForTesting IcebergTableOps icebergTableOps;
 
-  private IcebergCatalogPropertiesMetadata icebergCatalogPropertiesMetadata;
-
-  private IcebergTablePropertiesMetadata icebergTablePropertiesMetadata;
-
-  private IcebergSchemaPropertiesMetadata icebergSchemaPropertiesMetadata;
-
   private IcebergTableOpsHelper icebergTableOpsHelper;
 
   /**
@@ -82,14 +77,16 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
    * @throws RuntimeException if initialization fails.
    */
   @Override
-  public void initialize(Map<String, String> conf, CatalogInfo info) throws RuntimeException {
+  public void initialize(
+      Map<String, String> conf, CatalogInfo info, HasPropertyMetadata propertiesMetadata)
+      throws RuntimeException {
     // Key format like gravitino.bypass.a.b
     Map<String, String> prefixMap = MapUtils.getPrefixMap(conf, CATALOG_BYPASS_PREFIX);
 
-    this.icebergCatalogPropertiesMetadata = new IcebergCatalogPropertiesMetadata();
     // Hold keys that lie in GRAVITINO_CONFIG_TO_ICEBERG
     Map<String, String> gravitinoConfig =
-        this.icebergCatalogPropertiesMetadata.transformProperties(conf);
+        ((IcebergCatalogPropertiesMetadata) propertiesMetadata.catalogPropertiesMetadata())
+            .transformProperties(conf);
 
     Map<String, String> resultConf = Maps.newHashMap(prefixMap);
     resultConf.putAll(gravitinoConfig);
@@ -98,8 +95,6 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
 
     this.icebergTableOps = new IcebergTableOps(icebergConfig);
     this.icebergTableOpsHelper = icebergTableOps.createIcebergTableOpsHelper();
-    this.icebergTablePropertiesMetadata = new IcebergTablePropertiesMetadata();
-    this.icebergSchemaPropertiesMetadata = new IcebergSchemaPropertiesMetadata();
   }
 
   /** Closes the Iceberg catalog and releases the associated client pool. */
@@ -542,32 +537,5 @@ public class IcebergCatalogOperations implements CatalogOperations, SupportsSche
   // TODO. We should figure out a better way to get the current user from servlet container.
   private static String currentUser() {
     return System.getProperty("user.name");
-  }
-
-  @Override
-  public PropertiesMetadata tablePropertiesMetadata() throws UnsupportedOperationException {
-    return icebergTablePropertiesMetadata;
-  }
-
-  @Override
-  public PropertiesMetadata catalogPropertiesMetadata() throws UnsupportedOperationException {
-    return icebergCatalogPropertiesMetadata;
-  }
-
-  @Override
-  public PropertiesMetadata schemaPropertiesMetadata() throws UnsupportedOperationException {
-    return icebergSchemaPropertiesMetadata;
-  }
-
-  @Override
-  public PropertiesMetadata filesetPropertiesMetadata() throws UnsupportedOperationException {
-    throw new UnsupportedOperationException(
-        "Iceberg catalog doesn't support fileset related operations");
-  }
-
-  @Override
-  public PropertiesMetadata topicPropertiesMetadata() throws UnsupportedOperationException {
-    throw new UnsupportedOperationException(
-        "Iceberg catalog doesn't support topic related operations");
   }
 }

--- a/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/main/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/IcebergCatalogOperations.java
@@ -13,7 +13,6 @@ import com.datastrato.gravitino.catalog.lakehouse.iceberg.ops.IcebergTableOpsHel
 import com.datastrato.gravitino.connector.CatalogInfo;
 import com.datastrato.gravitino.connector.CatalogOperations;
 import com.datastrato.gravitino.connector.HasPropertyMetadata;
-import com.datastrato.gravitino.connector.SupportsSchemas;
 import com.datastrato.gravitino.exceptions.NoSuchCatalogException;
 import com.datastrato.gravitino.exceptions.NoSuchSchemaException;
 import com.datastrato.gravitino.exceptions.NoSuchTableException;

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergCatalog.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergCatalog.java
@@ -4,10 +4,15 @@
  */
 package com.datastrato.gravitino.catalog.lakehouse.iceberg;
 
+import static com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergCatalog.CATALOG_PROPERTIES_META;
+import static com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergCatalog.SCHEMA_PROPERTIES_META;
+import static com.datastrato.gravitino.catalog.lakehouse.iceberg.IcebergCatalog.TABLE_PROPERTIES_META;
+
 import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.catalog.PropertiesMetadataHelpers;
 import com.datastrato.gravitino.catalog.lakehouse.iceberg.ops.IcebergTableOps;
 import com.datastrato.gravitino.connector.CatalogOperations;
+import com.datastrato.gravitino.connector.HasPropertyMetadata;
 import com.datastrato.gravitino.connector.PropertiesMetadata;
 import com.datastrato.gravitino.meta.AuditInfo;
 import com.datastrato.gravitino.meta.CatalogEntity;
@@ -19,6 +24,34 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestIcebergCatalog {
+  static final HasPropertyMetadata ICEBERG_PROPERTIES_METADATA =
+      new HasPropertyMetadata() {
+        @Override
+        public PropertiesMetadata tablePropertiesMetadata() throws UnsupportedOperationException {
+          return TABLE_PROPERTIES_META;
+        }
+
+        @Override
+        public PropertiesMetadata catalogPropertiesMetadata() throws UnsupportedOperationException {
+          return CATALOG_PROPERTIES_META;
+        }
+
+        @Override
+        public PropertiesMetadata schemaPropertiesMetadata() throws UnsupportedOperationException {
+          return SCHEMA_PROPERTIES_META;
+        }
+
+        @Override
+        public PropertiesMetadata filesetPropertiesMetadata() throws UnsupportedOperationException {
+          throw new UnsupportedOperationException("Fileset properties are not supported");
+        }
+
+        @Override
+        public PropertiesMetadata topicPropertiesMetadata() throws UnsupportedOperationException {
+          throw new UnsupportedOperationException("Topic properties are not supported");
+        }
+      };
+
   @Test
   public void testListDatabases() {
     AuditInfo auditInfo =
@@ -65,10 +98,10 @@ public class TestIcebergCatalog {
     Map<String, String> conf = Maps.newHashMap();
 
     try (IcebergCatalogOperations ops = new IcebergCatalogOperations()) {
-      ops.initialize(conf, entity.toCatalogInfo());
+      ops.initialize(conf, entity.toCatalogInfo(), ICEBERG_PROPERTIES_METADATA);
       Map<String, String> map1 = Maps.newHashMap();
       map1.put(IcebergCatalogPropertiesMetadata.CATALOG_BACKEND_NAME, "test");
-      PropertiesMetadata metadata = ops.catalogPropertiesMetadata();
+      PropertiesMetadata metadata = ICEBERG_PROPERTIES_METADATA.catalogPropertiesMetadata();
       Assertions.assertThrows(
           IllegalArgumentException.class,
           () -> {

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergSchema.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergSchema.java
@@ -4,6 +4,8 @@
  */
 package com.datastrato.gravitino.catalog.lakehouse.iceberg;
 
+import static com.datastrato.gravitino.catalog.lakehouse.iceberg.TestIcebergCatalog.ICEBERG_PROPERTIES_METADATA;
+
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.catalog.PropertiesMetadataHelpers;
@@ -158,10 +160,10 @@ public class TestIcebergSchema {
     Map<String, String> conf = Maps.newHashMap();
 
     try (IcebergCatalogOperations ops = new IcebergCatalogOperations()) {
-      ops.initialize(conf, entity.toCatalogInfo());
+      ops.initialize(conf, entity.toCatalogInfo(), ICEBERG_PROPERTIES_METADATA);
       Map<String, String> map = Maps.newHashMap();
       map.put(IcebergSchemaPropertiesMetadata.COMMENT, "test");
-      PropertiesMetadata metadata = ops.schemaPropertiesMetadata();
+      PropertiesMetadata metadata = ICEBERG_PROPERTIES_METADATA.schemaPropertiesMetadata();
 
       IllegalArgumentException illegalArgumentException =
           Assertions.assertThrows(

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergTable.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/TestIcebergTable.java
@@ -4,6 +4,7 @@
  */
 package com.datastrato.gravitino.catalog.lakehouse.iceberg;
 
+import static com.datastrato.gravitino.catalog.lakehouse.iceberg.TestIcebergCatalog.ICEBERG_PROPERTIES_METADATA;
 import static com.datastrato.gravitino.rel.expressions.transforms.Transforms.bucket;
 import static com.datastrato.gravitino.rel.expressions.transforms.Transforms.day;
 import static com.datastrato.gravitino.rel.expressions.transforms.Transforms.identity;
@@ -481,7 +482,7 @@ public class TestIcebergTable {
   public void testTableProperty() {
     CatalogEntity entity = createDefaultCatalogEntity();
     try (IcebergCatalogOperations ops = new IcebergCatalogOperations()) {
-      ops.initialize(Maps.newHashMap(), entity.toCatalogInfo());
+      ops.initialize(Maps.newHashMap(), entity.toCatalogInfo(), ICEBERG_PROPERTIES_METADATA);
       Map<String, String> map = Maps.newHashMap();
       map.put(IcebergTablePropertiesMetadata.COMMENT, "test");
       map.put(IcebergTablePropertiesMetadata.CREATOR, "test");
@@ -496,7 +497,7 @@ public class TestIcebergTable {
                 put(entry.getKey(), entry.getValue());
               }
             };
-        PropertiesMetadata metadata = ops.tablePropertiesMetadata();
+        PropertiesMetadata metadata = icebergCatalog.tablePropertiesMetadata();
         Assertions.assertThrows(
             IllegalArgumentException.class,
             () -> {
@@ -514,7 +515,7 @@ public class TestIcebergTable {
                 put(entry.getKey(), entry.getValue());
               }
             };
-        PropertiesMetadata metadata = ops.tablePropertiesMetadata();
+        PropertiesMetadata metadata = icebergCatalog.tablePropertiesMetadata();
         Assertions.assertDoesNotThrow(
             () -> {
               PropertiesMetadataHelpers.validatePropertyForCreate(metadata, properties);

--- a/core/src/main/java/com/datastrato/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/CatalogManager.java
@@ -23,9 +23,7 @@ import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.StringIdentifier;
 import com.datastrato.gravitino.connector.BaseCatalog;
-import com.datastrato.gravitino.connector.CatalogOperations;
 import com.datastrato.gravitino.connector.HasPropertyMetadata;
-import com.datastrato.gravitino.connector.PropertiesMetadata;
 import com.datastrato.gravitino.connector.PropertyEntry;
 import com.datastrato.gravitino.connector.capability.Capability;
 import com.datastrato.gravitino.exceptions.CatalogAlreadyExistsException;
@@ -152,7 +150,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
 
     public <R> R doWithPropertiesMeta(ThrowableFunction<HasPropertyMetadata, R> fn)
         throws Exception {
-      return classLoader.withClassLoader(cl -> fn.apply(catalog.ops()));
+      return classLoader.withClassLoader(cl -> fn.apply(catalog));
     }
 
     public Capability capabilities() throws Exception {
@@ -577,7 +575,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
         cl -> {
           Map<String, String> configWithoutId = Maps.newHashMap(conf);
           configWithoutId.remove(ID_KEY);
-          validatePropertyForCreate(catalog.ops().catalogPropertiesMetadata(), configWithoutId);
+          validatePropertyForCreate(catalog.catalogPropertiesMetadata(), configWithoutId);
 
           // Call wrapper.catalog.properties() to make BaseCatalog#properties in IsolatedClassLoader
           // not null. Why we do this? Because wrapper.catalog.properties() need to be called in the
@@ -600,18 +598,11 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
     try (IsolatedClassLoader classLoader = createClassLoader(provider, conf)) {
       BaseCatalog<?> catalog = createBaseCatalog(classLoader, entity);
       return classLoader.withClassLoader(
-          cl -> {
-            try (CatalogOperations ops = catalog.ops()) {
-              PropertiesMetadata catalogPropertiesMetadata = ops.catalogPropertiesMetadata();
-              return catalogPropertiesMetadata.propertyEntries().values().stream()
+          cl ->
+              catalog.catalogPropertiesMetadata().propertyEntries().values().stream()
                   .filter(PropertyEntry::isHidden)
                   .map(PropertyEntry::getName)
-                  .collect(Collectors.toSet());
-            } catch (Exception e) {
-              LOG.error("Failed to get hidden property names", e);
-              throw e;
-            }
-          },
+                  .collect(Collectors.toSet()),
           RuntimeException.class);
     }
   }

--- a/core/src/main/java/com/datastrato/gravitino/connector/BaseCatalog.java
+++ b/core/src/main/java/com/datastrato/gravitino/connector/BaseCatalog.java
@@ -96,27 +96,32 @@ public abstract class BaseCatalog<T extends BaseCatalog>
 
   @Override
   public PropertiesMetadata tablePropertiesMetadata() throws UnsupportedOperationException {
-    return ops().tablePropertiesMetadata();
+    throw new UnsupportedOperationException(
+        "The catalog does not support table properties metadata");
   }
 
   @Override
   public PropertiesMetadata catalogPropertiesMetadata() throws UnsupportedOperationException {
-    return ops().catalogPropertiesMetadata();
+    throw new UnsupportedOperationException(
+        "The catalog does not support catalog properties metadata");
   }
 
   @Override
   public PropertiesMetadata schemaPropertiesMetadata() throws UnsupportedOperationException {
-    return ops().schemaPropertiesMetadata();
+    throw new UnsupportedOperationException(
+        "The catalog does not support schema properties metadata");
   }
 
   @Override
   public PropertiesMetadata filesetPropertiesMetadata() throws UnsupportedOperationException {
-    return ops().filesetPropertiesMetadata();
+    throw new UnsupportedOperationException(
+        "The catalog does not support fileset properties metadata");
   }
 
   @Override
   public PropertiesMetadata topicPropertiesMetadata() throws UnsupportedOperationException {
-    return ops().topicPropertiesMetadata();
+    throw new UnsupportedOperationException(
+        "The catalog does not support topic properties metadata");
   }
 
   /**
@@ -133,7 +138,7 @@ public abstract class BaseCatalog<T extends BaseCatalog>
           Preconditions.checkArgument(
               entity != null && conf != null, "entity and conf must be set before calling ops()");
           CatalogOperations newOps = createOps(conf);
-          newOps.initialize(conf, entity.toCatalogInfo());
+          newOps.initialize(conf, entity.toCatalogInfo(), this);
           ops =
               newProxyPlugin(conf)
                   .map(
@@ -245,8 +250,7 @@ public abstract class BaseCatalog<T extends BaseCatalog>
           Map<String, String> tempProperties = Maps.newHashMap(entity.getProperties());
           tempProperties
               .entrySet()
-              .removeIf(
-                  entry -> ops().catalogPropertiesMetadata().isHiddenProperty(entry.getKey()));
+              .removeIf(entry -> catalogPropertiesMetadata().isHiddenProperty(entry.getKey()));
           properties = tempProperties;
         }
       }

--- a/core/src/main/java/com/datastrato/gravitino/connector/CatalogInfo.java
+++ b/core/src/main/java/com/datastrato/gravitino/connector/CatalogInfo.java
@@ -15,7 +15,8 @@ import java.util.Map;
  * corresponding to CatalogEntity that is used internally.
  *
  * <p>This class object will be passed in through {@link CatalogOperations#initialize(Map,
- * CatalogInfo)}, users can leverage this object to get the information about the catalog.
+ * CatalogInfo, HasPropertyMetadata)}, users can leverage this object to get the information about
+ * the catalog.
  */
 @Evolving
 public final class CatalogInfo implements Catalog {

--- a/core/src/main/java/com/datastrato/gravitino/connector/CatalogOperations.java
+++ b/core/src/main/java/com/datastrato/gravitino/connector/CatalogOperations.java
@@ -16,7 +16,7 @@ import java.util.Map;
  * operation, {@link TableCatalog} to support table operations, etc.
  */
 @Evolving
-public interface CatalogOperations extends Closeable, HasPropertyMetadata {
+public interface CatalogOperations extends Closeable {
 
   /**
    * Initialize the CatalogOperation with specified configuration. This method is called after
@@ -26,7 +26,10 @@ public interface CatalogOperations extends Closeable, HasPropertyMetadata {
    *
    * @param config The configuration of this Catalog.
    * @param info The information of this Catalog.
+   * @param propertiesMetadata The properties metadata of this Catalog.
    * @throws RuntimeException if the initialization failed.
    */
-  void initialize(Map<String, String> config, CatalogInfo info) throws RuntimeException;
+  void initialize(
+      Map<String, String> config, CatalogInfo info, HasPropertyMetadata propertiesMetadata)
+      throws RuntimeException;
 }

--- a/core/src/test/java/com/datastrato/gravitino/TestCatalog.java
+++ b/core/src/test/java/com/datastrato/gravitino/TestCatalog.java
@@ -4,7 +4,7 @@
  */
 package com.datastrato.gravitino;
 
-import static com.datastrato.gravitino.TestCatalogOperations.FAIL_CREATE;
+import static com.datastrato.gravitino.connector.TestCatalogOperations.FAIL_CREATE;
 
 import com.datastrato.gravitino.connector.BaseCatalog;
 import com.datastrato.gravitino.connector.BasePropertiesMetadata;

--- a/core/src/test/java/com/datastrato/gravitino/TestCatalog.java
+++ b/core/src/test/java/com/datastrato/gravitino/TestCatalog.java
@@ -7,13 +7,23 @@ package com.datastrato.gravitino;
 import static com.datastrato.gravitino.TestCatalogOperations.FAIL_CREATE;
 
 import com.datastrato.gravitino.connector.BaseCatalog;
+import com.datastrato.gravitino.connector.BasePropertiesMetadata;
 import com.datastrato.gravitino.connector.CatalogOperations;
+import com.datastrato.gravitino.connector.PropertiesMetadata;
+import com.datastrato.gravitino.connector.PropertyEntry;
+import com.datastrato.gravitino.connector.TestCatalogOperations;
 import com.datastrato.gravitino.connector.capability.Capability;
 import com.datastrato.gravitino.rel.TableCatalog;
+import com.google.common.collect.ImmutableMap;
 import java.util.Map;
-import java.util.Objects;
 
 public class TestCatalog extends BaseCatalog<TestCatalog> {
+
+  private static final TestBasePropertiesMetadata BASE_PROPERTIES_METADATA =
+      new TestBasePropertiesMetadata();
+
+  private static final TestFilesetPropertiesMetadata FILESET_PROPERTIES_METADATA =
+      new TestFilesetPropertiesMetadata();
 
   public TestCatalog() {}
 
@@ -24,9 +34,6 @@ public class TestCatalog extends BaseCatalog<TestCatalog> {
 
   @Override
   protected CatalogOperations newOps(Map<String, String> config) {
-    if (Objects.equals(config.get(FAIL_CREATE), "true")) {
-      throw new RuntimeException("Failed to create Test catalog");
-    }
     return new TestCatalogOperations(config);
   }
 
@@ -38,5 +45,79 @@ public class TestCatalog extends BaseCatalog<TestCatalog> {
   @Override
   public TableCatalog asTableCatalog() {
     return (TableCatalog) ops();
+  }
+
+  @Override
+  public PropertiesMetadata tablePropertiesMetadata() throws UnsupportedOperationException {
+    return BASE_PROPERTIES_METADATA;
+  }
+
+  @Override
+  public PropertiesMetadata catalogPropertiesMetadata() throws UnsupportedOperationException {
+    return new BasePropertiesMetadata() {
+      @Override
+      protected Map<String, PropertyEntry<?>> specificPropertyEntries() {
+        return ImmutableMap.<String, PropertyEntry<?>>builder()
+            .put(
+                "key1",
+                PropertyEntry.stringPropertyEntry("key1", "value1", true, true, null, false, false))
+            .put(
+                "key2",
+                PropertyEntry.stringPropertyEntry(
+                    "key2", "value2", true, false, null, false, false))
+            .put(
+                "key3",
+                new PropertyEntry.Builder<Integer>()
+                    .withDecoder(Integer::parseInt)
+                    .withEncoder(Object::toString)
+                    .withDefaultValue(1)
+                    .withDescription("key3")
+                    .withHidden(false)
+                    .withReserved(false)
+                    .withImmutable(true)
+                    .withJavaType(Integer.class)
+                    .withRequired(false)
+                    .withName("key3")
+                    .build())
+            .put(
+                "key4",
+                PropertyEntry.stringPropertyEntry(
+                    "key4", "value4", false, false, "value4", false, false))
+            .put(
+                "reserved_key",
+                PropertyEntry.stringPropertyEntry(
+                    "reserved_key", "reserved_key", false, true, "reserved_value", false, true))
+            .put(
+                "hidden_key",
+                PropertyEntry.stringPropertyEntry(
+                    "hidden_key", "hidden_key", false, false, "hidden_value", true, false))
+            .put(
+                FAIL_CREATE,
+                PropertyEntry.booleanPropertyEntry(
+                    FAIL_CREATE,
+                    "Whether an exception needs to be thrown on creation",
+                    false,
+                    false,
+                    false,
+                    false,
+                    false))
+            .build();
+      }
+    };
+  }
+
+  @Override
+  public PropertiesMetadata schemaPropertiesMetadata() throws UnsupportedOperationException {
+    return BASE_PROPERTIES_METADATA;
+  }
+
+  @Override
+  public PropertiesMetadata filesetPropertiesMetadata() throws UnsupportedOperationException {
+    return FILESET_PROPERTIES_METADATA;
+  }
+
+  @Override
+  public PropertiesMetadata topicPropertiesMetadata() throws UnsupportedOperationException {
+    return BASE_PROPERTIES_METADATA;
   }
 }

--- a/core/src/test/java/com/datastrato/gravitino/TestCatalogOperations.java
+++ b/core/src/test/java/com/datastrato/gravitino/TestCatalogOperations.java
@@ -6,8 +6,6 @@ package com.datastrato.gravitino.connector;
 
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
-import com.datastrato.gravitino.Schema;
-import com.datastrato.gravitino.SchemaChange;
 import com.datastrato.gravitino.TestFileset;
 import com.datastrato.gravitino.TestSchema;
 import com.datastrato.gravitino.TestTable;

--- a/core/src/test/java/com/datastrato/gravitino/TestCatalogOperations.java
+++ b/core/src/test/java/com/datastrato/gravitino/TestCatalogOperations.java
@@ -2,13 +2,16 @@
  * Copyright 2023 Datastrato Pvt Ltd.
  * This software is licensed under the Apache License version 2.
  */
-package com.datastrato.gravitino;
+package com.datastrato.gravitino.connector;
 
-import com.datastrato.gravitino.connector.BasePropertiesMetadata;
-import com.datastrato.gravitino.connector.CatalogInfo;
-import com.datastrato.gravitino.connector.CatalogOperations;
-import com.datastrato.gravitino.connector.PropertiesMetadata;
-import com.datastrato.gravitino.connector.PropertyEntry;
+import com.datastrato.gravitino.NameIdentifier;
+import com.datastrato.gravitino.Namespace;
+import com.datastrato.gravitino.Schema;
+import com.datastrato.gravitino.SchemaChange;
+import com.datastrato.gravitino.TestFileset;
+import com.datastrato.gravitino.TestSchema;
+import com.datastrato.gravitino.TestTable;
+import com.datastrato.gravitino.TestTopic;
 import com.datastrato.gravitino.exceptions.FilesetAlreadyExistsException;
 import com.datastrato.gravitino.exceptions.NoSuchCatalogException;
 import com.datastrato.gravitino.exceptions.NoSuchFilesetException;
@@ -38,7 +41,6 @@ import com.datastrato.gravitino.rel.expressions.distributions.Distribution;
 import com.datastrato.gravitino.rel.expressions.sorts.SortOrder;
 import com.datastrato.gravitino.rel.expressions.transforms.Transform;
 import com.datastrato.gravitino.rel.indexes.Index;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import java.io.IOException;
 import java.time.Instant;
@@ -56,16 +58,6 @@ public class TestCatalogOperations
 
   private final Map<NameIdentifier, TestTopic> topics;
 
-  private final BasePropertiesMetadata tablePropertiesMetadata;
-
-  private final BasePropertiesMetadata schemaPropertiesMetadata;
-
-  private final BasePropertiesMetadata filesetPropertiesMetadata;
-
-  private final BasePropertiesMetadata topicPropertiesMetadata;
-
-  private Map<String, String> config;
-
   public static final String FAIL_CREATE = "fail-create";
 
   public TestCatalogOperations(Map<String, String> config) {
@@ -73,15 +65,12 @@ public class TestCatalogOperations
     schemas = Maps.newHashMap();
     filesets = Maps.newHashMap();
     topics = Maps.newHashMap();
-    tablePropertiesMetadata = new TestBasePropertiesMetadata();
-    schemaPropertiesMetadata = new TestBasePropertiesMetadata();
-    filesetPropertiesMetadata = new TestFilesetPropertiesMetadata();
-    topicPropertiesMetadata = new TestBasePropertiesMetadata();
-    this.config = config;
   }
 
   @Override
-  public void initialize(Map<String, String> config, CatalogInfo info) throws RuntimeException {}
+  public void initialize(
+      Map<String, String> config, CatalogInfo info, HasPropertyMetadata propertyMetadata)
+      throws RuntimeException {}
 
   @Override
   public void close() throws IOException {}
@@ -309,102 +298,6 @@ public class TestCatalogOperations
     }
 
     return true;
-  }
-
-  @Override
-  public PropertiesMetadata tablePropertiesMetadata() throws UnsupportedOperationException {
-    return tablePropertiesMetadata;
-  }
-
-  @Override
-  public PropertiesMetadata schemaPropertiesMetadata() throws UnsupportedOperationException {
-    return schemaPropertiesMetadata;
-  }
-
-  @Override
-  public PropertiesMetadata catalogPropertiesMetadata() throws UnsupportedOperationException {
-    if (config.containsKey("mock")) {
-      return new BasePropertiesMetadata() {
-        @Override
-        protected Map<String, PropertyEntry<?>> specificPropertyEntries() {
-          return ImmutableMap.<String, PropertyEntry<?>>builder()
-              .put(
-                  "key1",
-                  PropertyEntry.stringPropertyEntry(
-                      "key1", "value1", true, true, null, false, false))
-              .put(
-                  "key2",
-                  PropertyEntry.stringPropertyEntry(
-                      "key2", "value2", true, false, null, false, false))
-              .put(
-                  "key3",
-                  new PropertyEntry.Builder<Integer>()
-                      .withDecoder(Integer::parseInt)
-                      .withEncoder(Object::toString)
-                      .withDefaultValue(1)
-                      .withDescription("key3")
-                      .withHidden(false)
-                      .withReserved(false)
-                      .withImmutable(true)
-                      .withJavaType(Integer.class)
-                      .withRequired(false)
-                      .withName("key3")
-                      .build())
-              .put(
-                  "key4",
-                  PropertyEntry.stringPropertyEntry(
-                      "key4", "value4", false, false, "value4", false, false))
-              .put(
-                  "reserved_key",
-                  PropertyEntry.stringPropertyEntry(
-                      "reserved_key", "reserved_key", false, true, "reserved_value", false, true))
-              .put(
-                  "hidden_key",
-                  PropertyEntry.stringPropertyEntry(
-                      "hidden_key", "hidden_key", false, false, "hidden_value", true, false))
-              .put(
-                  FAIL_CREATE,
-                  PropertyEntry.booleanPropertyEntry(
-                      FAIL_CREATE,
-                      "Whether an exception needs to be thrown on creation",
-                      false,
-                      false,
-                      false,
-                      false,
-                      false))
-              .build();
-        }
-      };
-    } else if (config.containsKey("hive")) {
-      return new BasePropertiesMetadata() {
-        @Override
-        protected Map<String, PropertyEntry<?>> specificPropertyEntries() {
-          return ImmutableMap.<String, PropertyEntry<?>>builder()
-              .put(
-                  "hive.metastore.uris",
-                  PropertyEntry.stringPropertyEntry(
-                      "hive.metastore.uris",
-                      "The Hive metastore URIs",
-                      true,
-                      true,
-                      null,
-                      false,
-                      false))
-              .build();
-        }
-      };
-    }
-    return Maps::newHashMap;
-  }
-
-  @Override
-  public PropertiesMetadata filesetPropertiesMetadata() throws UnsupportedOperationException {
-    return filesetPropertiesMetadata;
-  }
-
-  @Override
-  public PropertiesMetadata topicPropertiesMetadata() throws UnsupportedOperationException {
-    return topicPropertiesMetadata;
   }
 
   @Override

--- a/core/src/test/java/com/datastrato/gravitino/catalog/DummyCatalogOperations.java
+++ b/core/src/test/java/com/datastrato/gravitino/catalog/DummyCatalogOperations.java
@@ -7,39 +7,16 @@ package com.datastrato.gravitino.catalog;
 
 import com.datastrato.gravitino.connector.CatalogInfo;
 import com.datastrato.gravitino.connector.CatalogOperations;
-import com.datastrato.gravitino.connector.PropertiesMetadata;
+import com.datastrato.gravitino.connector.HasPropertyMetadata;
 import java.io.IOException;
 import java.util.Map;
 
 public class DummyCatalogOperations implements CatalogOperations {
 
   @Override
-  public void initialize(Map<String, String> config, CatalogInfo info) throws RuntimeException {}
-
-  @Override
-  public PropertiesMetadata tablePropertiesMetadata() throws UnsupportedOperationException {
-    return null;
-  }
-
-  @Override
-  public PropertiesMetadata catalogPropertiesMetadata() throws UnsupportedOperationException {
-    return null;
-  }
-
-  @Override
-  public PropertiesMetadata schemaPropertiesMetadata() throws UnsupportedOperationException {
-    return null;
-  }
-
-  @Override
-  public PropertiesMetadata filesetPropertiesMetadata() throws UnsupportedOperationException {
-    return null;
-  }
-
-  @Override
-  public PropertiesMetadata topicPropertiesMetadata() throws UnsupportedOperationException {
-    return null;
-  }
+  public void initialize(
+      Map<String, String> config, CatalogInfo info, HasPropertyMetadata propertiesMetadata)
+      throws RuntimeException {}
 
   @Override
   public void close() throws IOException {}

--- a/core/src/test/java/com/datastrato/gravitino/catalog/TestBaseCatalog.java
+++ b/core/src/test/java/com/datastrato/gravitino/catalog/TestBaseCatalog.java
@@ -6,9 +6,9 @@
 package com.datastrato.gravitino.catalog;
 
 import com.datastrato.gravitino.TestCatalog;
-import com.datastrato.gravitino.TestCatalogOperations;
 import com.datastrato.gravitino.connector.BaseCatalog;
 import com.datastrato.gravitino.connector.CatalogOperations;
+import com.datastrato.gravitino.connector.TestCatalogOperations;
 import com.datastrato.gravitino.meta.CatalogEntity;
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Assertions;

--- a/core/src/test/java/com/datastrato/gravitino/catalog/TestCatalogNormalizeDispatcher.java
+++ b/core/src/test/java/com/datastrato/gravitino/catalog/TestCatalogNormalizeDispatcher.java
@@ -17,8 +17,10 @@ import com.datastrato.gravitino.meta.BaseMetalake;
 import com.datastrato.gravitino.meta.SchemaVersion;
 import com.datastrato.gravitino.storage.RandomIdGenerator;
 import com.datastrato.gravitino.storage.memory.TestMemoryEntityStore;
+import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Map;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -83,8 +85,9 @@ public class TestCatalogNormalizeDispatcher {
     String[] legalNames = {"catalog", "_catalog", "1_catalog", "_", "1"};
     for (String legalName : legalNames) {
       NameIdentifier catalogIdent = NameIdentifier.of(metalake, legalName);
+      Map<String, String> props = ImmutableMap.of("key1", "value1", "key2", "value2");
       Catalog catalog =
-          catalogNormalizeDispatcher.createCatalog(catalogIdent, RELATIONAL, "test", null, null);
+          catalogNormalizeDispatcher.createCatalog(catalogIdent, RELATIONAL, "test", null, props);
       Assertions.assertEquals(legalName, catalog.name());
     }
 

--- a/core/src/test/java/com/datastrato/gravitino/catalog/TestOperationDispatcher.java
+++ b/core/src/test/java/com/datastrato/gravitino/catalog/TestOperationDispatcher.java
@@ -70,7 +70,7 @@ public abstract class TestOperationDispatcher {
     catalogManager = new CatalogManager(config, entityStore, idGenerator);
 
     NameIdentifier ident = NameIdentifier.of(metalake, catalog);
-    Map<String, String> props = ImmutableMap.of();
+    Map<String, String> props = ImmutableMap.of("key1", "value1", "key2", "value2");
     catalogManager.createCatalog(ident, Catalog.Type.RELATIONAL, "test", "comment", props);
   }
 

--- a/server/src/test/java/com/datastrato/gravitino/server/web/rest/TestCatalog.java
+++ b/server/src/test/java/com/datastrato/gravitino/server/web/rest/TestCatalog.java
@@ -7,12 +7,15 @@ package com.datastrato.gravitino.server.web.rest;
 import com.datastrato.gravitino.connector.BaseCatalog;
 import com.datastrato.gravitino.connector.CatalogInfo;
 import com.datastrato.gravitino.connector.CatalogOperations;
+import com.datastrato.gravitino.connector.HasPropertyMetadata;
 import com.datastrato.gravitino.connector.PropertiesMetadata;
-import com.google.common.collect.Maps;
+import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.util.Map;
 
 public class TestCatalog extends BaseCatalog<TestCatalog> {
+  private static final PropertiesMetadata PROPERTIES_METADATA = ImmutableMap::of;
+
   @Override
   public String shortName() {
     return "test";
@@ -21,36 +24,19 @@ public class TestCatalog extends BaseCatalog<TestCatalog> {
   @Override
   protected CatalogOperations newOps(Map config) {
     return new CatalogOperations() {
-      @Override
-      public PropertiesMetadata tablePropertiesMetadata() throws UnsupportedOperationException {
-        throw new UnsupportedOperationException();
-      }
 
       @Override
-      public PropertiesMetadata schemaPropertiesMetadata() throws UnsupportedOperationException {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public PropertiesMetadata filesetPropertiesMetadata() throws UnsupportedOperationException {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public PropertiesMetadata topicPropertiesMetadata() throws UnsupportedOperationException {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public void initialize(Map<String, String> config, CatalogInfo info)
+      public void initialize(
+          Map<String, String> config, CatalogInfo info, HasPropertyMetadata propertiesMetadata)
           throws RuntimeException {}
 
       @Override
       public void close() throws IOException {}
-
-      public PropertiesMetadata catalogPropertiesMetadata() throws UnsupportedOperationException {
-        return Maps::newHashMap;
-      }
     };
+  }
+
+  @Override
+  public PropertiesMetadata catalogPropertiesMetadata() throws UnsupportedOperationException {
+    return PROPERTIES_METADATA;
   }
 }

--- a/web/src/app/metalakes/metalake/MetalakeView.js
+++ b/web/src/app/metalakes/metalake/MetalakeView.js
@@ -45,59 +45,62 @@ const MetalakeView = () => {
       fileset: searchParams.get('fileset'),
       topic: searchParams.get('topic')
     }
-    if ([...searchParams.keys()].length) {
-      const { metalake, catalog, type, schema, table, fileset, topic } = routeParams
+    async function fetchDependsData() {
+      if ([...searchParams.keys()].length) {
+        const { metalake, catalog, type, schema, table, fileset, topic } = routeParams
 
-      if (paramsSize === 1 && metalake) {
-        dispatch(fetchCatalogs({ init: true, page: 'metalakes', metalake }))
-        dispatch(getMetalakeDetails({ metalake }))
-      }
+        if (paramsSize === 1 && metalake) {
+          dispatch(fetchCatalogs({ init: true, page: 'metalakes', metalake }))
+          dispatch(getMetalakeDetails({ metalake }))
+        }
 
-      if (paramsSize === 3 && catalog) {
-        if (!store.catalogs.length) {
-          dispatch(fetchCatalogs({ metalake }))
+        if (paramsSize === 3 && catalog) {
+          if (!store.catalogs.length) {
+            await dispatch(fetchCatalogs({ metalake }))
+          }
+          dispatch(fetchSchemas({ init: true, page: 'catalogs', metalake, catalog, type }))
+          dispatch(getCatalogDetails({ metalake, catalog, type }))
         }
-        dispatch(fetchSchemas({ init: true, page: 'catalogs', metalake, catalog, type }))
-        dispatch(getCatalogDetails({ metalake, catalog, type }))
-      }
 
-      if (paramsSize === 4 && catalog && type && schema) {
-        if (!store.catalogs.length) {
-          dispatch(fetchCatalogs({ metalake }))
-          dispatch(fetchSchemas({ metalake, catalog, type }))
+        if (paramsSize === 4 && catalog && type && schema) {
+          if (!store.catalogs.length) {
+            await dispatch(fetchCatalogs({ metalake }))
+            await dispatch(fetchSchemas({ metalake, catalog, type }))
+          }
+          switch (type) {
+            case 'relational':
+              dispatch(fetchTables({ init: true, page: 'schemas', metalake, catalog, schema }))
+              break
+            case 'fileset':
+              dispatch(fetchFilesets({ init: true, page: 'schemas', metalake, catalog, schema }))
+              break
+            case 'messaging':
+              dispatch(fetchTopics({ init: true, page: 'schemas', metalake, catalog, schema }))
+              break
+            default:
+              break
+          }
+          dispatch(getSchemaDetails({ metalake, catalog, schema }))
         }
-        switch (type) {
-          case 'relational':
-            dispatch(fetchTables({ init: true, page: 'schemas', metalake, catalog, schema }))
-            break
-          case 'fileset':
-            dispatch(fetchFilesets({ init: true, page: 'schemas', metalake, catalog, schema }))
-            break
-          case 'messaging':
-            dispatch(fetchTopics({ init: true, page: 'schemas', metalake, catalog, schema }))
-            break
-          default:
-            break
-        }
-        dispatch(getSchemaDetails({ metalake, catalog, schema }))
-      }
 
-      if (paramsSize === 5 && catalog && schema) {
-        if (!store.catalogs.length) {
-          dispatch(fetchCatalogs({ metalake }))
-          dispatch(fetchSchemas({ metalake, catalog, type }))
-        }
-        if (table) {
-          dispatch(getTableDetails({ init: true, metalake, catalog, schema, table }))
-        }
-        if (fileset) {
-          dispatch(getFilesetDetails({ init: true, metalake, catalog, schema, fileset }))
-        }
-        if (topic) {
-          dispatch(getTopicDetails({ init: true, metalake, catalog, schema, topic }))
+        if (paramsSize === 5 && catalog && schema) {
+          if (!store.catalogs.length) {
+            await dispatch(fetchCatalogs({ metalake }))
+            await dispatch(fetchSchemas({ metalake, catalog, type }))
+          }
+          if (table) {
+            dispatch(getTableDetails({ init: true, metalake, catalog, schema, table }))
+          }
+          if (fileset) {
+            dispatch(getFilesetDetails({ init: true, metalake, catalog, schema, fileset }))
+          }
+          if (topic) {
+            dispatch(getTopicDetails({ init: true, metalake, catalog, schema, topic }))
+          }
         }
       }
     }
+    fetchDependsData()
 
     dispatch(
       setSelectedNodes(


### PR DESCRIPTION
### What changes were proposed in this pull request?

 - move `HasPropertyMetadata` from interface to initialize method in `CatalogOperations`

### Why are the changes needed?

the CatalogOperations initialize may take a long time when `getHiddenPropertyNames`

Fix: #3244 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

modified tests