### PR TITLE
[MINOR] fix(pageIT): add Kafka catalog dependency to pageIT

### DIFF
--- a/catalogs/catalog-kafka/build.gradle.kts
+++ b/catalogs/catalog-kafka/build.gradle.kts
@@ -68,7 +68,6 @@ tasks.getByName("generateMetadataFileForMavenJavaPublication") {
   dependsOn("runtimeJars")
 }
 
-// TODO. add test task later on.
 tasks.test {
   val skipUTs = project.hasProperty("skipTests")
   if (skipUTs) {

--- a/integration-test/build.gradle.kts
+++ b/integration-test/build.gradle.kts
@@ -130,6 +130,7 @@ tasks.test {
     dependsOn(":catalogs:catalog-jdbc-postgresql:jar", ":catalogs:catalog-jdbc-postgresql:runtimeJars")
     dependsOn(":catalogs:catalog-hadoop:jar", ":catalogs:catalog-hadoop:runtimeJars")
     dependsOn(":catalogs:catalog-hive:jar", ":catalogs:catalog-hive:runtimeJars")
+    dependsOn(":catalogs:catalog-kafka:jar", ":catalogs:catalog-kafka:runtimeJars")
 
     doFirst {
       // Gravitino CI Docker image


### PR DESCRIPTION
### What changes were proposed in this pull request?

add Kafka catalog dependency to pageIT

### Why are the changes needed?

`./gradlew clean build` failed because:

```
Caused by: java.lang.ClassNotFoundException: Class no found org.apache.kafka.common.KafkaException
        at com.datastrato.gravitino.utils.IsolatedClassLoader$CustomURLClassLoader.loadClass(IsolatedClassLoader.java:161)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:352)
        ... 86 more
```

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

local tested
