### PR TITLE
[#3673] fix(core): avoid to initialize catalog ops when closing catalog

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/catalog/CatalogManager.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/CatalogManager.java
@@ -162,7 +162,7 @@ public class CatalogManager implements CatalogDispatcher, Closeable {
         classLoader.withClassLoader(
             cl -> {
               if (catalog != null) {
-                catalog.ops().close();
+                catalog.close();
               }
               catalog = null;
               return null;

--- a/core/src/main/java/com/datastrato/gravitino/connector/BaseCatalog.java
+++ b/core/src/main/java/com/datastrato/gravitino/connector/BaseCatalog.java
@@ -13,6 +13,8 @@ import com.datastrato.gravitino.meta.CatalogEntity;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -32,7 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 @Evolving
 public abstract class BaseCatalog<T extends BaseCatalog>
-    implements Catalog, CatalogProvider, HasPropertyMetadata {
+    implements Catalog, CatalogProvider, HasPropertyMetadata, Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(BaseCatalog.class);
 
   // This variable is used as a key in properties of catalogs to inject custom operation to
@@ -151,6 +153,14 @@ public abstract class BaseCatalog<T extends BaseCatalog>
     }
 
     return ops;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (ops != null) {
+      ops.close();
+      ops = null;
+    }
   }
 
   public Capability capability() {


### PR DESCRIPTION
### What changes were proposed in this pull request?

avoid to initialize catalog ops when closing catalog

### Why are the changes needed?

Fix: #3673 

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

no
