### PR TITLE
[Improvement] In HiveCatalogOperations.java it may be better to use java.nio.file.Files#delete

### DIFF
--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveCatalogOperations.java
@@ -282,7 +282,8 @@ public class HiveCatalogOperations implements CatalogOperations, SupportsSchemas
       checkTgtExecutor = null;
     }
     try {
-      Path keytabPath = Paths.get(String.format(GRAVITINO_KEYTAB_FORMAT, info.id())).toAbsolutePath();
+      Path keytabPath =
+          Paths.get(String.format(GRAVITINO_KEYTAB_FORMAT, info.id())).toAbsolutePath();
       if (!Files.deleteIfExists(keytabPath)) {
         LOG.error("Fail to delete key tab file {}", keytabPath);
       }


### PR DESCRIPTION
[Improvement] In HiveCatalogOperations.java #1909 

 I think use the java.nio.file.Files#deleteIfExists is more better than  java.nio.file.Files#delete

I ran `TestHadoopCatalogOperations`, `TestHiveCatalog` and all tests passed 

