### PR TITLE
[#3746] improvement(spark-connector): Add scala version to maven artifact name for spark-connector

### DIFF
--- a/spark-connector/v3.3/spark-runtime/build.gradle.kts
+++ b/spark-connector/v3.3/spark-runtime/build.gradle.kts
@@ -47,7 +47,6 @@ publishing {
   }
 }
 
-
 tasks.jar {
   dependsOn(tasks.named("shadowJar"))
   archiveClassifier.set("empty")

--- a/spark-connector/v3.3/spark-runtime/build.gradle.kts
+++ b/spark-connector/v3.3/spark-runtime/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 val scalaVersion: String = project.properties["scalaVersion"] as? String ?: extra["defaultScalaVersion"].toString()
 val sparkVersion: String = libs.versions.spark33.get()
 val sparkMajorVersion: String = sparkVersion.substringBeforeLast(".")
-val baseName = "spark-connector-runtime-${sparkMajorVersion}_$scalaVersion"
+val baseName = "${rootProject.name}-spark-connector-runtime-${sparkMajorVersion}_$scalaVersion"
 
 dependencies {
   implementation(project(":clients:client-java-runtime", configuration = "shadow"))

--- a/spark-connector/v3.3/spark-runtime/build.gradle.kts
+++ b/spark-connector/v3.3/spark-runtime/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 val scalaVersion: String = project.properties["scalaVersion"] as? String ?: extra["defaultScalaVersion"].toString()
 val sparkVersion: String = libs.versions.spark33.get()
 val sparkMajorVersion: String = sparkVersion.substringBeforeLast(".")
-val baseName = "${rootProject.name}-spark-connector-runtime-${sparkMajorVersion}_$scalaVersion"
+val baseName = "spark-connector-runtime-${sparkMajorVersion}_$scalaVersion"
 
 dependencies {
   implementation(project(":clients:client-java-runtime", configuration = "shadow"))
@@ -38,6 +38,15 @@ tasks.withType<ShadowJar>(ShadowJar::class.java) {
   relocate("google", "com.datastrato.gravitino.shaded.google")
   relocate("org.apache.hc", "com.datastrato.gravitino.shaded.org.apache.hc")
 }
+
+publishing {
+  publications {
+    withType<MavenPublication>().configureEach {
+      artifactId = baseName
+    }
+  }
+}
+
 
 tasks.jar {
   dependsOn(tasks.named("shadowJar"))

--- a/spark-connector/v3.3/spark/build.gradle.kts
+++ b/spark-connector/v3.3/spark/build.gradle.kts
@@ -20,6 +20,8 @@ val icebergVersion: String = libs.versions.iceberg4spark.get()
 val kyuubiVersion: String = libs.versions.kyuubi4spark33.get()
 val scalaJava8CompatVersion: String = libs.versions.scala.java.compat.get()
 val scalaCollectionCompatVersion: String = libs.versions.scala.collection.compat.get()
+val artifactName = "spark-${sparkMajorVersion}_$scalaVersion"
+
 
 dependencies {
   implementation(project(":spark-connector:spark-common"))
@@ -135,13 +137,13 @@ tasks.test {
 }
 
 tasks.withType<Jar> {
-  archiveBaseName.set("spark-${sparkMajorVersion}_$scalaVersion")
+  archiveBaseName.set(artifactName)
 }
 
 publishing {
   publications {
     withType<MavenPublication>().configureEach {
-      artifactId = "spark-${sparkMajorVersion}_$scalaVersion"
+      artifactId = artifactName
     }
   }
 }

--- a/spark-connector/v3.3/spark/build.gradle.kts
+++ b/spark-connector/v3.3/spark/build.gradle.kts
@@ -134,6 +134,18 @@ tasks.test {
   }
 }
 
+tasks.withType<Jar> {
+  archiveBaseName.set("spark-${sparkMajorVersion}_${scalaVersion}")
+}
+
+publishing {
+  publications {
+    withType<MavenPublication>().configureEach {
+      artifactId = "spark-${sparkMajorVersion}_${scalaVersion}"
+    }
+  }
+}
+
 tasks.clean {
   delete("derby.log")
   delete("metastore_db")

--- a/spark-connector/v3.3/spark/build.gradle.kts
+++ b/spark-connector/v3.3/spark/build.gradle.kts
@@ -20,8 +20,7 @@ val icebergVersion: String = libs.versions.iceberg4spark.get()
 val kyuubiVersion: String = libs.versions.kyuubi4spark33.get()
 val scalaJava8CompatVersion: String = libs.versions.scala.java.compat.get()
 val scalaCollectionCompatVersion: String = libs.versions.scala.collection.compat.get()
-val artifactName = "spark-${sparkMajorVersion}_$scalaVersion"
-
+val artifactName = "${rootProject.name}-spark-${sparkMajorVersion}_$scalaVersion"
 
 dependencies {
   implementation(project(":spark-connector:spark-common"))

--- a/spark-connector/v3.3/spark/build.gradle.kts
+++ b/spark-connector/v3.3/spark/build.gradle.kts
@@ -135,13 +135,13 @@ tasks.test {
 }
 
 tasks.withType<Jar> {
-  archiveBaseName.set("spark-${sparkMajorVersion}_${scalaVersion}")
+  archiveBaseName.set("spark-${sparkMajorVersion}_$scalaVersion")
 }
 
 publishing {
   publications {
     withType<MavenPublication>().configureEach {
-      artifactId = "spark-${sparkMajorVersion}_${scalaVersion}"
+      artifactId = "spark-${sparkMajorVersion}_$scalaVersion"
     }
   }
 }

--- a/spark-connector/v3.4/spark-runtime/build.gradle.kts
+++ b/spark-connector/v3.4/spark-runtime/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 val scalaVersion: String = project.properties["scalaVersion"] as? String ?: extra["defaultScalaVersion"].toString()
 val sparkVersion: String = libs.versions.spark34.get()
 val sparkMajorVersion: String = sparkVersion.substringBeforeLast(".")
-val baseName = "spark-connector-runtime-${sparkMajorVersion}_$scalaVersion"
+val baseName = "${rootProject.name}-spark-connector-runtime-${sparkMajorVersion}_$scalaVersion"
 
 dependencies {
   implementation(project(":clients:client-java-runtime", configuration = "shadow"))

--- a/spark-connector/v3.4/spark-runtime/build.gradle.kts
+++ b/spark-connector/v3.4/spark-runtime/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 val scalaVersion: String = project.properties["scalaVersion"] as? String ?: extra["defaultScalaVersion"].toString()
 val sparkVersion: String = libs.versions.spark34.get()
 val sparkMajorVersion: String = sparkVersion.substringBeforeLast(".")
-val baseName = "${rootProject.name}-spark-connector-runtime-${sparkMajorVersion}_$scalaVersion"
+val baseName = "spark-connector-runtime-${sparkMajorVersion}_$scalaVersion"
 
 dependencies {
   implementation(project(":clients:client-java-runtime", configuration = "shadow"))
@@ -37,6 +37,14 @@ tasks.withType<ShadowJar>(ShadowJar::class.java) {
   relocate("com.google", "com.datastrato.gravitino.shaded.com.google")
   relocate("google", "com.datastrato.gravitino.shaded.google")
   relocate("org.apache.hc", "com.datastrato.gravitino.shaded.org.apache.hc")
+}
+
+publishing {
+  publications {
+    withType<MavenPublication>().configureEach {
+      artifactId = baseName
+    }
+  }
 }
 
 tasks.jar {

--- a/spark-connector/v3.4/spark/build.gradle.kts
+++ b/spark-connector/v3.4/spark/build.gradle.kts
@@ -136,13 +136,13 @@ tasks.test {
 }
 
 tasks.withType<Jar> {
-  archiveBaseName.set("spark-${sparkMajorVersion}_${scalaVersion}")
+  archiveBaseName.set("spark-${sparkMajorVersion}_$scalaVersion")
 }
 
 publishing {
   publications {
     withType<MavenPublication>().configureEach {
-      artifactId = "spark-${sparkMajorVersion}_${scalaVersion}"
+      artifactId = "spark-${sparkMajorVersion}_$scalaVersion"
     }
   }
 }

--- a/spark-connector/v3.4/spark/build.gradle.kts
+++ b/spark-connector/v3.4/spark/build.gradle.kts
@@ -20,6 +20,7 @@ val icebergVersion: String = libs.versions.iceberg4spark.get()
 val kyuubiVersion: String = libs.versions.kyuubi4spark34.get()
 val scalaJava8CompatVersion: String = libs.versions.scala.java.compat.get()
 val scalaCollectionCompatVersion: String = libs.versions.scala.collection.compat.get()
+val artifactName = "spark-${sparkMajorVersion}_$scalaVersion"
 
 dependencies {
   implementation(project(":spark-connector:spark-common"))
@@ -136,13 +137,13 @@ tasks.test {
 }
 
 tasks.withType<Jar> {
-  archiveBaseName.set("spark-${sparkMajorVersion}_$scalaVersion")
+  archiveBaseName.set(artifactName)
 }
 
 publishing {
   publications {
     withType<MavenPublication>().configureEach {
-      artifactId = "spark-${sparkMajorVersion}_$scalaVersion"
+      artifactId = artifactName
     }
   }
 }

--- a/spark-connector/v3.4/spark/build.gradle.kts
+++ b/spark-connector/v3.4/spark/build.gradle.kts
@@ -20,7 +20,7 @@ val icebergVersion: String = libs.versions.iceberg4spark.get()
 val kyuubiVersion: String = libs.versions.kyuubi4spark34.get()
 val scalaJava8CompatVersion: String = libs.versions.scala.java.compat.get()
 val scalaCollectionCompatVersion: String = libs.versions.scala.collection.compat.get()
-val artifactName = "spark-${sparkMajorVersion}_$scalaVersion"
+val artifactName = "${rootProject.name}-spark-${sparkMajorVersion}_$scalaVersion"
 
 dependencies {
   implementation(project(":spark-connector:spark-common"))

--- a/spark-connector/v3.4/spark/build.gradle.kts
+++ b/spark-connector/v3.4/spark/build.gradle.kts
@@ -135,6 +135,18 @@ tasks.test {
   }
 }
 
+tasks.withType<Jar> {
+  archiveBaseName.set("spark-${sparkMajorVersion}_${scalaVersion}")
+}
+
+publishing {
+  publications {
+    withType<MavenPublication>().configureEach {
+      artifactId = "spark-${sparkMajorVersion}_${scalaVersion}"
+    }
+  }
+}
+
 tasks.clean {
   delete("derby.log")
   delete("metastore_db")

--- a/spark-connector/v3.5/spark-runtime/build.gradle.kts
+++ b/spark-connector/v3.5/spark-runtime/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 val scalaVersion: String = project.properties["scalaVersion"] as? String ?: extra["defaultScalaVersion"].toString()
 val sparkVersion: String = libs.versions.spark35.get()
 val sparkMajorVersion: String = sparkVersion.substringBeforeLast(".")
-val baseName = "${rootProject.name}-spark-connector-runtime-${sparkMajorVersion}_$scalaVersion"
+val baseName = "spark-connector-runtime-${sparkMajorVersion}_$scalaVersion"
 
 dependencies {
   implementation(project(":clients:client-java-runtime", configuration = "shadow"))
@@ -37,6 +37,14 @@ tasks.withType<ShadowJar>(ShadowJar::class.java) {
   relocate("com.google", "com.datastrato.gravitino.shaded.com.google")
   relocate("google", "com.datastrato.gravitino.shaded.google")
   relocate("org.apache.hc", "com.datastrato.gravitino.shaded.org.apache.hc")
+}
+
+publishing {
+  publications {
+    withType<MavenPublication>().configureEach {
+      artifactId = baseName
+    }
+  }
 }
 
 tasks.jar {

--- a/spark-connector/v3.5/spark-runtime/build.gradle.kts
+++ b/spark-connector/v3.5/spark-runtime/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 val scalaVersion: String = project.properties["scalaVersion"] as? String ?: extra["defaultScalaVersion"].toString()
 val sparkVersion: String = libs.versions.spark35.get()
 val sparkMajorVersion: String = sparkVersion.substringBeforeLast(".")
-val baseName = "spark-connector-runtime-${sparkMajorVersion}_$scalaVersion"
+val baseName = "${rootProject.name}-spark-connector-runtime-${sparkMajorVersion}_$scalaVersion"
 
 dependencies {
   implementation(project(":clients:client-java-runtime", configuration = "shadow"))

--- a/spark-connector/v3.5/spark/build.gradle.kts
+++ b/spark-connector/v3.5/spark/build.gradle.kts
@@ -137,7 +137,7 @@ tasks.test {
 }
 
 tasks.withType<Jar> {
-  archiveBaseName.set("spark-${sparkMajorVersion}_${scalaVersion}")
+  archiveBaseName.set("spark-${sparkMajorVersion}_$scalaVersion")
 }
 
 publishing {

--- a/spark-connector/v3.5/spark/build.gradle.kts
+++ b/spark-connector/v3.5/spark/build.gradle.kts
@@ -136,6 +136,18 @@ tasks.test {
   }
 }
 
+tasks.withType<Jar> {
+  archiveBaseName.set("spark-${sparkMajorVersion}_${scalaVersion}")
+}
+
+publishing {
+  publications {
+    withType<MavenPublication>().configureEach {
+      artifactId = "spark-${sparkMajorVersion}_$scalaVersion"
+    }
+  }
+}
+
 tasks.clean {
   delete("derby.log")
   delete("metastore_db")

--- a/spark-connector/v3.5/spark/build.gradle.kts
+++ b/spark-connector/v3.5/spark/build.gradle.kts
@@ -20,6 +20,7 @@ val icebergVersion: String = libs.versions.iceberg4spark.get()
 val kyuubiVersion: String = libs.versions.kyuubi4spark35.get()
 val scalaJava8CompatVersion: String = libs.versions.scala.java.compat.get()
 val scalaCollectionCompatVersion: String = libs.versions.scala.collection.compat.get()
+val artifactName = "spark-${sparkMajorVersion}_$scalaVersion"
 
 dependencies {
   implementation(project(":spark-connector:spark-3.4"))
@@ -137,13 +138,13 @@ tasks.test {
 }
 
 tasks.withType<Jar> {
-  archiveBaseName.set("spark-${sparkMajorVersion}_$scalaVersion")
+  archiveBaseName.set(artifactName)
 }
 
 publishing {
   publications {
     withType<MavenPublication>().configureEach {
-      artifactId = "spark-${sparkMajorVersion}_$scalaVersion"
+      artifactId = artifactName
     }
   }
 }

--- a/spark-connector/v3.5/spark/build.gradle.kts
+++ b/spark-connector/v3.5/spark/build.gradle.kts
@@ -20,7 +20,7 @@ val icebergVersion: String = libs.versions.iceberg4spark.get()
 val kyuubiVersion: String = libs.versions.kyuubi4spark35.get()
 val scalaJava8CompatVersion: String = libs.versions.scala.java.compat.get()
 val scalaCollectionCompatVersion: String = libs.versions.scala.collection.compat.get()
-val artifactName = "spark-${sparkMajorVersion}_$scalaVersion"
+val artifactName = "${rootProject.name}-spark-${sparkMajorVersion}_$scalaVersion"
 
 dependencies {
   implementation(project(":spark-connector:spark-3.4"))


### PR DESCRIPTION

### What changes were proposed in this pull request?

Add scala version to the name of maven artifact. 

### Why are the changes needed?

Currently, we support multiple versions of scala version, if we don't include the scale version information, users would be unable to use jars with different scala version.

Fix: #3746

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

<img width="1046" alt="image" src="https://github.com/datastrato/gravitino/assets/15794564/039bfc0e-555b-4481-94ec-c88660ca60df">

