### PR TITLE
[#3701]refactor(API): Refactoring SupportsSchemas.listSchemas() method to return String[]

### DIFF
--- a/api/src/main/java/com/datastrato/gravitino/SupportsSchemas.java
+++ b/api/src/main/java/com/datastrato/gravitino/SupportsSchemas.java
@@ -44,7 +44,7 @@ public interface SupportsSchemas {
    * @return An array of schema identifier under the namespace.
    * @throws NoSuchCatalogException If the catalog does not exist.
    */
-  NameIdentifier[] listSchemas() throws NoSuchCatalogException;
+  String[] listSchemas() throws NoSuchCatalogException;
 
   /**
    * Check if a schema exists.

--- a/api/src/main/java/com/datastrato/gravitino/SupportsSchemas.java
+++ b/api/src/main/java/com/datastrato/gravitino/SupportsSchemas.java
@@ -39,9 +39,9 @@ public interface SupportsSchemas {
    *
    * <p>If an entity such as a table, view exists, its parent schemas must also exist and must be
    * returned by this discovery method. For example, if table a.b.t exists, this method invoked as
-   * listSchemas(a) must return [a.b] in the result array
+   * listSchemas(a) must return [b] in the result array
    *
-   * @return An array of schema identifier under the namespace.
+   * @return An array of schema names under the namespace.
    * @throws NoSuchCatalogException If the catalog does not exist.
    */
   String[] listSchemas() throws NoSuchCatalogException;

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
@@ -200,10 +200,10 @@ public class CatalogHiveIT extends AbstractIT {
   @AfterAll
   public static void stop() throws IOException {
     Arrays.stream(catalog.asSchemas().listSchemas())
-        .filter(ident -> !ident.equals("default"))
+        .filter(schema -> !schema.equals("default"))
         .forEach(
-            (ident -> {
-              catalog.asSchemas().dropSchema(ident, true);
+            (schema -> {
+              catalog.asSchemas().dropSchema(schema, true);
             }));
     Arrays.stream(metalake.listCatalogs())
         .forEach(

--- a/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
+++ b/catalogs/catalog-hive/src/test/java/com/datastrato/gravitino/catalog/hive/integration/test/CatalogHiveIT.java
@@ -200,10 +200,10 @@ public class CatalogHiveIT extends AbstractIT {
   @AfterAll
   public static void stop() throws IOException {
     Arrays.stream(catalog.asSchemas().listSchemas())
-        .filter(ident -> !ident.name().equals("default"))
+        .filter(ident -> !ident.equals("default"))
         .forEach(
             (ident -> {
-              catalog.asSchemas().dropSchema(ident.name(), true);
+              catalog.asSchemas().dropSchema(ident, true);
             }));
     Arrays.stream(metalake.listCatalogs())
         .forEach(

--- a/catalogs/catalog-jdbc-doris/src/test/java/com/datastrato/gravitino/catalog/doris/integration/test/CatalogDorisIT.java
+++ b/catalogs/catalog-jdbc-doris/src/test/java/com/datastrato/gravitino/catalog/doris/integration/test/CatalogDorisIT.java
@@ -35,10 +35,9 @@ import com.google.common.collect.Maps;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -185,20 +184,16 @@ public class CatalogDorisIT extends AbstractIT {
     SupportsSchemas schemas = catalog.asSchemas();
 
     // test list schemas
-    NameIdentifier[] nameIdentifiers = schemas.listSchemas();
-    Set<String> schemaNames =
-        Arrays.stream(nameIdentifiers).map(NameIdentifier::name).collect(Collectors.toSet());
-    Assertions.assertTrue(schemaNames.contains(schemaName));
+    String[] schemaNames = schemas.listSchemas();
+    Assertions.assertTrue(Arrays.asList(schemaNames).contains(schemaName));
 
     // test create schema already exists
     String testSchemaName = GravitinoITUtils.genRandomName("create_schema_test");
     NameIdentifier schemaIdent = NameIdentifier.of(metalakeName, catalogName, testSchemaName);
     schemas.createSchema(schemaIdent.name(), schema_comment, Collections.emptyMap());
 
-    nameIdentifiers = schemas.listSchemas();
-    Map<String, NameIdentifier> schemaMap =
-        Arrays.stream(nameIdentifiers).collect(Collectors.toMap(NameIdentifier::name, v -> v));
-    Assertions.assertTrue(schemaMap.containsKey(testSchemaName));
+    List<String> schemaNameList = Arrays.asList(schemas.listSchemas());
+    Assertions.assertTrue(schemaNameList.contains(testSchemaName));
 
     Assertions.assertThrows(
         SchemaAlreadyExistsException.class,
@@ -215,10 +210,8 @@ public class CatalogDorisIT extends AbstractIT {
         NoSuchSchemaException.class, () -> schemas.loadSchema(schemaIdent.name()));
 
     // 2. check by list schema
-    nameIdentifiers = schemas.listSchemas();
-    schemaMap =
-        Arrays.stream(nameIdentifiers).collect(Collectors.toMap(NameIdentifier::name, v -> v));
-    Assertions.assertFalse(schemaMap.containsKey(testSchemaName));
+    schemaNameList = Arrays.asList(schemas.listSchemas());
+    Assertions.assertFalse(schemaNameList.contains(testSchemaName));
 
     // test drop schema not exists
     NameIdentifier notExistsSchemaIdent = NameIdentifier.of(metalakeName, catalogName, "no-exits");

--- a/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -243,9 +244,8 @@ public class CatalogMysqlIT extends AbstractIT {
     SupportsSchemas schemas = catalog.asSchemas();
     Namespace namespace = Namespace.of(metalakeName, catalogName);
     // list schema check.
-    NameIdentifier[] nameIdentifiers = schemas.listSchemas();
-    Set<String> schemaNames =
-        Arrays.stream(nameIdentifiers).map(NameIdentifier::name).collect(Collectors.toSet());
+    String[] nameIdentifiers = schemas.listSchemas();
+    Set<String> schemaNames = new HashSet<>(Arrays.asList(nameIdentifiers));
     Assertions.assertTrue(schemaNames.contains(schemaName));
 
     NameIdentifier[] mysqlNamespaces = mysqlService.listSchemas(namespace);
@@ -258,9 +258,8 @@ public class CatalogMysqlIT extends AbstractIT {
     NameIdentifier schemaIdent = NameIdentifier.of(metalakeName, catalogName, testSchemaName);
     schemas.createSchema(schemaIdent.name(), schema_comment, Collections.emptyMap());
     nameIdentifiers = schemas.listSchemas();
-    Map<String, NameIdentifier> schemaMap =
-        Arrays.stream(nameIdentifiers).collect(Collectors.toMap(NameIdentifier::name, v -> v));
-    Assertions.assertTrue(schemaMap.containsKey(testSchemaName));
+    schemaNames = new HashSet<>(Arrays.asList(nameIdentifiers));
+    Assertions.assertTrue(schemaNames.contains(testSchemaName));
 
     mysqlNamespaces = mysqlService.listSchemas(namespace);
     schemaNames =
@@ -282,9 +281,8 @@ public class CatalogMysqlIT extends AbstractIT {
         NoSuchSchemaException.class, () -> mysqlService.loadSchema(schemaIdent));
 
     nameIdentifiers = schemas.listSchemas();
-    schemaMap =
-        Arrays.stream(nameIdentifiers).collect(Collectors.toMap(NameIdentifier::name, v -> v));
-    Assertions.assertFalse(schemaMap.containsKey(testSchemaName));
+    schemaNames = new HashSet<>(Arrays.asList(nameIdentifiers));
+    Assertions.assertFalse(schemaNames.contains(testSchemaName));
     Assertions.assertFalse(schemas.dropSchema("no-exits", false));
     TableCatalog tableCatalog = catalog.asTableCatalog();
 
@@ -1327,9 +1325,8 @@ public class CatalogMysqlIT extends AbstractIT {
     Schema schema = catalog.asSchemas().loadSchema(testSchemaName);
     Assertions.assertEquals(testSchemaName, schema.name());
 
-    NameIdentifier[] schemaIdents = catalog.asSchemas().listSchemas();
-    Assertions.assertTrue(
-        Arrays.stream(schemaIdents).anyMatch(s -> s.name().equals(testSchemaName)));
+    String[] schemaIdents = catalog.asSchemas().listSchemas();
+    Assertions.assertTrue(Arrays.stream(schemaIdents).anyMatch(s -> s.equals(testSchemaName)));
 
     Assertions.assertTrue(catalog.asSchemas().dropSchema(testSchemaName, false));
     Assertions.assertFalse(catalog.asSchemas().schemaExists(testSchemaName));
@@ -1374,10 +1371,7 @@ public class CatalogMysqlIT extends AbstractIT {
       Assertions.assertNotNull(schemaSupport.loadSchema(schema));
     }
 
-    Set<String> schemaNames =
-        Arrays.stream(schemaSupport.listSchemas())
-            .map(NameIdentifier::name)
-            .collect(Collectors.toSet());
+    Set<String> schemaNames = new HashSet<>(Arrays.asList(schemaSupport.listSchemas()));
 
     Assertions.assertTrue(schemaNames.containsAll(Arrays.asList(schemas)));
 

--- a/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
+++ b/catalogs/catalog-jdbc-mysql/src/test/java/com/datastrato/gravitino/catalog/mysql/integration/test/CatalogMysqlIT.java
@@ -45,11 +45,11 @@ import com.datastrato.gravitino.rel.types.Decimal;
 import com.datastrato.gravitino.rel.types.Types;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -245,7 +245,7 @@ public class CatalogMysqlIT extends AbstractIT {
     Namespace namespace = Namespace.of(metalakeName, catalogName);
     // list schema check.
     String[] nameIdentifiers = schemas.listSchemas();
-    Set<String> schemaNames = new HashSet<>(Arrays.asList(nameIdentifiers));
+    Set<String> schemaNames = Sets.newHashSet(nameIdentifiers);
     Assertions.assertTrue(schemaNames.contains(schemaName));
 
     NameIdentifier[] mysqlNamespaces = mysqlService.listSchemas(namespace);
@@ -258,7 +258,7 @@ public class CatalogMysqlIT extends AbstractIT {
     NameIdentifier schemaIdent = NameIdentifier.of(metalakeName, catalogName, testSchemaName);
     schemas.createSchema(schemaIdent.name(), schema_comment, Collections.emptyMap());
     nameIdentifiers = schemas.listSchemas();
-    schemaNames = new HashSet<>(Arrays.asList(nameIdentifiers));
+    schemaNames = Sets.newHashSet(nameIdentifiers);
     Assertions.assertTrue(schemaNames.contains(testSchemaName));
 
     mysqlNamespaces = mysqlService.listSchemas(namespace);
@@ -281,7 +281,7 @@ public class CatalogMysqlIT extends AbstractIT {
         NoSuchSchemaException.class, () -> mysqlService.loadSchema(schemaIdent));
 
     nameIdentifiers = schemas.listSchemas();
-    schemaNames = new HashSet<>(Arrays.asList(nameIdentifiers));
+    schemaNames = Sets.newHashSet(nameIdentifiers);
     Assertions.assertFalse(schemaNames.contains(testSchemaName));
     Assertions.assertFalse(schemas.dropSchema("no-exits", false));
     TableCatalog tableCatalog = catalog.asTableCatalog();
@@ -1371,7 +1371,7 @@ public class CatalogMysqlIT extends AbstractIT {
       Assertions.assertNotNull(schemaSupport.loadSchema(schema));
     }
 
-    Set<String> schemaNames = new HashSet<>(Arrays.asList(schemaSupport.listSchemas()));
+    Set<String> schemaNames = Sets.newHashSet(schemaSupport.listSchemas());
 
     Assertions.assertTrue(schemaNames.containsAll(Arrays.asList(schemas)));
 

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
@@ -44,12 +44,12 @@ import com.datastrato.gravitino.rel.types.Types;
 import com.datastrato.gravitino.rel.types.Types.IntegerType;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -291,7 +291,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     Namespace namespace = Namespace.of(metalakeName, catalogName);
     // list schema check.
     String[] nameIdentifiers = schemas.listSchemas();
-    Set<String> schemaNames = new HashSet<>(Arrays.asList(nameIdentifiers));
+    Set<String> schemaNames = Sets.newHashSet(nameIdentifiers);
     Assertions.assertTrue(schemaNames.contains(schemaName));
 
     NameIdentifier[] postgreSqlNamespaces = postgreSqlService.listSchemas(namespace);
@@ -304,7 +304,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     NameIdentifier schemaIdent = NameIdentifier.of(metalakeName, catalogName, testSchemaName);
     schemas.createSchema(schemaIdent.name(), schema_comment, Collections.emptyMap());
     nameIdentifiers = schemas.listSchemas();
-    schemaNames = new HashSet<>(Arrays.asList(nameIdentifiers));
+    schemaNames = Sets.newHashSet(nameIdentifiers);
     Assertions.assertTrue(schemaNames.contains(testSchemaName));
 
     postgreSqlNamespaces = postgreSqlService.listSchemas(namespace);
@@ -327,7 +327,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
         NoSuchSchemaException.class, () -> postgreSqlService.loadSchema(schemaIdent));
 
     nameIdentifiers = schemas.listSchemas();
-    schemaNames = new HashSet<>(Arrays.asList(nameIdentifiers));
+    schemaNames = Sets.newHashSet(nameIdentifiers);
     Assertions.assertFalse(schemaNames.contains(testSchemaName));
     Assertions.assertFalse(schemas.dropSchema("no_exits", false));
     TableCatalog tableCatalog = catalog.asTableCatalog();
@@ -544,7 +544,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
   @Test
   void testListSchema() {
     String[] nameIdentifiers = catalog.asSchemas().listSchemas();
-    Set<String> schemaNames = new HashSet<>(Arrays.asList(nameIdentifiers));
+    Set<String> schemaNames = Sets.newHashSet(nameIdentifiers);
     Assertions.assertTrue(schemaNames.contains("public"));
   }
 
@@ -1213,7 +1213,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
       Assertions.assertNotNull(schemaSupport.loadSchema(schema));
     }
 
-    Set<String> schemaNames = new HashSet<>(Arrays.asList(schemaSupport.listSchemas()));
+    Set<String> schemaNames = Sets.newHashSet(schemaSupport.listSchemas());
     Assertions.assertTrue(schemaNames.containsAll(Arrays.asList(schemas)));
 
     String tableName = "test1";

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/CatalogPostgreSqlIT.java
@@ -49,6 +49,7 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -108,9 +109,9 @@ public class CatalogPostgreSqlIT extends AbstractIT {
   @AfterAll
   public void stop() {
     clearTableAndSchema();
-    NameIdentifier[] schemaIdentifiers = catalog.asSchemas().listSchemas();
-    for (NameIdentifier nameIdentifier : schemaIdentifiers) {
-      catalog.asSchemas().dropSchema(nameIdentifier.name(), true);
+    String[] schemaNames = catalog.asSchemas().listSchemas();
+    for (String schemaName : schemaNames) {
+      catalog.asSchemas().dropSchema(schemaName, true);
     }
     metalake.dropCatalog(catalogName);
     client.dropMetalake(metalakeName);
@@ -289,9 +290,8 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     SupportsSchemas schemas = catalog.asSchemas();
     Namespace namespace = Namespace.of(metalakeName, catalogName);
     // list schema check.
-    NameIdentifier[] nameIdentifiers = schemas.listSchemas();
-    Set<String> schemaNames =
-        Arrays.stream(nameIdentifiers).map(NameIdentifier::name).collect(Collectors.toSet());
+    String[] nameIdentifiers = schemas.listSchemas();
+    Set<String> schemaNames = new HashSet<>(Arrays.asList(nameIdentifiers));
     Assertions.assertTrue(schemaNames.contains(schemaName));
 
     NameIdentifier[] postgreSqlNamespaces = postgreSqlService.listSchemas(namespace);
@@ -304,9 +304,8 @@ public class CatalogPostgreSqlIT extends AbstractIT {
     NameIdentifier schemaIdent = NameIdentifier.of(metalakeName, catalogName, testSchemaName);
     schemas.createSchema(schemaIdent.name(), schema_comment, Collections.emptyMap());
     nameIdentifiers = schemas.listSchemas();
-    Map<String, NameIdentifier> schemaMap =
-        Arrays.stream(nameIdentifiers).collect(Collectors.toMap(NameIdentifier::name, v -> v));
-    Assertions.assertTrue(schemaMap.containsKey(testSchemaName));
+    schemaNames = new HashSet<>(Arrays.asList(nameIdentifiers));
+    Assertions.assertTrue(schemaNames.contains(testSchemaName));
 
     postgreSqlNamespaces = postgreSqlService.listSchemas(namespace);
     schemaNames =
@@ -328,9 +327,8 @@ public class CatalogPostgreSqlIT extends AbstractIT {
         NoSuchSchemaException.class, () -> postgreSqlService.loadSchema(schemaIdent));
 
     nameIdentifiers = schemas.listSchemas();
-    schemaMap =
-        Arrays.stream(nameIdentifiers).collect(Collectors.toMap(NameIdentifier::name, v -> v));
-    Assertions.assertFalse(schemaMap.containsKey(testSchemaName));
+    schemaNames = new HashSet<>(Arrays.asList(nameIdentifiers));
+    Assertions.assertFalse(schemaNames.contains(testSchemaName));
     Assertions.assertFalse(schemas.dropSchema("no_exits", false));
     TableCatalog tableCatalog = catalog.asTableCatalog();
 
@@ -545,9 +543,8 @@ public class CatalogPostgreSqlIT extends AbstractIT {
 
   @Test
   void testListSchema() {
-    NameIdentifier[] nameIdentifiers = catalog.asSchemas().listSchemas();
-    Set<String> schemaNames =
-        Arrays.stream(nameIdentifiers).map(NameIdentifier::name).collect(Collectors.toSet());
+    String[] nameIdentifiers = catalog.asSchemas().listSchemas();
+    Set<String> schemaNames = new HashSet<>(Arrays.asList(nameIdentifiers));
     Assertions.assertTrue(schemaNames.contains("public"));
   }
 
@@ -1216,11 +1213,7 @@ public class CatalogPostgreSqlIT extends AbstractIT {
       Assertions.assertNotNull(schemaSupport.loadSchema(schema));
     }
 
-    Set<String> schemaNames =
-        Arrays.stream(schemaSupport.listSchemas())
-            .map(NameIdentifier::name)
-            .collect(Collectors.toSet());
-
+    Set<String> schemaNames = new HashSet<>(Arrays.asList(schemaSupport.listSchemas()));
     Assertions.assertTrue(schemaNames.containsAll(Arrays.asList(schemas)));
 
     String tableName = "test1";

--- a/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/TestMultipleJDBCLoad.java
+++ b/catalogs/catalog-jdbc-postgresql/src/test/java/com/datastrato/gravitino/catalog/postgresql/integration/test/TestMultipleJDBCLoad.java
@@ -75,11 +75,11 @@ public class TestMultipleJDBCLoad extends AbstractIT {
         metalake.createCatalog(
             mysqlCatalogName, Catalog.Type.RELATIONAL, "jdbc-mysql", "comment", mysqlConf);
 
-    NameIdentifier[] nameIdentifiers = mysqlCatalog.asSchemas().listSchemas();
+    String[] nameIdentifiers = mysqlCatalog.asSchemas().listSchemas();
     Assertions.assertNotEquals(0, nameIdentifiers.length);
     nameIdentifiers = postgreSqlCatalog.asSchemas().listSchemas();
     Assertions.assertEquals(1, nameIdentifiers.length);
-    Assertions.assertEquals("public", nameIdentifiers[0].name());
+    Assertions.assertEquals("public", nameIdentifiers[0]);
 
     String schemaName = RandomNameUtils.genRandomName("it_schema");
     mysqlCatalog.asSchemas().createSchema(schemaName, null, Collections.emptyMap());

--- a/catalogs/catalog-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/integration/test/CatalogKafkaIT.java
+++ b/catalogs/catalog-kafka/src/test/java/com/datastrato/gravitino/catalog/kafka/integration/test/CatalogKafkaIT.java
@@ -101,10 +101,10 @@ public class CatalogKafkaIT extends AbstractIT {
   public static void shutdown() {
     Catalog catalog = metalake.loadCatalog(CATALOG_NAME);
     Arrays.stream(catalog.asSchemas().listSchemas())
-        .filter(ident -> !ident.name().equals("default"))
+        .filter(ident -> !ident.equals("default"))
         .forEach(
             (ident -> {
-              catalog.asSchemas().dropSchema(ident.name(), true);
+              catalog.asSchemas().dropSchema(ident, true);
             }));
     Arrays.stream(metalake.listCatalogs())
         .forEach(
@@ -223,9 +223,9 @@ public class CatalogKafkaIT extends AbstractIT {
 
   @Test
   public void testDefaultSchema() {
-    NameIdentifier[] schemas = catalog.asSchemas().listSchemas();
+    String[] schemas = catalog.asSchemas().listSchemas();
     Assertions.assertEquals(1, schemas.length);
-    Assertions.assertEquals(DEFAULT_SCHEMA_NAME, schemas[0].name());
+    Assertions.assertEquals(DEFAULT_SCHEMA_NAME, schemas[0]);
 
     Schema loadSchema = catalog.asSchemas().loadSchema(DEFAULT_SCHEMA_NAME);
     Assertions.assertEquals(
@@ -262,9 +262,9 @@ public class CatalogKafkaIT extends AbstractIT {
 
   @Test
   public void testListSchema() {
-    NameIdentifier[] schemas = catalog.asSchemas().listSchemas();
+    String[] schemas = catalog.asSchemas().listSchemas();
     Assertions.assertEquals(1, schemas.length);
-    Assertions.assertEquals(DEFAULT_SCHEMA_NAME, schemas[0].name());
+    Assertions.assertEquals(DEFAULT_SCHEMA_NAME, schemas[0]);
   }
 
   @Test

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergBaseIT.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/CatalogIcebergBaseIT.java
@@ -56,6 +56,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -251,9 +252,7 @@ public abstract class CatalogIcebergBaseIT extends AbstractIT {
   void testOperationIcebergSchema() {
     SupportsSchemas schemas = catalog.asSchemas();
     // list schema check.
-    NameIdentifier[] nameIdentifiers = schemas.listSchemas();
-    Set<String> schemaNames =
-        Arrays.stream(nameIdentifiers).map(NameIdentifier::name).collect(Collectors.toSet());
+    Set<String> schemaNames = new HashSet<>(Arrays.asList(schemas.listSchemas()));
     Assertions.assertTrue(schemaNames.contains(schemaName));
 
     List<org.apache.iceberg.catalog.Namespace> icebergNamespaces =
@@ -266,10 +265,9 @@ public abstract class CatalogIcebergBaseIT extends AbstractIT {
     String testSchemaName = GravitinoITUtils.genRandomName("test_schema_1");
     NameIdentifier schemaIdent = NameIdentifier.of(metalakeName, catalogName, testSchemaName);
     schemas.createSchema(schemaIdent.name(), schema_comment, Collections.emptyMap());
-    nameIdentifiers = schemas.listSchemas();
-    Map<String, NameIdentifier> schemaMap =
-        Arrays.stream(nameIdentifiers).collect(Collectors.toMap(NameIdentifier::name, v -> v));
-    Assertions.assertTrue(schemaMap.containsKey(testSchemaName));
+
+    schemaNames = new HashSet<>(Arrays.asList(schemas.listSchemas()));
+    Assertions.assertTrue(schemaNames.contains(testSchemaName));
 
     icebergNamespaces =
         icebergSupportsNamespaces.listNamespaces(IcebergTableOpsHelper.getIcebergNamespace());
@@ -305,10 +303,8 @@ public abstract class CatalogIcebergBaseIT extends AbstractIT {
           icebergSupportsNamespaces.loadNamespaceMetadata(icebergNamespace);
         });
 
-    nameIdentifiers = schemas.listSchemas();
-    schemaMap =
-        Arrays.stream(nameIdentifiers).collect(Collectors.toMap(NameIdentifier::name, v -> v));
-    Assertions.assertFalse(schemaMap.containsKey(testSchemaName));
+    schemaNames = new HashSet<>(Arrays.asList(schemas.listSchemas()));
+    Assertions.assertFalse(schemaNames.contains(testSchemaName));
     Assertions.assertFalse(schemas.dropSchema("no-exits", false));
     TableCatalog tableCatalog = catalog.asTableCatalog();
 

--- a/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/TestMultipleJDBCLoad.java
+++ b/catalogs/catalog-lakehouse-iceberg/src/test/java/com/datastrato/gravitino/catalog/lakehouse/iceberg/integration/test/TestMultipleJDBCLoad.java
@@ -92,7 +92,7 @@ public class TestMultipleJDBCLoad extends AbstractIT {
             "comment",
             icebergMysqlConf);
 
-    NameIdentifier[] nameIdentifiers = mysqlCatalog.asSchemas().listSchemas();
+    String[] nameIdentifiers = mysqlCatalog.asSchemas().listSchemas();
     Assertions.assertEquals(0, nameIdentifiers.length);
     nameIdentifiers = postgreSqlCatalog.asSchemas().listSchemas();
     Assertions.assertEquals(0, nameIdentifiers.length);

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/BaseSchemaCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/BaseSchemaCatalog.java
@@ -80,10 +80,8 @@ abstract class BaseSchemaCatalog extends CatalogDTO implements Catalog, Supports
             Collections.emptyMap(),
             ErrorHandlers.schemaErrorHandler());
     resp.validate();
-    String[] schemas =
-        Arrays.stream(resp.identifiers()).map(NameIdentifier::name).toArray(String[]::new);
 
-    return schemas;
+    return Arrays.stream(resp.identifiers()).map(NameIdentifier::name).toArray(String[]::new);
   }
 
   /**

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/BaseSchemaCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/BaseSchemaCatalog.java
@@ -67,7 +67,7 @@ abstract class BaseSchemaCatalog extends CatalogDTO implements Catalog, Supports
   /**
    * List all the schemas under the given catalog namespace.
    *
-   * @return A list of {@link NameIdentifier} of the schemas under the given catalog namespace.
+   * @return A list of the schema names under the given catalog namespace.
    * @throws NoSuchCatalogException if the catalog with specified namespace does not exist.
    */
   @Override

--- a/clients/client-java/src/main/java/com/datastrato/gravitino/client/BaseSchemaCatalog.java
+++ b/clients/client-java/src/main/java/com/datastrato/gravitino/client/BaseSchemaCatalog.java
@@ -71,7 +71,7 @@ abstract class BaseSchemaCatalog extends CatalogDTO implements Catalog, Supports
    * @throws NoSuchCatalogException if the catalog with specified namespace does not exist.
    */
   @Override
-  public NameIdentifier[] listSchemas() throws NoSuchCatalogException {
+  public String[] listSchemas() throws NoSuchCatalogException {
 
     EntityListResponse resp =
         restClient.get(
@@ -80,8 +80,10 @@ abstract class BaseSchemaCatalog extends CatalogDTO implements Catalog, Supports
             Collections.emptyMap(),
             ErrorHandlers.schemaErrorHandler());
     resp.validate();
+    String[] schemas =
+        Arrays.stream(resp.identifiers()).map(NameIdentifier::name).toArray(String[]::new);
 
-    return resp.identifiers();
+    return schemas;
   }
 
   /**

--- a/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalCatalog.java
+++ b/clients/client-java/src/test/java/com/datastrato/gravitino/client/TestRelationalCatalog.java
@@ -139,16 +139,16 @@ public class TestRelationalCatalog extends TestBase {
 
     EntityListResponse resp = new EntityListResponse(new NameIdentifier[] {schema1, schema2});
     buildMockResource(Method.GET, schemaPath, null, resp, SC_OK);
-    NameIdentifier[] schemas = catalog.asSchemas().listSchemas();
+    String[] schemas = catalog.asSchemas().listSchemas();
 
     Assertions.assertEquals(2, schemas.length);
-    Assertions.assertEquals(schema1, schemas[0]);
-    Assertions.assertEquals(schema2, schemas[1]);
+    Assertions.assertEquals(schema1.name(), schemas[0]);
+    Assertions.assertEquals(schema2.name(), schemas[1]);
 
     // Test return empty schema list
     EntityListResponse emptyResp = new EntityListResponse(new NameIdentifier[] {});
     buildMockResource(Method.GET, schemaPath, null, emptyResp, SC_OK);
-    NameIdentifier[] emptySchemas = catalog.asSchemas().listSchemas();
+    String[] emptySchemas = catalog.asSchemas().listSchemas();
     Assertions.assertEquals(0, emptySchemas.length);
 
     // Test throw NoSuchCatalogException

--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoQueryITBase.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoQueryITBase.java
@@ -185,36 +185,36 @@ public class TrinoQueryITBase {
     Catalog catalog = metalake.loadCatalog(catalogName);
     SupportsSchemas schemas = catalog.asSchemas();
     Arrays.stream(schemas.listSchemas())
-        .filter(schema -> schema.name().startsWith("gt_"))
+        .filter(schema -> schema.startsWith("gt_"))
         .forEach(
             schema -> {
               try {
                 TableCatalog tableCatalog = catalog.asTableCatalog();
                 Arrays.stream(
                         tableCatalog.listTables(
-                            Namespace.ofTable(metalakeName, catalogName, schema.name())))
+                            Namespace.ofTable(metalakeName, catalogName, schema)))
                     .forEach(
                         table -> {
                           boolean dropped =
                               tableCatalog.dropTable(
                                   NameIdentifier.ofTable(
-                                      metalakeName, catalogName, schema.name(), table.name()));
+                                      metalakeName, catalogName, schema, table.name()));
                           LOG.info(
                               "Drop table \"{}.{}\".{}.{}",
                               metalakeName,
                               catalogName,
-                              schema.name(),
+                              schema,
                               table.name());
                           if (!dropped) {
                             LOG.error("Failed to drop table {}", table);
                           }
                         });
 
-                schemas.dropSchema(schema.name(), false);
+                schemas.dropSchema(schema, false);
               } catch (Exception e) {
                 LOG.error("Failed to drop schema {}", schema);
               }
-              LOG.info("Drop schema \"{}.{}\".{}", metalakeName, catalogName, schema.name());
+              LOG.info("Drop schema \"{}.{}\".{}", metalakeName, catalogName, schema);
             });
 
     metalake.dropCatalog(catalogName);

--- a/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/catalog/BaseCatalog.java
+++ b/spark-connector/spark-common/src/main/java/com/datastrato/gravitino/spark/connector/catalog/BaseCatalog.java
@@ -308,10 +308,8 @@ public abstract class BaseCatalog implements TableCatalog, SupportsNamespaces {
 
   @Override
   public String[][] listNamespaces() throws NoSuchNamespaceException {
-    NameIdentifier[] schemas = gravitinoCatalogClient.asSchemas().listSchemas();
-    return Arrays.stream(schemas)
-        .map(schema -> new String[] {schema.name()})
-        .toArray(String[][]::new);
+    String[] schemas = gravitinoCatalogClient.asSchemas().listSchemas();
+    return Arrays.stream(schemas).map(schema -> new String[] {schema}).toArray(String[][]::new);
   }
 
   @Override

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/CatalogConnectorMetadata.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/CatalogConnectorMetadata.java
@@ -71,7 +71,7 @@ public class CatalogConnectorMetadata {
 
   public List<String> listSchemaNames() {
     try {
-      return Arrays.stream(schemaCatalog.listSchemas()).map(NameIdentifier::name).toList();
+      return Arrays.asList(schemaCatalog.listSchemas());
     } catch (NoSuchCatalogException e) {
       throw new TrinoException(GRAVITINO_CATALOG_NOT_EXISTS, CATALOG_DOES_NOT_EXIST_MSG, e);
     }

--- a/trino-connector/src/test/java/com/datastrato/gravitino/trino/connector/GravitinoMockServer.java
+++ b/trino-connector/src/test/java/com/datastrato/gravitino/trino/connector/GravitinoMockServer.java
@@ -267,9 +267,9 @@ public class GravitinoMockServer implements AutoCloseable {
 
     when(schemas.listSchemas())
         .thenAnswer(
-            new Answer<NameIdentifier[]>() {
+            new Answer<String[]>() {
               @Override
-              public NameIdentifier[] answer(InvocationOnMock invocation) throws Throwable {
+              public String[] answer(InvocationOnMock invocation) throws Throwable {
                 MemoryConnector memoryConnector =
                     (MemoryConnector)
                         catalogConnectorManager
@@ -277,12 +277,7 @@ public class GravitinoMockServer implements AutoCloseable {
                                 catalogConnectorManager.getTrinoCatalogName(catalog))
                             .getInternalConnector();
                 ConnectorMetadata metadata = memoryConnector.getMetadata(null, null);
-                return metadata.listSchemaNames(null).stream()
-                    .map(
-                        schemaName ->
-                            NameIdentifier.ofSchema(
-                                catalog.getMetalake(), catalog.getName(), schemaName))
-                    .toArray(NameIdentifier[]::new);
+                return metadata.listSchemaNames(null).toArray(new String[0]);
               }
             });
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently, the SupportsSchemas.listSchemas() method returns an array of NameIdentifier to represents the schemas. Actually a String[] will be more clear and easier to use.

### Why are the changes needed?

To make the API more clear to use.

Fix: #3701

### Does this PR introduce _any_ user-facing change?

Almost not; Just return type changed, will be more simple.

### How was this patch tested?

Yes, many test cases cover this API.
