### PR TITLE
[MINOR] improvement: Fix the typo in ConfigEntry.java

### DIFF
--- a/core/src/main/java/com/datastrato/gravitino/config/ConfigEntry.java
+++ b/core/src/main/java/com/datastrato/gravitino/config/ConfigEntry.java
@@ -140,7 +140,7 @@ public class ConfigEntry<T> {
    * Split the string to a list, then map each string element to its converted form.
    *
    * @param str The string form of the value list from the conf entry.
-   * @param converter The orignal ConfigEntry valueConverter.
+   * @param converter The original ConfigEntry valueConverter.
    * @return The list of converted type.
    */
   public List<T> strToSeq(String str, Function<String, T> converter) {
@@ -154,7 +154,7 @@ public class ConfigEntry<T> {
    * Reduce the values then join them as a string.
    *
    * @param seq The sequence of the value list from the conf entry.
-   * @param converter The orignal ConfigEntry stringConverter.
+   * @param converter The original ConfigEntry stringConverter.
    * @return The converted string.
    */
   public String seqToStr(List<T> seq, Function<T, String> converter) {


### PR DESCRIPTION


<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

orignal -> original