### PR TITLE
[#3409] improve(docs): Replace multi language tags with <Tabs groupId='language' queryString>

### DIFF
--- a/docs/expression.md
+++ b/docs/expression.md
@@ -17,7 +17,7 @@ Gravitino expression system divides expressions into three basic parts: field re
 Field reference is a reference to a field in a table.
 The following is an example of creating a field reference expression, demonstrating how to create a reference for the `student` field.
 
-<Tabs>
+<Tabs groupId='language' queryString>
   <TabItem value="Json" label="Json">
 
 ```json
@@ -46,7 +46,7 @@ NamedReference field = NamedReference.field("student");
 Literal is a constant value.
 The following is an example of creating a literal expression, demonstrating how to create a `NULL` literal and three different data types of literal expressions for the value `1024`.
 
-<Tabs>
+<Tabs groupId='language' queryString>
   <TabItem value="Json" label="Json">
 
 ```json
@@ -95,7 +95,7 @@ Literal<?>[] literals =
 Function expression represents a function call with/without arguments. The arguments can be field references, literals, or other function expressions.
 The following is an example of creating a function expression, demonstrating how to create function expressions for `rand()` and `date_trunc('year', birthday)`.
 
-<Tabs>
+<Tabs groupId='language' queryString>
   <TabItem value="Json" label="Json">
 
 ```json
@@ -144,7 +144,7 @@ FunctionExpression[] functionExpressions =
 Unparsed expression is a special type of expression, currently serves exclusively for presenting the default value of a column when it's unsolvable.
 The following shows the data structure of an unparsed expression in JSON and Java, enabling easy retrieval of its value.
 
-<Tabs>
+<Tabs groupId='language' queryString>
   <TabItem value="Json" label="Json">
 
 ```json

--- a/docs/jdbc-doris-catalog.md
+++ b/docs/jdbc-doris-catalog.md
@@ -121,7 +121,7 @@ Unsupported for now.
 
     Please be aware that the index can only apply to a single column.
 
-    <Tabs>
+    <Tabs groupId='language' queryString>
     <TabItem value="json" label="Json">
 
     ```json

--- a/docs/jdbc-mysql-catalog.md
+++ b/docs/jdbc-mysql-catalog.md
@@ -115,7 +115,7 @@ Meanwhile, the data types other than listed above are mapped to Gravitino **[Ext
 MySQL setting an auto-increment column requires simultaneously setting a unique index; otherwise, an error will occur.
 :::
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="json" label="Json">
 
 ```json
@@ -182,7 +182,7 @@ The index name of the PRIMARY_KEY must be PRIMARY
 [Create table index](https://dev.mysql.com/doc/refman/8.0/en/create-table.html)
 :::
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="json" label="Json">
 
 ```json

--- a/docs/jdbc-postgresql-catalog.md
+++ b/docs/jdbc-postgresql-catalog.md
@@ -126,7 +126,7 @@ Meanwhile, the data types other than listed above are mapped to Gravitino **[Ext
 
 - Supports PRIMARY_KEY and UNIQUE_KEY.
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="json" label="Json">
 
 ```json

--- a/docs/lakehouse-iceberg-catalog.md
+++ b/docs/lakehouse-iceberg-catalog.md
@@ -130,7 +130,7 @@ For `bucket` and `truncate`, the first argument must be integer literal, and the
 
 - Gravitino used by default `NoneDistribution`.
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="json" label="JSON">
 
 ```json
@@ -153,7 +153,7 @@ Distributions.NONE;
 
 - Support `HashDistribution`, Hash distribute by partition key.
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="json" label="JSON">
 
 ```json
@@ -175,7 +175,7 @@ Distributions.HASH;
 
 - Support `RangeDistribution`, You can pass `range` as values through the API. Range distribute by partition key or sort key if table has an SortOrder.
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="json" label="JSON">
 
 ```json

--- a/docs/manage-messaging-metadata-using-gravitino.md
+++ b/docs/manage-messaging-metadata-using-gravitino.md
@@ -29,7 +29,7 @@ For a messaging catalog, you must specify the `type` as `messaging` when creatin
 You can create a catalog by sending a `POST` request to the `/api/metalakes/{metalake_name}/catalogs`
 endpoint or just use the Gravitino Java client. The following is an example of creating a messaging catalog:
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="shell" label="Shell">
 
 ```shell
@@ -148,7 +148,7 @@ You can create a topic by sending a `POST` request to the `/api/metalakes/{metal
 endpoint or just use the Gravitino Java client. The following is an example of creating a topic:
 
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="shell" label="Shell">
 
 ```shell
@@ -197,7 +197,7 @@ You can modify a topic by sending a `PUT` request to the `/api/metalakes/{metala
 endpoint or just use the Gravitino Java client. The following is an example of altering a topic:
 
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="shell" label="Shell">
 
 ```shell
@@ -248,7 +248,7 @@ You can remove a topic by sending a `DELETE` request to the `/api/metalakes/{met
 /catalogs/{catalog_name}/schemas/{schema_name}/topics/{topic_name}` endpoint or by using the
 Gravitino Java client. The following is an example of dropping a topic:
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="shell" label="Shell">
 
 ```shell
@@ -281,7 +281,7 @@ You can list all topics in a schema by sending a `GET` request to the `/api/meta
 {metalake_name}/catalogs/{catalog_name}/schemas/{schema_name}/topics` endpoint or by using the
 Gravitino Java client. The following is an example of listing all the topics in a schema:
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="shell" label="Shell">
 
 ```shell

--- a/docs/manage-relational-metadata-using-gravitino.md
+++ b/docs/manage-relational-metadata-using-gravitino.md
@@ -42,7 +42,7 @@ For relational catalog, you must specify the catalog `type` as `RELATIONAL` when
 
 You can create a catalog by sending a `POST` request to the `/api/metalakes/{metalake_name}/catalogs` endpoint or just use the Gravitino Java client. The following is an example of creating a catalog:
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="shell" label="Shell">
 
 ```shell
@@ -100,7 +100,7 @@ Currently, Gravitino supports the following catalog providers:
 
 You can load a catalog by sending a `GET` request to the `/api/metalakes/{metalake_name}/catalogs/{catalog_name}` endpoint or just use the Gravitino Java client. The following is an example of loading a catalog:
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="shell" label="Shell">
 
 ```shell
@@ -125,7 +125,7 @@ Catalog catalog = gravitinoClient.loadCatalog(NameIdentifier.of("metalake", "cat
 
 You can modify a catalog by sending a `PUT` request to the `/api/metalakes/{metalake_name}/catalogs/{catalog_name}` endpoint or just use the Gravitino Java client. The following is an example of altering a catalog:
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="shell" label="Shell">
 
 ```shell
@@ -512,7 +512,7 @@ Users should create a metalake, a catalog and a schema before creating a table.
 
 You can create a table by sending a `POST` request to the `/api/metalakes/{metalake_name}/catalogs/{catalog_name}/schemas/{schema_name}/tables` endpoint or just use the Gravitino Java client. The following is an example of creating a table:
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="shell" label="Shell">
 
 ```shell
@@ -732,7 +732,7 @@ you can use the ExternalType to represent the type. Similarly, if the original t
 represented by ExternalType.
 The following shows the data structure of an external type in JSON and Java, enabling easy retrieval of its string value.
 
-<Tabs>
+<Tabs groupId='language' queryString>
   <TabItem value="Json" label="Json">
 
 ```json
@@ -760,7 +760,7 @@ deserialization between the server and client. For instance, if a new column typ
 that the client does not recognize, it will be treated as an unparsed type on the client side.
 The following shows the data structure of an unparsed type in JSON and Java, enabling easy retrieval of its value.
 
-<Tabs>
+<Tabs groupId='language' queryString>
   <TabItem value="Json" label="Json">
 
 ```json
@@ -839,7 +839,7 @@ The code above is an example of creating a Hive table. For other catalogs, the c
 
 You can load a table by sending a `GET` request to the `/api/metalakes/{metalake_name}/catalogs/{catalog_name}/schemas/{schema_name}/tables/{table_name}` endpoint or just use the Gravitino Java client. The following is an example of loading a table:
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="shell" label="Shell">
 
 ```shell
@@ -873,7 +873,7 @@ tableCatalog.loadTable(NameIdentifier.of("metalake", "hive_catalog", "schema", "
 
 You can modify a table by sending a `PUT` request to the `/api/metalakes/{metalake_name}/catalogs/{catalog_name}/schemas/{schema_name}/tables/{table_name}` endpoint or just use the Gravitino Java client. The following is an example of modifying a table:
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="shell" label="Shell">
 
 ```shell
@@ -931,7 +931,7 @@ Currently, Gravitino supports the following changes to a table:
 
 You can remove a table by sending a `DELETE` request to the `/api/metalakes/{metalake_name}/catalogs/{catalog_name}/schemas/{schema_name}/tables/{table_name}` endpoint or just use the Gravitino Java client. The following is an example of dropping a table:
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="shell" label="Shell">
 
 ```shell
@@ -974,7 +974,7 @@ Hive catalog and lakehouse-iceberg catalog supports `purgeTable` while jdbc-mysq
 
 You can list all tables in a schema by sending a `GET` request to the `/api/metalakes/{metalake_name}/catalogs/{catalog_name}/schemas/{schema_name}/tables` endpoint or just use the Gravitino Java client. The following is an example of list all tables in a schema:
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="shell" label="Shell">
 
 ```shell

--- a/docs/manage-table-partition-using-gravitino.md
+++ b/docs/manage-table-partition-using-gravitino.md
@@ -209,7 +209,7 @@ Each list in the lists must have the same length. The values in each list must c
 You can add a partition to a partitioned table by sending a `POST` request to the `/api/metalakes/{metalake_name}/catalogs/{catalog_name}/schemas/{schema_name}/tables/{partitioned_table_name}/partitions` endpoint or by using the Gravitino Java client.
 The following is an example of adding a identity partition to a Hive partitioned table:
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="shell" label="Shell">
 
 ```shell
@@ -275,7 +275,7 @@ Partition addedPartition =
 You can get a partition by its name via sending a `GET` request to the `/api/metalakes/{metalake_name}/catalogs/{catalog_name}/schemas/{schema_name}/tables/{partitioned_table_name}/partitions/{partition_name}` endpoint or by using the Gravitino Java client.
 The following is an example of getting a partition by its name:
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="shell" label="Shell">
 
 ```shell
@@ -315,7 +315,7 @@ Partition Partition =
 You can list all partition names under a partitioned table by sending a `GET` request to the `/api/metalakes/{metalake_name}/catalogs/{catalog_name}/schemas/{schema_name}/tables/{partitioned_table_name}/partitions` endpoint or by using the Gravitino Java client.
 The following is an example of listing all partition names under a partitioned table:
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="shell" label="Shell">
 
 ```shell
@@ -351,7 +351,7 @@ String[] partitionNames =
 If you want to get more detailed information about the partitions under a partitioned table, you can list all partitions under a partitioned table by sending a `GET` request to the `/api/metalakes/{metalake_name}/catalogs/{catalog_name}/schemas/{schema_name}/tables/{partitioned_table_name}/partitions` endpoint or by using the Gravitino Java client.
 The following is an example of listing all partitions under a partitioned table:
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="shell" label="Shell">
 
 ```shell
@@ -382,7 +382,7 @@ Partition[] partitions =
 You can drop a partition by its name via sending a `DELETE` request to the `/api/metalakes/{metalake_name}/catalogs/{catalog_name}/schemas/{schema_name}/tables/{partitioned_table_name}/partitions/{partition_name}` endpoint or by using the Gravitino Java client.
 The following is an example of dropping a partition by its name:
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="shell" label="Shell">
 
 ```shell

--- a/docs/table-partitioning-bucketing-sort-order-indexes.md
+++ b/docs/table-partitioning-bucketing-sort-order-indexes.md
@@ -60,7 +60,7 @@ To create a bucketed table, you should use the following three components to con
 - number. It defines how many buckets you use to bucket the table.
 - funcArgs. It defines the arguments of the strategy, the argument must be an [expression](./expression.md).
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="Json" label="Json">
 
 ```json
@@ -109,7 +109,7 @@ Note: If the direction value is `ascending`, the default ordering value is `null
 
 - sortTerm. It shows which field or function Gravitino uses to sort the table, must be an [expression](./expression.md).
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="Json" label="Json">
 
 ```json
@@ -140,7 +140,7 @@ SortOrders.of(NamedReference.field("score"), SortDirection.ASCENDING, NullOrderi
 
 The following is an example of creating a partitioned, bucketed table, and sorted order table:
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="shell" label="Shell">
 
 ```shell
@@ -251,7 +251,7 @@ To define an indexed table, you should utilize the following three components to
 
 - FieldNames. It defines which table fields Gravitino uses to index the table.
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="Json" label="Json">
 
 ```json
@@ -274,7 +274,7 @@ Indexes.of(IndexType.PRIMARY_KEY, "PRIMARY", new String[][]{{"col_1"}, {"col_2"}
 
 The following is an example of creating a index table:
 
-<Tabs>
+<Tabs groupId='language' queryString>
 <TabItem value="shell" label="Shell">
 
 ```shell


### PR DESCRIPTION
<!--
1. Title: [#3409] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
This pull request updates all `<Tabs>` components in the documentation to support multi-language switching by adding `groupId='language'` and `queryString` attributes. It also ensures that all related links in the documentation include the appropriate `queryString` parameter for language selection.

Changes include:
- Updating all `<Tabs>` components to the following format:
  ```markdown
  <Tabs groupId='language' queryString>
    <TabItem value="Json" label="Json">
      ```json
      {
        "direction": "asc",
        "nullOrder": "NULLS_LAST",
        "sortTerm":  {
          "type": "field",
          "fieldName": ["score"]
        }
      }
      ```
    </TabItem>
    <TabItem value="java" label="Java">
      ```java
      SortOrders.of(NamedReference.field("score"), SortDirection.ASCENDING, NullOrdering.NULLS_LAST);
      ```
    </TabItem>
  </Tabs>
****
### Why are the changes needed?
Fix: #3409
These changes are needed to enable multi-language support in the documentation, allowing users to easily switch between different language examples. This improves the usability and accessibility of the documentation for a wider audience.

### Does this PR introduce any user-facing change?
Yes, this PR introduces the following user-facing changes:

Users can now switch between different language examples in the documentation using a consistent interface.
Documentation links will now include queryString parameters to ensure the correct language example is displayed.
How was this patch tested?
The changes were tested by:

-Not yet