### PR TITLE
[#3612] wait for the Gravitino server to start before running IT in deploy mode by using Awaitility backage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -237,6 +237,10 @@ subprojects {
     mavenLocal()
   }
 
+  dependencies {
+        testImplementation("org.awaitility:awaitility:4.2.1")
+  }
+  
   java {
     toolchain {
       // Some JDK vendors like Homebrew installed OpenJDK 17 have problems in building trino-connector:

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/client/AuditIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/client/AuditIT.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.awaitility.Awaitility;
+import java.util.concurrent.TimeUnit;
 
 public class AuditIT extends AbstractIT {
 
@@ -35,17 +37,33 @@ public class AuditIT extends AbstractIT {
     String metalakeAuditName = RandomNameUtils.genRandomName("metalakeAudit");
     String newName = RandomNameUtils.genRandomName("newmetaname");
 
-    GravitinoMetalake metaLake =
-        client.createMetalake(metalakeAuditName, "metalake A comment", Collections.emptyMap());
+    Awaitility.await().atMost(1, TimeUnit.MINUTES).until(() -> isGravitinoServerUp());
+
+    GravitinoMetalake metaLake = client.createMetalake(metalakeAuditName, "metalake A comment", Collections.emptyMap());
     Assertions.assertEquals(expectUser, metaLake.auditInfo().creator());
     Assertions.assertNull(metaLake.auditInfo().lastModifier());
-    MetalakeChange[] changes =
-        new MetalakeChange[] {
-          MetalakeChange.rename(newName), MetalakeChange.updateComment("new metalake comment")
-        };
+    MetalakeChange[] changes = new MetalakeChange[] {
+        MetalakeChange.rename(newName), MetalakeChange.updateComment("new metalake comment")
+    };
     metaLake = client.alterMetalake(metalakeAuditName, changes);
     Assertions.assertEquals(expectUser, metaLake.auditInfo().creator());
     Assertions.assertEquals(expectUser, metaLake.auditInfo().lastModifier());
     client.dropMetalake(newName);
+  }
+
+  // Method to check if the Gravitino server is up
+  private boolean isGravitinoServerUp() {
+    try {
+      URL url = new URL("http://localhost:8090");
+      HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+      connection.setRequestMethod("GET");
+      connection.setConnectTimeout(1000);
+      connection.connect();
+      int responseCode = connection.getResponseCode();
+      return responseCode == 200;
+      System.out.println("/n/n/n"+responseCode+"/n/n/n");
+    } catch (IOException e) {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

1. add a dependencies of Awaitility backage
2. add a function waiting for Gravitino server starting.
 fix: [#3612 ](https://github.com/datastrato/gravitino/issues/3612)

### Why are the changes needed?

  1. To prevent a bug that run IT test before  starting Gravitino server. 

Fix: # (issue)

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

./gradlew  clean && ./gradlew compileDistribution -x test && :integration-test:test --tests "com.datastrato.gravitino.integration.test.client.MetalakeIT"
FYI: https://datastrato.ai/docs/0.5.0/how-to-test#run-the-integration-tests-in-embedded-mode