### PR TITLE
[#3750] feat: Support running in frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ To stop the Gravitino server, please run:
 ./bin/gravitino.sh stop
 ```
 
+Alternatively, to run the Gravitino server in frontend, please run:
+
+```shell
+./bin/gravitino.sh run
+```
+
+And press `CTRL+C` to stop the Gravitino server.
+
 ### Using Trino with Gravitino
 
 Gravitino provides a Trino connector to access the metadata in Gravitino. To use Trino with Gravitino, please follow the [trino-gravitino-connector doc](docs/trino-connector/index.md).

--- a/bin/gravitino.sh
+++ b/bin/gravitino.sh
@@ -5,7 +5,7 @@
 #
 #set -ex
 USAGE="-e Usage: bin/gravitino.sh [--config <conf-dir>]\n\t
-        {start|stop|restart|status}"
+        {start|run|stop|restart|status}"
 
 if [[ "$1" == "--config" ]]; then
   shift
@@ -110,6 +110,10 @@ function start() {
   check_process_status
 }
 
+function run() {
+  ${JAVA_RUNNER} ${JAVA_OPTS} ${GRAVITINO_DEBUG_OPTS} -cp ${GRAVITINO_CLASSPATH} ${GRAVITINO_SERVER_NAME}
+}
+
 function stop() {
   local pid
 
@@ -163,6 +167,9 @@ addJarInDir "${GRAVITINO_HOME}/libs"
 case "${1}" in
   start)
     start
+    ;;
+  run)
+    run
     ;;
   stop)
     stop

--- a/docs/how-to-install.md
+++ b/docs/how-to-install.md
@@ -99,10 +99,16 @@ it automatically.
 
 #### Start Gravitino server
 
-After configuring the Gravitino server, start the Gravitino server by running:
+After configuring the Gravitino server, start the Gravitino server on daemon by running:
 
 ```shell
 ./bin/gravitino.sh start
+```
+
+Alternatively, to run the Gravitino server in frontend, please run:
+
+```shell
+./bin/gravitino.sh run
 ```
 
 You can access the Gravitino Web UI by typing [http://localhost:8090](http://localhost:8090) in your browser. or you


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

`bin/gravitino.sh` support running on frontend.

### Why are the changes needed?

For dev cases, it's easy to start/stop and watch logs.

For production environments where services are managed by `supervisord` or `systemd`, we usually run the service in frontend and print logs to stdout/stderr.

### Does this PR introduce _any_ user-facing change?

Yes, users can run `bin/gravitino.sh run` to run Gravitino in frontend, and press `Ctrl + C` to terminate the process.

### How was this patch tested?

Manuel test.

```
$ ./gradlew clean compileDistribution -x test

$ cd distribution/package

$ echo > conf/log4j2.properties <<EOF
rootLogger.level = info
rootLogger.appenderRef.rolling.ref = console

appender.console.type = Console
appender.console.name = console
appender.console.target = SYSTEM_ERR
appender.console.layout.type = PatternLayout
appender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n%ex
EOF

$ bin/gravitino.sh run
24/06/04 17:53:58 INFO GravitinoServer: Starting Gravitino Server
24/06/04 17:53:58 INFO GravitinoEnv: Initializing Gravitino Environment...
24/06/04 17:53:58 INFO MetricsSystem: Register jvm to metrics system 
24/06/04 17:53:58 INFO RocksDBKvBackend: Rocksdb storage directory:/Users/chengpan/Projects/gravitino/distribution/package/data/rocksdb/instance
24/06/04 17:53:59 INFO AuxiliaryServiceManager: AuxService name:iceberg-rest, config:{classpath=catalogs/lakehouse-iceberg/libs, catalogs/lakehouse-iceberg/conf, httpPort=9001, host=0.0.0.0}, valid classpath:[/Users/chengpan/Projects/gravitino/distribution/package/catalogs/lakehouse-iceberg/libs, /Users/chengpan/Projects/gravitino/distribution/package/catalogs/lakehouse-iceberg/conf]
24/06/04 17:53:59 INFO AuxiliaryServiceManager: AuxService:iceberg-rest registered successfully
24/06/04 17:53:59 INFO log: Logging initialized @767ms to org.eclipse.jetty.util.log.Slf4jLog
24/06/04 17:53:59 INFO MetricsSystem: Register iceberg-rest-server to metrics system 
24/06/04 17:53:59 INFO IcebergCatalogUtil: Load catalog backend of memory
24/06/04 17:53:59 INFO IcebergTableOps: Load Iceberg metrics store: com.datastrato.gravitino.catalog.lakehouse.iceberg.web.metrics.DummyMetricsStore.
24/06/04 17:53:59 INFO IcebergRESTService: Iceberg REST service inited
24/06/04 17:53:59 INFO GravitinoEnv: Gravitino Environment is initialized.
24/06/04 17:53:59 INFO LockManager: Start to check the dead lock...
24/06/04 17:53:59 INFO LockManager: Finish to check the dead lock...
24/06/04 17:53:59 INFO JettyServer: Gravitino Webapp path: /var/folders/v5/tw7cy5px1xjbt1pt77x70m980000gp/T/GravitinoWar17320525550260632159
24/06/04 17:53:59 INFO MetricsSystem: Register gravitino-server to metrics system 
24/06/04 17:53:59 INFO Server: jetty-9.4.51.v20230217; built: 2023-02-17T08:19:37.309Z; git: b45c405e4544384de066f814ed42ae3dceacdd49; jvm 17.0.8+7-LTS
Jun 04, 2024 5:53:59 PM org.glassfish.jersey.server.wadl.WadlFeature configure
WARNING: JAXBContext implementation could not be found. WADL feature is disabled.
24/06/04 17:53:59 INFO ContextHandler: Started o.e.j.s.ServletContextHandler@3ac3f6f{/,null,AVAILABLE}
24/06/04 17:53:59 INFO AbstractConnector: Started ServerConnector@7343922c{HTTP/1.1, (http/1.1)}{0.0.0.0:9001}
24/06/04 17:53:59 INFO Server: Started @1172ms
24/06/04 17:53:59 WARN JettyServer: Users would better use HTTPS to avoid token data leak.
24/06/04 17:53:59 INFO JettyServer: iceberg-rest web server started on host 0.0.0.0 port 9001.
24/06/04 17:53:59 INFO IcebergRESTService: Iceberg REST service started
24/06/04 17:53:59 INFO Server: jetty-9.4.51.v20230217; built: 2023-02-17T08:19:37.309Z; git: b45c405e4544384de066f814ed42ae3dceacdd49; jvm 17.0.8+7-LTS
24/06/04 17:53:59 INFO StandardDescriptorProcessor: NO JSP Support for /, did not find org.eclipse.jetty.jsp.JettyJspServlet
24/06/04 17:53:59 INFO session: DefaultSessionIdManager workerName=node0
24/06/04 17:53:59 INFO session: No SessionScavenger set, using defaults
24/06/04 17:53:59 INFO session: node0 Scavenging every 660000ms
Jun 04, 2024 5:53:59 PM org.glassfish.jersey.server.wadl.WadlFeature configure
WARNING: JAXBContext implementation could not be found. WADL feature is disabled.
24/06/04 17:53:59 INFO ContextHandler: Started o.e.j.w.WebAppContext@9f674ac{gravitino-web,/,jar:file:///Users/chengpan/Projects/gravitino/distribution/package/web/gravitino-web-0.6.0-SNAPSHOT.war!/,AVAILABLE}{/Users/chengpan/Projects/gravitino/distribution/package/web/gravitino-web-0.6.0-SNAPSHOT.war}
24/06/04 17:53:59 INFO AbstractConnector: Started ServerConnector@1da4b3f9{HTTP/1.1, (http/1.1)}{0.0.0.0:8090}
24/06/04 17:53:59 INFO Server: Started @1307ms
24/06/04 17:53:59 WARN JettyServer: Users would better use HTTPS to avoid token data leak.
24/06/04 17:53:59 INFO JettyServer: Gravitino-webserver web server started on host 0.0.0.0 port 8090.
24/06/04 17:53:59 INFO GravitinoServer: Done, Gravitino server started.

<Press CTRL+C>

^C24/06/04 17:54:03 INFO AbstractConnector: Stopped ServerConnector@7343922c{HTTP/1.1, (http/1.1)}{0.0.0.0:9001}
24/06/04 17:54:03 INFO ContextHandler: Stopped o.e.j.s.ServletContextHandler@3ac3f6f{/,null,STOPPED}
24/06/04 17:54:03 INFO AbstractConnector: Stopped ServerConnector@1da4b3f9{HTTP/1.1, (http/1.1)}{0.0.0.0:8090}
24/06/04 17:54:03 INFO session: node0 Stopped scavenging
24/06/04 17:54:03 INFO ContextHandler: Stopped o.e.j.w.WebAppContext@9f674ac{gravitino-web,/,null,STOPPED}{/Users/chengpan/Projects/gravitino/distribution/package/web/gravitino-web-0.6.0-SNAPSHOT.war}
24/06/04 17:54:03 INFO GravitinoServer: Shutting down Gravitino Server ... 
24/06/04 17:54:03 INFO JettyServer: Gravitino-webserver web server stopped on host 0.0.0.0 port 8090.
24/06/04 17:54:03 INFO GravitinoEnv: Shutting down Gravitino Environment...
24/06/04 17:54:03 INFO JettyServer: iceberg-rest web server stopped on host 0.0.0.0 port 9001.
24/06/04 17:54:03 INFO IcebergRESTService: Iceberg REST service stopped
24/06/04 17:54:03 WARN IcebergTableOps: Iceberg Metrics writer thread is interrupted.
24/06/04 17:54:03 INFO GravitinoEnv: Gravitino Environment is shut down.
24/06/04 17:54:03 INFO GravitinoServer: Gravitino Server has shut down.
```
