### PR TITLE
[Minor] Extend timeout time for crob integration test

### DIFF
--- a/.github/workflows/cron-integration-test.yml
+++ b/.github/workflows/cron-integration-test.yml
@@ -50,7 +50,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.source_changes == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     strategy:
       matrix:
         architecture: [linux/amd64]


### PR DESCRIPTION
### What changes were proposed in this pull request?

Extend timeout time for crob integration test 

### Why are the changes needed?

crob-integration-test timeout minutes is 60, but currently crob-integration-test job costs about 71 minutes per execution. 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

N/A