### PR TITLE
[#3847] improvement(flink-connector): Add the scale version to the flink-connector artifact name.

### DIFF
--- a/flink-connector/build.gradle.kts
+++ b/flink-connector/build.gradle.kts
@@ -14,6 +14,7 @@ repositories {
 
 val flinkVersion: String = libs.versions.flink.get()
 val scalaVersion: String = project.properties["scalaVersion"] as? String ?: extra["defaultScalaVersion"].toString()
+val artifactName = "gravitino-${project.name}-$scalaVersion"
 
 dependencies {
   implementation(project(":api"))
@@ -140,5 +141,17 @@ tasks.test {
 
     val init = project.extra.get("initIntegrationTest") as (Test) -> Unit
     init(this)
+  }
+}
+
+tasks.withType<Jar> {
+  archiveBaseName.set(artifactName)
+}
+
+publishing {
+  publications {
+    withType<MavenPublication>().configureEach {
+      artifactId = artifactName
+    }
   }
 }


### PR DESCRIPTION


### What changes were proposed in this pull request?

Add the scale version to the flink-connector artifact name.

### Why are the changes needed?

The Flink connector has introduced scala-related dependencies, we'd better add the scale version name to the artifact to make it more user-friendly.


Fix: #3847 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

Test locally.

<img width="939" alt="image" src="https://github.com/datastrato/gravitino/assets/15794564/808a1b9a-1c43-46b7-b2dc-46a78fbef296">

