### PR TITLE
[3286] Improvement(ui): row tooltip displays comment

### DIFF
--- a/web/src/app/metalakes/TableBody.js
+++ b/web/src/app/metalakes/TableBody.js
@@ -94,7 +94,7 @@ const TableBody = props => {
 
         return (
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
-            <Tooltip title={name} placement='right'>
+            <Tooltip title={row.comment} placement='right'>
               <Typography
                 noWrap
                 component={Link}

--- a/web/src/app/metalakes/metalake/rightContent/tabsContent/tableView/TableView.js
+++ b/web/src/app/metalakes/metalake/rightContent/tabsContent/tableView/TableView.js
@@ -199,24 +199,26 @@ const TableView = () => {
 
         return (
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
-            <Typography
-              noWrap
-              {...(path
-                ? {
-                    component: Link,
-                    href: path
-                  }
-                : {})}
-              onClick={() => handleClickUrl(path)}
-              sx={{
-                fontWeight: 400,
-                color: 'primary.main',
-                textDecoration: 'none',
-                '&:hover': { color: 'primary.main', textDecoration: 'underline' }
-              }}
-            >
-              {name}
-            </Typography>
+            <Tooltip title={row.comment} placement='right'>
+              <Typography
+                noWrap
+                {...(path
+                  ? {
+                      component: Link,
+                      href: path
+                    }
+                  : {})}
+                onClick={() => handleClickUrl(path)}
+                sx={{
+                  fontWeight: 400,
+                  color: 'primary.main',
+                  textDecoration: 'none',
+                  '&:hover': { color: 'primary.main', textDecoration: 'underline' }
+                }}
+              >
+                {name}
+              </Typography>
+            </Tooltip>
           </Box>
         )
       }

--- a/web/src/components/DetailsDrawer.js
+++ b/web/src/components/DetailsDrawer.js
@@ -98,21 +98,19 @@ const DetailsDrawer = props => {
       </Box>
       <Box sx={{ p: 4 }}>
         <Grid item xs={12} sx={{ mb: [0, 5] }}>
-          <Tooltip title={drawerData.name} placement='bottom-start'>
-            <Typography
-              variant='subtitle1'
-              className={
-                'twc-py-2 twc-font-semibold twc-text-[1.2rem] twc-w-full twc-overflow-hidden twc-text-ellipsis'
-              }
-              sx={{
-                borderBottom: theme => `1px solid ${theme.palette.divider}`,
-                whiteSpace: 'nowrap'
-              }}
-              data-refer='details-title'
-            >
-              {drawerData.name}
-            </Typography>
-          </Tooltip>
+          <Typography
+            variant='subtitle1'
+            className={
+              'twc-py-2 twc-font-semibold twc-text-[1.2rem] twc-w-full twc-overflow-hidden twc-text-ellipsis'
+            }
+            sx={{
+              borderBottom: theme => `1px solid ${theme.palette.divider}`,
+              whiteSpace: 'nowrap'
+            }}
+            data-refer='details-title'
+          >
+            {drawerData.name}
+          </Typography>
         </Grid>
 
         {isMetalakePage ? (

--- a/web/src/components/DetailsDrawer.js
+++ b/web/src/components/DetailsDrawer.js
@@ -100,9 +100,7 @@ const DetailsDrawer = props => {
         <Grid item xs={12} sx={{ mb: [0, 5] }}>
           <Typography
             variant='subtitle1'
-            className={
-              'twc-py-2 twc-font-semibold twc-text-[1.2rem] twc-w-full twc-overflow-hidden twc-text-ellipsis'
-            }
+            className={'twc-py-2 twc-font-semibold twc-text-[1.2rem] twc-w-full twc-overflow-hidden twc-text-ellipsis'}
             sx={{
               borderBottom: theme => `1px solid ${theme.palette.divider}`,
               whiteSpace: 'nowrap'


### PR DESCRIPTION

### What changes were proposed in this pull request?

In this PR, I've changed the tool tip to show the metalake comment and catalog comment when hovering over the metalake and catalog in each row respectively.

### Why are the changes needed?

Before the PR when hovering over the metalake row, it would display the metalake name which is redundant. Additionally, when hovering over the catalog name it did not show any tooltip at all.

Fix: #3286 

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?
I tested this using this the web UI to see if it displays correctly when the mouse is hovered over.
