### PR TITLE
 [#3833] improvement(relational-backend): Add index for table `role_meta_securable_object`

### DIFF
--- a/scripts/mysql/schema-0.6.0-mysql.sql
+++ b/scripts/mysql/schema-0.6.0-mysql.sql
@@ -155,7 +155,7 @@ CREATE TABLE IF NOT EXISTS `role_meta_securable_object` (
     `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'securable object deleted at',
     PRIMARY KEY (`id`),
     KEY `idx_obj_rid` (`role_id`),
-    KEY `idx_obj_eid` (`entity_id`, `type`)
+    KEY `idx_obj_eid` (`entity_id`)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'securable object meta';
 
 CREATE TABLE IF NOT EXISTS `user_role_rel` (

--- a/scripts/mysql/schema-0.6.0-mysql.sql
+++ b/scripts/mysql/schema-0.6.0-mysql.sql
@@ -154,7 +154,8 @@ CREATE TABLE IF NOT EXISTS `role_meta_securable_object` (
     `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'securable object last version',
     `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'securable object deleted at',
     PRIMARY KEY (`id`),
-    KEY `idx_obj_rid` (`role_id`)
+    KEY `idx_obj_rid` (`role_id`),
+    KEY `idx_obj_eid` (`entity_id`, `type`)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'securable object meta';
 
 CREATE TABLE IF NOT EXISTS `user_role_rel` (

--- a/scripts/mysql/upgrade-0.5.0-to-0.6.0-mysql.sql
+++ b/scripts/mysql/upgrade-0.5.0-to-0.6.0-mysql.sql
@@ -19,5 +19,5 @@ CREATE TABLE IF NOT EXISTS `role_meta_securable_object` (
     `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'securable object deleted at',
     PRIMARY KEY (`id`),
     KEY `idx_obj_rid` (`role_id`),
-    KEY `idx_obj_eid` (`entity_id`, `type`)
+    KEY `idx_obj_eid` (`entity_id`)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'securable object meta';

--- a/scripts/mysql/upgrade-0.5.0-to-0.6.0-mysql.sql
+++ b/scripts/mysql/upgrade-0.5.0-to-0.6.0-mysql.sql
@@ -18,5 +18,6 @@ CREATE TABLE IF NOT EXISTS `role_meta_securable_object` (
     `last_version` INT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'securable object last version',
     `deleted_at` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'securable object deleted at',
     PRIMARY KEY (`id`),
-    KEY `idx_obj_rid` (`role_id`)
+    KEY `idx_obj_rid` (`role_id`),
+    KEY `idx_obj_eid` (`entity_id`, `type`)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT 'securable object meta';


### PR DESCRIPTION
### What changes were proposed in this pull request?
If we support to remove securable object, we will use the entity id and type to find the securable object. It will be faster if we have the index.

### Why are the changes needed?

Fix: #3833

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
I run the SQL in my local mysql.
