### PR TITLE
[ #3843] fix (trino-connector) Fix the timestamp value not match with trino-connector 

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoQueryIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/trino/TrinoQueryIT.java
@@ -339,7 +339,7 @@ public class TrinoQueryIT extends TrinoQueryITBase {
         completedTask.get();
       } catch (InterruptedException | ExecutionException e) {
         executor.shutdownNow();
-        throw new RuntimeException("Failed to execute test " + e.getMessage(), e);
+        throw new RuntimeException("Failed to execute the test", e);
       }
     }
     executor.shutdownNow();
@@ -375,7 +375,7 @@ public class TrinoQueryIT extends TrinoQueryITBase {
                           "Failed to run the test %s's catalog %s: %s",
                           simpleTesterName(testSetDirName), testCatalogs[finalI], e.getMessage());
                   LOG.error(msg);
-                  throw new RuntimeException(msg, e);
+                  throw e;
                 }
               }));
     }

--- a/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-mysql/00006_datatype.sql
+++ b/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-mysql/00006_datatype.sql
@@ -30,6 +30,9 @@ VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 
 
 select * from tb01 order by f1;
 
+-- check values of original mysql connector
+select * from mysql.gt_db1.tb01 order by f1;
+
 CREATE TABLE tb02 (
     f1 VARCHAR(200) not null ,
     f2 CHAR(20) not null ,

--- a/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-mysql/00006_datatype.txt
+++ b/integration-test/src/test/resources/trino-ci-testset/testsets/jdbc-mysql/00006_datatype.txt
@@ -17,8 +17,8 @@ CREATE TABLE
    f11 integer,
    f12 bigint,
    f13 date,
-   f14 time(3),
-   f15 timestamp(3)
+   f14 time(0),
+   f15 timestamp(0)
 )
 COMMENT ''
 WITH (
@@ -29,7 +29,10 @@ INSERT: 1 row
 
 INSERT: 1 row
 
-"Sample text 1","Text1               ","65","123.456","7.89","12.34","1","100","1000","1000","100000","2024-01-01","08:00:00.000","2024-01-01 08:00:00.000"
+"Sample text 1","Text1               ","65","123.456","7.89","12.34","1","100","1000","1000","100000","2024-01-01","08:00:00","2024-01-01 08:00:00"
+"","","","","","","","","","","","","",""
+
+"Sample text 1","Text1               ","65","123.456","7.89","12.34","1","100","1000","1000","100000","2024-01-01","08:00:00","2024-01-01 08:00:00"
 "","","","","","","","","","","","","",""
 
 CREATE TABLE
@@ -47,8 +50,8 @@ CREATE TABLE
    f11 integer NOT NULL,
    f12 bigint NOT NULL,
    f13 date NOT NULL,
-   f14 time(3) NOT NULL,
-   f15 timestamp(3) NOT NULL
+   f14 time(0) NOT NULL,
+   f15 timestamp(0) NOT NULL
 )
 COMMENT ''
 WITH (

--- a/integration-test/trino-it/init/trino/config/catalog/mysql.properties
+++ b/integration-test/trino-it/init/trino/config/catalog/mysql.properties
@@ -1,0 +1,8 @@
+#
+# Copyright 2024 Datastrato Pvt Ltd.
+# This software is licensed under the Apache License version 2.
+#
+connector.name=mysql
+connection-url=jdbc:mysql://mysql/?useSSL=false
+connection-user=trino
+connection-password=ds123

--- a/integration-test/trino-it/init/trino/init.sh
+++ b/integration-test/trino-it/init/trino/init.sh
@@ -9,6 +9,7 @@ trino_conf_dir="$(cd "${trino_conf_dir}">/dev/null; pwd)"
 
 cp "$trino_conf_dir/config/config.properties" /etc/trino/config.properties
 cp "$trino_conf_dir/config/catalog/gravitino.properties" /etc/trino/catalog/gravitino.properties
+cp "$trino_conf_dir/config/catalog/mysql.properties" /etc/trino/catalog/mysql.properties
 #
 # Update `gravitino.uri = http://GRAVITINO_HOST_IP:GRAVITINO_HOST_PORT` in the `conf/catalog/gravitino.properties`
 sed -i "s/GRAVITINO_HOST_IP:GRAVITINO_HOST_PORT/${GRAVITINO_HOST_IP}:${GRAVITINO_HOST_PORT}/g" /etc/trino/catalog/gravitino.properties

--- a/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/jdbc/mysql/MySQLDataTypeTransformer.java
+++ b/trino-connector/src/main/java/com/datastrato/gravitino/trino/connector/catalog/jdbc/mysql/MySQLDataTypeTransformer.java
@@ -12,6 +12,7 @@ import com.datastrato.gravitino.trino.connector.GravitinoErrorCode;
 import com.datastrato.gravitino.trino.connector.util.GeneralDataTypeTransformer;
 import io.trino.spi.TrinoException;
 import io.trino.spi.type.CharType;
+import io.trino.spi.type.TimeType;
 
 /** Type transformer between MySQL and Trino */
 public class MySQLDataTypeTransformer extends GeneralDataTypeTransformer {
@@ -26,6 +27,14 @@ public class MySQLDataTypeTransformer extends GeneralDataTypeTransformer {
   public io.trino.spi.type.Type getTrinoType(Type type) {
     if (type.name() == Name.STRING) {
       return io.trino.spi.type.VarcharType.createUnboundedVarcharType();
+    } else if (type.name() == Name.TIMESTAMP) {
+      if (((Types.TimestampType) type).hasTimeZone())
+        return io.trino.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType(0);
+      else {
+        return io.trino.spi.type.TimestampType.createTimestampType(0);
+      }
+    } else if (type.name() == Name.TIME) {
+      return TimeType.TIME_SECONDS;
     }
 
     return super.getTrinoType(type);


### PR DESCRIPTION
### What changes were proposed in this pull request?

The timestamp values do not match when querying the same table using both the Trino connector and the MySQL connector

### Why are the changes needed?

Fix: #3843

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

Update IT
