### PR TITLE
[#3738] fix(docker): Fix query performance is lower than 0.5 version

### DIFF
--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoSplitSource.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/GravitinoSplitSource.java
@@ -25,10 +25,14 @@ public class GravitinoSplitSource implements ConnectorSplitSource {
 
   @Override
   public CompletableFuture<ConnectorSplitBatch> getNextBatch(int maxSize) {
-    ConnectorSplitBatch batch = connectorSplitSource.getNextBatch(maxSize).join();
-    List<ConnectorSplit> list =
-        batch.getSplits().stream().map(GravitinoSplit::new).collect(Collectors.toList());
-    return CompletableFuture.completedFuture(new ConnectorSplitBatch(list, batch.isNoMoreSplits()));
+    return connectorSplitSource
+        .getNextBatch(maxSize)
+        .thenApply(
+            batch -> {
+              List<ConnectorSplit> list =
+                  batch.getSplits().stream().map(GravitinoSplit::new).collect(Collectors.toList());
+              return new ConnectorSplitBatch(list, batch.isNoMoreSplits());
+            });
   }
 
   @Override


### PR DESCRIPTION

### What changes were proposed in this pull request?

Fix query performance is lower than 0.5 version

### Why are the changes needed?

Fix: #3738 

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

Manually test
