### PR TITLE
[#3746] improvement(spark-connector): Add scala version to maven artifact name for spark-connector

### DIFF
--- a/spark-connector/v3.3/spark-runtime/build.gradle.kts
+++ b/spark-connector/v3.3/spark-runtime/build.gradle.kts
@@ -39,6 +39,14 @@ tasks.withType<ShadowJar>(ShadowJar::class.java) {
   relocate("org.apache.hc", "com.datastrato.gravitino.shaded.org.apache.hc")
 }
 
+publishing {
+  publications {
+    withType<MavenPublication>().configureEach {
+      artifactId = baseName
+    }
+  }
+}
+
 tasks.jar {
   dependsOn(tasks.named("shadowJar"))
   archiveClassifier.set("empty")

--- a/spark-connector/v3.3/spark/build.gradle.kts
+++ b/spark-connector/v3.3/spark/build.gradle.kts
@@ -20,6 +20,7 @@ val icebergVersion: String = libs.versions.iceberg4spark.get()
 val kyuubiVersion: String = libs.versions.kyuubi4spark33.get()
 val scalaJava8CompatVersion: String = libs.versions.scala.java.compat.get()
 val scalaCollectionCompatVersion: String = libs.versions.scala.collection.compat.get()
+val artifactName = "${rootProject.name}-spark-${sparkMajorVersion}_$scalaVersion"
 
 dependencies {
   implementation(project(":spark-connector:spark-common"))
@@ -131,6 +132,18 @@ tasks.test {
 
     val init = project.extra.get("initIntegrationTest") as (Test) -> Unit
     init(this)
+  }
+}
+
+tasks.withType<Jar> {
+  archiveBaseName.set(artifactName)
+}
+
+publishing {
+  publications {
+    withType<MavenPublication>().configureEach {
+      artifactId = artifactName
+    }
   }
 }
 

--- a/spark-connector/v3.4/spark-runtime/build.gradle.kts
+++ b/spark-connector/v3.4/spark-runtime/build.gradle.kts
@@ -39,6 +39,14 @@ tasks.withType<ShadowJar>(ShadowJar::class.java) {
   relocate("org.apache.hc", "com.datastrato.gravitino.shaded.org.apache.hc")
 }
 
+publishing {
+  publications {
+    withType<MavenPublication>().configureEach {
+      artifactId = baseName
+    }
+  }
+}
+
 tasks.jar {
   dependsOn(tasks.named("shadowJar"))
   archiveClassifier.set("empty")

--- a/spark-connector/v3.4/spark/build.gradle.kts
+++ b/spark-connector/v3.4/spark/build.gradle.kts
@@ -20,6 +20,7 @@ val icebergVersion: String = libs.versions.iceberg4spark.get()
 val kyuubiVersion: String = libs.versions.kyuubi4spark34.get()
 val scalaJava8CompatVersion: String = libs.versions.scala.java.compat.get()
 val scalaCollectionCompatVersion: String = libs.versions.scala.collection.compat.get()
+val artifactName = "${rootProject.name}-spark-${sparkMajorVersion}_$scalaVersion"
 
 dependencies {
   implementation(project(":spark-connector:spark-common"))
@@ -132,6 +133,18 @@ tasks.test {
 
     val init = project.extra.get("initIntegrationTest") as (Test) -> Unit
     init(this)
+  }
+}
+
+tasks.withType<Jar> {
+  archiveBaseName.set(artifactName)
+}
+
+publishing {
+  publications {
+    withType<MavenPublication>().configureEach {
+      artifactId = artifactName
+    }
   }
 }
 

--- a/spark-connector/v3.5/spark-runtime/build.gradle.kts
+++ b/spark-connector/v3.5/spark-runtime/build.gradle.kts
@@ -39,6 +39,14 @@ tasks.withType<ShadowJar>(ShadowJar::class.java) {
   relocate("org.apache.hc", "com.datastrato.gravitino.shaded.org.apache.hc")
 }
 
+publishing {
+  publications {
+    withType<MavenPublication>().configureEach {
+      artifactId = baseName
+    }
+  }
+}
+
 tasks.jar {
   dependsOn(tasks.named("shadowJar"))
   archiveClassifier.set("empty")

--- a/spark-connector/v3.5/spark/build.gradle.kts
+++ b/spark-connector/v3.5/spark/build.gradle.kts
@@ -20,6 +20,7 @@ val icebergVersion: String = libs.versions.iceberg4spark.get()
 val kyuubiVersion: String = libs.versions.kyuubi4spark35.get()
 val scalaJava8CompatVersion: String = libs.versions.scala.java.compat.get()
 val scalaCollectionCompatVersion: String = libs.versions.scala.collection.compat.get()
+val artifactName = "${rootProject.name}-spark-${sparkMajorVersion}_$scalaVersion"
 
 dependencies {
   implementation(project(":spark-connector:spark-3.4"))
@@ -133,6 +134,18 @@ tasks.test {
 
     val init = project.extra.get("initIntegrationTest") as (Test) -> Unit
     init(this)
+  }
+}
+
+tasks.withType<Jar> {
+  archiveBaseName.set(artifactName)
+}
+
+publishing {
+  publications {
+    withType<MavenPublication>().configureEach {
+      artifactId = artifactName
+    }
   }
 }
 


### PR DESCRIPTION

### What changes were proposed in this pull request?

Add scala version to the name of maven artifact. 

### Why are the changes needed?

Currently, we support multiple versions of scala version, if we don't include the scale version information, users would be unable to use jars with different scala version.

Fix: #3746

### Does this PR introduce _any_ user-facing change?

N/A.

### How was this patch tested?

<img width="1046" alt="image" src="https://github.com/datastrato/gravitino/assets/15794564/039bfc0e-555b-4481-94ec-c88660ca60df">

