### PR TITLE
[#3824] improvement(client-python): Support generating pydoc from client-python code

### DIFF
--- a/clients/client-python/.gitignore
+++ b/clients/client-python/.gitignore
@@ -13,6 +13,7 @@ dist
 build
 README.md
 version.ini
+docs
 
 # Unit test / coverage reports
 htmlcov/

--- a/clients/client-python/build.gradle.kts
+++ b/clients/client-python/build.gradle.kts
@@ -167,7 +167,7 @@ tasks {
     args = listOf("scripts/generate_version.py")
   }
 
-  val doc by registering(VenvTask::class) {
+  val pydoc by registering(VenvTask::class) {
     venvExec = "python"
     args = listOf("scripts/generate_doc.py")
   }

--- a/clients/client-python/build.gradle.kts
+++ b/clients/client-python/build.gradle.kts
@@ -167,6 +167,11 @@ tasks {
     args = listOf("scripts/generate_version.py")
   }
 
+  val doc by registering(VenvTask::class) {
+    venvExec = "python"
+    args = listOf("scripts/generate_doc.py")
+  }
+
   val distribution by registering(VenvTask::class) {
     dependsOn(build)
     doFirst {
@@ -194,6 +199,8 @@ tasks {
   val clean by registering(Delete::class) {
     delete("build")
     delete("dist")
+    delete("docs")
+    delete("version.ini")
     delete("gravitino.egg-info")
     delete("tests/unittests/htmlcov")
     delete("tests/unittests/.coverage")

--- a/clients/client-python/gravitino/constants/doc.py
+++ b/clients/client-python/gravitino/constants/doc.py
@@ -6,5 +6,3 @@ This software is licensed under the Apache License version 2.
 from gravitino.constants.root import PROJECT_HOME
 
 DOC_DIR = PROJECT_HOME / "docs"
-EXCLUDE_FILES = ["__init__.py"]
-EXCLUDE_DIRS = ["__pycache__"]

--- a/clients/client-python/gravitino/constants/doc.py
+++ b/clients/client-python/gravitino/constants/doc.py
@@ -1,0 +1,10 @@
+"""
+Copyright 2024 Datastrato Pvt Ltd.
+This software is licensed under the Apache License version 2.
+"""
+
+from gravitino.constants.root import PROJECT_HOME
+
+DOC_DIR = PROJECT_HOME / "docs"
+EXCLUDE_FILES = ["__init__.py"]
+EXCLUDE_DIRS = ["__pycache__"]

--- a/clients/client-python/gravitino/constants/root.py
+++ b/clients/client-python/gravitino/constants/root.py
@@ -5,5 +5,6 @@ This software is licensed under the Apache License version 2.
 
 from pathlib import Path
 
+MODULE_NAME = "gravitino"
 PROJECT_HOME = Path(__file__).parent.parent.parent
-GRAVITNO_DIR = PROJECT_HOME / "gravitino"
+GRAVITNO_DIR = PROJECT_HOME / MODULE_NAME

--- a/clients/client-python/gravitino/constants/root.py
+++ b/clients/client-python/gravitino/constants/root.py
@@ -1,0 +1,9 @@
+"""
+Copyright 2024 Datastrato Pvt Ltd.
+This software is licensed under the Apache License version 2.
+"""
+
+from pathlib import Path
+
+PROJECT_HOME = Path(__file__).parent.parent.parent
+GRAVITNO_DIR = PROJECT_HOME / "gravitino"

--- a/clients/client-python/gravitino/constants/version.py
+++ b/clients/client-python/gravitino/constants/version.py
@@ -4,9 +4,9 @@ This software is licensed under the Apache License version 2.
 """
 
 from enum import Enum
-from pathlib import Path
 
-PROJECT_HOME = Path(__file__).parent.parent.parent
+from gravitino.constants.root import PROJECT_HOME
+
 VERSION_INI = PROJECT_HOME / "version.ini"
 SETUP_FILE = PROJECT_HOME / "setup.py"
 

--- a/clients/client-python/scripts/generate_doc.py
+++ b/clients/client-python/scripts/generate_doc.py
@@ -1,3 +1,8 @@
+"""
+Copyright 2024 Datastrato Pvt Ltd.
+This software is licensed under the Apache License version 2.
+"""
+
 import os
 import pydoc
 

--- a/clients/client-python/scripts/generate_doc.py
+++ b/clients/client-python/scripts/generate_doc.py
@@ -1,0 +1,36 @@
+import os
+import pydoc
+
+from gravitino.constants.doc import DOC_DIR, EXCLUDE_FILES, EXCLUDE_DIRS
+from gravitino.constants.root import GRAVITNO_DIR, PROJECT_HOME
+
+if __name__ == "__main__":
+
+    if not os.path.exists(DOC_DIR):
+        # If doc folder does not exist, create a new one
+        os.makedirs(DOC_DIR)
+
+    # Change work directory to doc folder
+    os.chdir(DOC_DIR)
+
+    # Traverse the project and generate docs
+    for dirpath, _, filenames in os.walk(GRAVITNO_DIR):
+
+        # Exclude some unwanted directories
+        if dirpath.split(os.sep)[-1] not in EXCLUDE_DIRS:
+
+            # Trim the root path
+            dirpath = dirpath.replace(PROJECT_HOME.as_posix() + os.sep, "")
+
+            # Convert directory path to module path
+            top_module_name = dirpath.replace(os.sep, ".")
+            pydoc.writedoc(top_module_name)
+
+            for filename in filenames:
+
+                # Exclude some unwanted files
+                if filename.endswith(".py") and filename not in EXCLUDE_FILES:
+
+                    # Convert file path to module path
+                    module_name = top_module_name + "." + filename[:-3]
+                    pydoc.writedoc(module_name)

--- a/clients/client-python/scripts/generate_doc.py
+++ b/clients/client-python/scripts/generate_doc.py
@@ -1,13 +1,8 @@
-"""
-Copyright 2024 Datastrato Pvt Ltd.
-This software is licensed under the Apache License version 2.
-"""
-
-import os
 import pydoc
+import os
 
-from gravitino.constants.doc import DOC_DIR, EXCLUDE_FILES, EXCLUDE_DIRS
-from gravitino.constants.root import GRAVITNO_DIR, PROJECT_HOME
+from gravitino.constants.doc import DOC_DIR
+from gravitino.constants.root import GRAVITNO_DIR, MODULE_NAME
 
 if __name__ == "__main__":
 
@@ -18,24 +13,8 @@ if __name__ == "__main__":
     # Change work directory to doc folder
     os.chdir(DOC_DIR)
 
-    # Traverse the project and generate docs
-    for dirpath, _, filenames in os.walk(GRAVITNO_DIR):
+    # Write doc for top module
+    pydoc.writedoc(MODULE_NAME)
 
-        # Exclude some unwanted directories
-        if dirpath.split(os.sep)[-1] not in EXCLUDE_DIRS:
-
-            # Trim the root path
-            dirpath = dirpath.replace(PROJECT_HOME.as_posix() + os.sep, "")
-
-            # Convert directory path to module path
-            top_module_name = dirpath.replace(os.sep, ".")
-            pydoc.writedoc(top_module_name)
-
-            for filename in filenames:
-
-                # Exclude some unwanted files
-                if filename.endswith(".py") and filename not in EXCLUDE_FILES:
-
-                    # Convert file path to module path
-                    module_name = top_module_name + "." + filename[:-3]
-                    pydoc.writedoc(module_name)
+    # Write doc for submodules
+    pydoc.writedocs(GRAVITNO_DIR.as_posix(), MODULE_NAME + ".")

--- a/clients/client-python/scripts/generate_doc.py
+++ b/clients/client-python/scripts/generate_doc.py
@@ -5,16 +5,19 @@ This software is licensed under the Apache License version 2.
 
 import pydoc
 import os
+import shutil
 
 from gravitino.constants.doc import DOC_DIR
 from gravitino.constants.root import GRAVITNO_DIR, MODULE_NAME
 
 if __name__ == "__main__":
 
-    if not os.path.exists(DOC_DIR):
-        # If doc folder does not exist, create a new one
-        os.makedirs(DOC_DIR)
+    if os.path.exists(DOC_DIR):
+        # If doc folder exists, delete it
+        shutil.rmtree(DOC_DIR)
 
+    # Create a new doc folder
+    os.makedirs(DOC_DIR)
     # Change work directory to doc folder
     os.chdir(DOC_DIR)
 

--- a/clients/client-python/scripts/generate_doc.py
+++ b/clients/client-python/scripts/generate_doc.py
@@ -1,3 +1,8 @@
+"""
+Copyright 2024 Datastrato Pvt Ltd.
+This software is licensed under the Apache License version 2.
+"""
+
 import pydoc
 import os
 


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

* Use `pydoc` to generate docs
* Add Gradle task `doc` to generate docs (it will create a `docs` folder and generate all doc html files in it)

Screenshots of generated htmls:
* gravitino.html
<img width="1469" alt="image" src="https://github.com/datastrato/gravitino/assets/55401762/42ee9484-0677-407c-b9d9-778fc4a870f7">

* gravitino.api.fileset.html
<img width="1459" alt="image" src="https://github.com/datastrato/gravitino/assets/55401762/5856203a-0d79-4a65-b509-8171ce3c1aa8">


### Why are the changes needed?

Fix: #3824 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

`./gradlew clients:client-python:test`