### PR TITLE
[#3895] feat(core): Add a basic tag manager framework for tag system

### DIFF
--- a/api/src/main/java/com/datastrato/gravitino/MetadataObject.java
+++ b/api/src/main/java/com/datastrato/gravitino/MetadataObject.java
@@ -68,7 +68,13 @@ public interface MetadataObject {
    *
    * @return The name of the object.
    */
-  String fullName();
+  default String fullName() {
+    if (parent() == null) {
+      return name();
+    } else {
+      return parent() + "." + name();
+    }
+  }
 
   /**
    * The type of the object.

--- a/api/src/main/java/com/datastrato/gravitino/MetadataObjects.java
+++ b/api/src/main/java/com/datastrato/gravitino/MetadataObjects.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+
+/** The helper class for {@link MetadataObject}. */
+public class MetadataObjects {
+
+  /**
+   * The reserved name for the metadata object.
+   *
+   * <p>It is used to represent the root metadata object of all metalakes.
+   */
+  public static final String METADATA_OBJECT_RESERVED_NAME = "*";
+
+  private static final Splitter DOT_SPLITTER = Splitter.on('.');
+
+  private static final Joiner DOT_JOINER = Joiner.on('.');
+
+  private MetadataObjects() {}
+
+  /**
+   * Create the metadata object with the given name, parent and type.
+   *
+   * @param name The name of the metadata object
+   * @param parent The parent of the metadata object
+   * @param type The type of the metadata object
+   * @return The created metadata object
+   */
+  public static MetadataObject of(String parent, String name, MetadataObject.Type type) {
+    Preconditions.checkArgument(name != null, "Cannot create a metadata object with null name");
+    Preconditions.checkArgument(type != null, "Cannot create a metadata object with no type");
+
+    return new MetadataObjectImpl(parent, name, type);
+  }
+
+  /**
+   * Create the metadata object with the given names and type.
+   *
+   * @param names The names of the metadata object
+   * @param type The type of the metadata object
+   * @return The created metadata object
+   */
+  public static MetadataObject of(List<String> names, MetadataObject.Type type) {
+    Preconditions.checkArgument(names != null, "Cannot create a metadata object with null names");
+    Preconditions.checkArgument(!names.isEmpty(), "Cannot create a metadata object with no names");
+    Preconditions.checkArgument(
+        names.size() <= 4,
+        "Cannot create a metadata object with the name length which is greater than 4");
+    Preconditions.checkArgument(type != null, "Cannot create a metadata object with no type");
+
+    Preconditions.checkArgument(
+        names.size() != 1
+            || type == MetadataObject.Type.CATALOG
+            || type == MetadataObject.Type.METALAKE,
+        "If the length of names is 1, it must be the CATALOG or METALAKE type");
+
+    Preconditions.checkArgument(
+        names.size() != 2 || type == MetadataObject.Type.SCHEMA,
+        "If the length of names is 2, it must be the SCHEMA type");
+
+    Preconditions.checkArgument(
+        names.size() != 3
+            || type == MetadataObject.Type.FILESET
+            || type == MetadataObject.Type.TABLE
+            || type == MetadataObject.Type.TOPIC,
+        "If the length of names is 3, it must be FILESET, TABLE or TOPIC");
+
+    Preconditions.checkArgument(
+        names.size() != 4 || type == MetadataObject.Type.COLUMN,
+        "If the length of names is 4, it must be COLUMN");
+
+    for (String name : names) {
+      checkName(name);
+    }
+
+    return new MetadataObjectImpl(getParentFullName(names), getLastName(names), type);
+  }
+
+  /**
+   * Parse the metadata object with the given full name and type.
+   *
+   * @param fullName The full name of the metadata object
+   * @param type The type of the metadata object
+   * @return The parsed metadata object
+   */
+  public static MetadataObject parse(String fullName, MetadataObject.Type type) {
+    if (METADATA_OBJECT_RESERVED_NAME.equals(fullName)) {
+      if (type != MetadataObject.Type.METALAKE) {
+        throw new IllegalArgumentException("If metadata object isn't metalake, it can't be `*`");
+      }
+      return new MetadataObjectImpl(METADATA_OBJECT_RESERVED_NAME, null, type);
+    }
+
+    Preconditions.checkArgument(
+        StringUtils.isNotBlank(fullName), "Metadata object full name cannot be blank");
+
+    List<String> parts = DOT_SPLITTER.splitToList(fullName);
+
+    return MetadataObjects.of(parts, type);
+  }
+
+  private static String getParentFullName(List<String> names) {
+    if (names.size() <= 1) {
+      return null;
+    }
+
+    return DOT_JOINER.join(names.subList(0, names.size() - 1));
+  }
+
+  private static String getLastName(List<String> names) {
+    return names.get(names.size() - 1);
+  }
+
+  private static void checkName(String name) {
+    Preconditions.checkArgument(name != null, "Cannot create a metadata object with null name");
+    Preconditions.checkArgument(
+        !METADATA_OBJECT_RESERVED_NAME.equals(name),
+        "Cannot create a metadata object with `*` name.");
+  }
+
+  /** The implementation of the {@link MetadataObject}. */
+  public static class MetadataObjectImpl implements MetadataObject {
+
+    private final String name;
+
+    private final String parent;
+
+    private final Type type;
+
+    public MetadataObjectImpl(String parent, String name, Type type) {
+      this.name = name;
+      this.parent = parent;
+      this.type = type;
+    }
+
+    @Override
+    public String name() {
+      return name;
+    }
+
+    @Override
+    public String parent() {
+      return parent;
+    }
+
+    @Override
+    public Type type() {
+      return type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+
+      if (!(o instanceof MetadataObjectImpl)) {
+        return false;
+      }
+
+      MetadataObjectImpl that = (MetadataObjectImpl) o;
+      return java.util.Objects.equals(name, that.name)
+          && java.util.Objects.equals(parent, that.parent)
+          && type == that.type;
+    }
+
+    @Override
+    public int hashCode() {
+      return java.util.Objects.hash(name, parent, type);
+    }
+
+    @Override
+    public String toString() {
+      return "MetadataObject: [fullName=" + fullName() + "], [type=" + type + "]";
+    }
+  }
+}

--- a/api/src/main/java/com/datastrato/gravitino/MetadataObjects.java
+++ b/api/src/main/java/com/datastrato/gravitino/MetadataObjects.java
@@ -29,8 +29,8 @@ public class MetadataObjects {
   /**
    * Create the metadata object with the given name, parent and type.
    *
-   * @param name The name of the metadata object
    * @param parent The parent of the metadata object
+   * @param name The name of the metadata object
    * @param type The type of the metadata object
    * @return The created metadata object
    */
@@ -96,7 +96,7 @@ public class MetadataObjects {
       if (type != MetadataObject.Type.METALAKE) {
         throw new IllegalArgumentException("If metadata object isn't metalake, it can't be `*`");
       }
-      return new MetadataObjectImpl(METADATA_OBJECT_RESERVED_NAME, null, type);
+      return new MetadataObjectImpl(null, METADATA_OBJECT_RESERVED_NAME, type);
     }
 
     Preconditions.checkArgument(
@@ -135,9 +135,16 @@ public class MetadataObjects {
 
     private final Type type;
 
+    /**
+     * Create the metadata object with the given name, parent and type.
+     *
+     * @param parent The parent of the metadata object
+     * @param name The name of the metadata object
+     * @param type The type of the metadata object
+     */
     public MetadataObjectImpl(String parent, String name, Type type) {
-      this.name = name;
       this.parent = parent;
+      this.name = name;
       this.type = type;
     }
 

--- a/api/src/main/java/com/datastrato/gravitino/authorization/SecurableObjects.java
+++ b/api/src/main/java/com/datastrato/gravitino/authorization/SecurableObjects.java
@@ -5,18 +5,18 @@
 package com.datastrato.gravitino.authorization;
 
 import com.datastrato.gravitino.MetadataObject;
+import com.datastrato.gravitino.MetadataObjects;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringUtils;
 
 /** The helper class for {@link SecurableObject}. */
 public class SecurableObjects {
 
-  private static final Splitter DOT = Splitter.on('.');
+  private static final Splitter DOT_SPLITTER = Splitter.on('.');
 
   /**
    * Create the metalake {@link SecurableObject} with the given metalake name.
@@ -51,7 +51,6 @@ public class SecurableObjects {
    */
   public static SecurableObject ofSchema(
       SecurableObject catalog, String schema, List<Privilege> privileges) {
-
     return of(
         SecurableObject.Type.SCHEMA, Lists.newArrayList(catalog.fullName(), schema), privileges);
   }
@@ -66,7 +65,7 @@ public class SecurableObjects {
    */
   public static SecurableObject ofTable(
       SecurableObject schema, String table, List<Privilege> privileges) {
-    List<String> names = Lists.newArrayList(DOT.splitToList(schema.fullName()));
+    List<String> names = Lists.newArrayList(DOT_SPLITTER.splitToList(schema.fullName()));
     names.add(table);
     return of(SecurableObject.Type.TABLE, names, privileges);
   }
@@ -81,7 +80,7 @@ public class SecurableObjects {
    */
   public static SecurableObject ofTopic(
       SecurableObject schema, String topic, List<Privilege> privileges) {
-    List<String> names = Lists.newArrayList(DOT.splitToList(schema.fullName()));
+    List<String> names = Lists.newArrayList(DOT_SPLITTER.splitToList(schema.fullName()));
     names.add(topic);
     return of(SecurableObject.Type.TOPIC, names, privileges);
   }
@@ -97,7 +96,7 @@ public class SecurableObjects {
    */
   public static SecurableObject ofFileset(
       SecurableObject schema, String fileset, List<Privilege> privileges) {
-    List<String> names = Lists.newArrayList(DOT.splitToList(schema.fullName()));
+    List<String> names = Lists.newArrayList(DOT_SPLITTER.splitToList(schema.fullName()));
     names.add(fileset);
     return of(SecurableObject.Type.FILESET, names, privileges);
   }
@@ -115,42 +114,14 @@ public class SecurableObjects {
     return new SecurableObjectImpl(null, "*", SecurableObject.Type.METALAKE, privileges);
   }
 
-  private static class SecurableObjectImpl implements SecurableObject {
+  private static class SecurableObjectImpl extends MetadataObjects.MetadataObjectImpl
+      implements SecurableObject {
 
-    private final String parent;
-    private final String name;
-    private final Type type;
     private List<Privilege> privileges;
 
     SecurableObjectImpl(String parent, String name, Type type, List<Privilege> privileges) {
-      this.parent = parent;
-      this.name = name;
-      this.type = type;
+      super(parent, name, type);
       this.privileges = ImmutableList.copyOf(privileges);
-    }
-
-    @Override
-    public String parent() {
-      return parent;
-    }
-
-    @Override
-    public String name() {
-      return name;
-    }
-
-    @Override
-    public String fullName() {
-      if (parent != null) {
-        return parent + "." + name;
-      } else {
-        return name;
-      }
-    }
-
-    @Override
-    public Type type() {
-      return type;
     }
 
     @Override
@@ -160,7 +131,8 @@ public class SecurableObjects {
 
     @Override
     public int hashCode() {
-      return Objects.hash(parent, name, type, privileges);
+      int result = super.hashCode();
+      return 31 * result + Objects.hash(privileges);
     }
 
     @Override
@@ -173,7 +145,7 @@ public class SecurableObjects {
       return "SecurableObject: [fullName="
           + fullName()
           + "], [type="
-          + type
+          + type()
           + "], [privileges="
           + privilegesStr
           + "]";
@@ -181,15 +153,20 @@ public class SecurableObjects {
 
     @Override
     public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      }
+
       if (!(other instanceof SecurableObject)) {
         return false;
       }
 
+      if (!super.equals(other)) {
+        return false;
+      }
+
       SecurableObject otherSecurableObject = (SecurableObject) other;
-      return Objects.equals(parent, otherSecurableObject.parent())
-          && Objects.equals(name, otherSecurableObject.name())
-          && Objects.equals(type, otherSecurableObject.type())
-          && Objects.equals(privileges, otherSecurableObject.privileges());
+      return Objects.equals(privileges, otherSecurableObject.privileges());
     }
   }
 
@@ -203,20 +180,9 @@ public class SecurableObjects {
    */
   public static SecurableObject parse(
       String fullName, MetadataObject.Type type, List<Privilege> privileges) {
-    if ("*".equals(fullName)) {
-      if (type != MetadataObject.Type.METALAKE) {
-        throw new IllegalArgumentException("If securable object isn't metalake, it can't be `*`");
-      }
-      return SecurableObjects.ofAllMetalakes(privileges);
-    }
-
-    if (StringUtils.isBlank(fullName)) {
-      throw new IllegalArgumentException("securable object full name can't be blank");
-    }
-
-    List<String> parts = DOT.splitToList(fullName);
-
-    return SecurableObjects.of(type, parts, privileges);
+    MetadataObject metadataObject = MetadataObjects.parse(fullName, type);
+    return new SecurableObjectImpl(
+        metadataObject.parent(), metadataObject.name(), type, privileges);
   }
 
   /**
@@ -229,68 +195,8 @@ public class SecurableObjects {
    */
   static SecurableObject of(
       MetadataObject.Type type, List<String> names, List<Privilege> privileges) {
-    if (names == null) {
-      throw new IllegalArgumentException("Cannot create a securable object with null names");
-    }
-
-    if (names.isEmpty()) {
-      throw new IllegalArgumentException("Cannot create a securable object with no names");
-    }
-
-    if (type == null) {
-      throw new IllegalArgumentException("Cannot create a securable object with no type");
-    }
-
-    if (names.size() > 3) {
-      throw new IllegalArgumentException(
-          "Cannot create a securable object with the name length which is greater than 3");
-    }
-
-    if (names.size() == 1
-        && type != MetadataObject.Type.CATALOG
-        && type != MetadataObject.Type.METALAKE) {
-      throw new IllegalArgumentException(
-          "If the length of names is 1, it must be the CATALOG or METALAKE type");
-    }
-
-    if (names.size() == 2 && type != SecurableObject.Type.SCHEMA) {
-      throw new IllegalArgumentException("If the length of names is 2, it must be the SCHEMA type");
-    }
-
-    if (names.size() == 3
-        && type != MetadataObject.Type.FILESET
-        && type != MetadataObject.Type.TABLE
-        && type != MetadataObject.Type.TOPIC) {
-      throw new IllegalArgumentException(
-          "If the length of names is 3, it must be FILESET, TABLE or TOPIC");
-    }
-
-    for (String name : names) {
-      checkName(name);
-    }
-
-    return new SecurableObjectImpl(getParentFullName(names), getLastName(names), type, privileges);
-  }
-
-  private static String getParentFullName(List<String> names) {
-    if (names.size() <= 1) {
-      return null;
-    }
-
-    return String.join(".", names.subList(0, names.size() - 1));
-  }
-
-  private static String getLastName(List<String> names) {
-    return names.get(names.size() - 1);
-  }
-
-  private static void checkName(String name) {
-    if (name == null) {
-      throw new IllegalArgumentException("Cannot create a securable object with null name");
-    }
-
-    if ("*".equals(name)) {
-      throw new IllegalArgumentException("Cannot create a securable object with `*` name.");
-    }
+    MetadataObject metadataObject = MetadataObjects.of(names, type);
+    return new SecurableObjectImpl(
+        metadataObject.parent(), metadataObject.name(), type, privileges);
   }
 }

--- a/api/src/main/java/com/datastrato/gravitino/authorization/SecurableObjects.java
+++ b/api/src/main/java/com/datastrato/gravitino/authorization/SecurableObjects.java
@@ -132,7 +132,7 @@ public class SecurableObjects {
     @Override
     public int hashCode() {
       int result = super.hashCode();
-      return 31 * result + Objects.hash(privileges);
+      return Objects.hash(result, privileges);
     }
 
     @Override

--- a/api/src/main/java/com/datastrato/gravitino/authorization/SecurableObjects.java
+++ b/api/src/main/java/com/datastrato/gravitino/authorization/SecurableObjects.java
@@ -161,12 +161,8 @@ public class SecurableObjects {
         return false;
       }
 
-      if (!super.equals(other)) {
-        return false;
-      }
-
       SecurableObject otherSecurableObject = (SecurableObject) other;
-      return Objects.equals(privileges, otherSecurableObject.privileges());
+      return super.equals(other) && Objects.equals(privileges, otherSecurableObject.privileges());
     }
   }
 

--- a/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveTableOperations.java
+++ b/catalogs/catalog-hive/src/main/java/com/datastrato/gravitino/catalog/hive/HiveTableOperations.java
@@ -4,7 +4,7 @@
  */
 package com.datastrato.gravitino.catalog.hive;
 
-import com.datastrato.gravitino.Entity;
+import com.datastrato.gravitino.MetadataObjects;
 import com.datastrato.gravitino.connector.TableOperations;
 import com.datastrato.gravitino.exceptions.NoSuchPartitionException;
 import com.datastrato.gravitino.exceptions.NoSuchTableException;
@@ -133,7 +133,7 @@ public class HiveTableOperations implements TableOperations, SupportsPartitions 
 
   @Override
   public Partition addPartition(Partition partition) throws PartitionAlreadyExistsException {
-    if (Entity.SECURABLE_ENTITY_RESERVED_NAME.equals(partition.name())) {
+    if (MetadataObjects.METADATA_OBJECT_RESERVED_NAME.equals(partition.name())) {
       throw new IllegalArgumentException("Can't create a catalog with with reserved partition `*`");
     }
 

--- a/core/src/main/java/com/datastrato/gravitino/Entity.java
+++ b/core/src/main/java/com/datastrato/gravitino/Entity.java
@@ -23,9 +23,6 @@ public interface Entity extends Serializable {
   /** The system reserved catalog name. */
   String SYSTEM_CATALOG_RESERVED_NAME = "system";
 
-  /** The securable object reserved entity name. */
-  String SECURABLE_ENTITY_RESERVED_NAME = "*";
-
   /** The authorization catalog name in the system metalake. */
   String AUTHORIZATION_CATALOG_NAME = "authorization";
 
@@ -34,11 +31,15 @@ public interface Entity extends Serializable {
 
   /** The group schema name in the system catalog. */
   String GROUP_SCHEMA_NAME = "group";
+
   /** The role schema name in the system catalog. */
   String ROLE_SCHEMA_NAME = "role";
 
   /** The admin schema name in the authorization catalog of the system metalake. */
   String ADMIN_SCHEMA_NAME = "admin";
+
+  /** The tag schema name in the system catalog. */
+  String TAG_SCHEMA_NAME = "tag";
 
   /**
    * All metalakes are a virtual entity. It represents all the metalakes. We don't store it. We use
@@ -65,6 +66,7 @@ public interface Entity extends Serializable {
     USER("us", 7),
     GROUP("gr", 8),
     ROLE("ro", 9),
+    TAG("ta", 10),
 
     AUDIT("au", 65534);
 

--- a/core/src/main/java/com/datastrato/gravitino/GravitinoEnv.java
+++ b/core/src/main/java/com/datastrato/gravitino/GravitinoEnv.java
@@ -40,6 +40,7 @@ import com.datastrato.gravitino.metrics.MetricsSystem;
 import com.datastrato.gravitino.metrics.source.JVMMetricsSource;
 import com.datastrato.gravitino.storage.IdGenerator;
 import com.datastrato.gravitino.storage.RandomIdGenerator;
+import com.datastrato.gravitino.tag.TagManager;
 import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,7 +81,10 @@ public class GravitinoEnv {
   private MetricsSystem metricsSystem;
 
   private LockManager lockManager;
+
   private EventListenerManager eventListenerManager;
+
+  private TagManager tagManager;
 
   private GravitinoEnv() {}
 
@@ -176,6 +180,10 @@ public class GravitinoEnv {
 
     // Tree lock
     this.lockManager = new LockManager(config);
+
+    // Tag manager
+    this.tagManager = new TagManager(idGenerator, entityStore);
+
     LOG.info("Gravitino Environment is initialized.");
   }
 
@@ -285,6 +293,15 @@ public class GravitinoEnv {
    */
   public AccessControlManager accessControlManager() {
     return accessControlManager;
+  }
+
+  /**
+   * Get the TagManager associated with the Gravitino environment.
+   *
+   * @return The TagManager instance.
+   */
+  public TagManager tagManager() {
+    return tagManager;
   }
 
   public void start() {

--- a/core/src/main/java/com/datastrato/gravitino/catalog/CatalogNormalizeDispatcher.java
+++ b/core/src/main/java/com/datastrato/gravitino/catalog/CatalogNormalizeDispatcher.java
@@ -4,11 +4,11 @@
  */
 package com.datastrato.gravitino.catalog;
 
-import static com.datastrato.gravitino.Entity.SECURABLE_ENTITY_RESERVED_NAME;
 import static com.datastrato.gravitino.Entity.SYSTEM_CATALOG_RESERVED_NAME;
 
 import com.datastrato.gravitino.Catalog;
 import com.datastrato.gravitino.CatalogChange;
+import com.datastrato.gravitino.MetadataObjects;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.exceptions.CatalogAlreadyExistsException;
@@ -21,7 +21,7 @@ import java.util.Set;
 
 public class CatalogNormalizeDispatcher implements CatalogDispatcher {
   private static final Set<String> RESERVED_WORDS =
-      ImmutableSet.of(SECURABLE_ENTITY_RESERVED_NAME, SYSTEM_CATALOG_RESERVED_NAME);
+      ImmutableSet.of(MetadataObjects.METADATA_OBJECT_RESERVED_NAME, SYSTEM_CATALOG_RESERVED_NAME);
   /**
    * Regular expression explanation:
    *

--- a/core/src/main/java/com/datastrato/gravitino/connector/capability/Capability.java
+++ b/core/src/main/java/com/datastrato/gravitino/connector/capability/Capability.java
@@ -4,8 +4,7 @@
  */
 package com.datastrato.gravitino.connector.capability;
 
-import static com.datastrato.gravitino.Entity.SECURABLE_ENTITY_RESERVED_NAME;
-
+import com.datastrato.gravitino.MetadataObjects;
 import com.datastrato.gravitino.annotation.Evolving;
 import com.google.common.collect.ImmutableSet;
 import java.util.Set;
@@ -82,7 +81,7 @@ public interface Capability {
   class DefaultCapability implements Capability {
 
     private static final Set<String> RESERVED_WORDS =
-        ImmutableSet.of(SECURABLE_ENTITY_RESERVED_NAME);
+        ImmutableSet.of(MetadataObjects.METADATA_OBJECT_RESERVED_NAME);
 
     /**
      * Regular expression explanation:

--- a/core/src/main/java/com/datastrato/gravitino/meta/TableEntity.java
+++ b/core/src/main/java/com/datastrato/gravitino/meta/TableEntity.java
@@ -105,7 +105,6 @@ public class TableEntity implements Entity, Auditable, HasIdentifier {
       return false;
     }
 
-    // Ignore field namespace
     TableEntity baseTable = (TableEntity) o;
     return Objects.equal(id, baseTable.id)
         && Objects.equal(name, baseTable.name)

--- a/core/src/main/java/com/datastrato/gravitino/meta/TagEntity.java
+++ b/core/src/main/java/com/datastrato/gravitino/meta/TagEntity.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2024 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+
+package com.datastrato.gravitino.meta;
+
+import com.datastrato.gravitino.Audit;
+import com.datastrato.gravitino.Auditable;
+import com.datastrato.gravitino.Entity;
+import com.datastrato.gravitino.Field;
+import com.datastrato.gravitino.HasIdentifier;
+import com.datastrato.gravitino.MetadataObject;
+import com.datastrato.gravitino.Namespace;
+import com.datastrato.gravitino.tag.Tag;
+import com.google.common.collect.Maps;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public class TagEntity implements Tag, Entity, Auditable, HasIdentifier {
+
+  public static final Field ID =
+      Field.required("id", Long.class, "The unique id of the tag entity.");
+
+  public static final Field NAME =
+      Field.required("name", String.class, "The name of the tag entity.");
+
+  public static final Field COMMENT =
+      Field.optional("comment", String.class, "The comment of the tag entity.");
+
+  public static final Field PROPERTIES =
+      Field.optional("properties", Map.class, "The properties of the tag entity.");
+
+  public static final Field ASSOCIATED_OBJECTS =
+      Field.optional(
+          "objects", MetadataObject[].class, "The associated objects of the tag entity.");
+
+  public static final Field AUDIT_INFO =
+      Field.required("audit_info", Audit.class, "The audit details of the tag entity.");
+
+  private Long id;
+  private String name;
+  private Namespace namespace;
+  private String comment;
+  private Map<String, String> properties;
+  private MetadataObject[] objects = null;
+  private Audit auditInfo;
+
+  private TagEntity() {}
+
+  @Override
+  public Map<Field, Object> fields() {
+    Map<Field, Object> fields = Maps.newHashMap();
+    fields.put(ID, id);
+    fields.put(NAME, name);
+    fields.put(COMMENT, comment);
+    fields.put(PROPERTIES, properties);
+    fields.put(AUDIT_INFO, auditInfo);
+    fields.put(ASSOCIATED_OBJECTS, objects);
+
+    return Collections.unmodifiableMap(fields);
+  }
+
+  @Override
+  public EntityType type() {
+    return EntityType.TAG;
+  }
+
+  @Override
+  public Long id() {
+    return id;
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public Namespace namespace() {
+    return namespace;
+  }
+
+  @Override
+  public String comment() {
+    return comment;
+  }
+
+  @Override
+  public Map<String, String> properties() {
+    return properties;
+  }
+
+  @Override
+  public Optional<Boolean> inherited() {
+    return Optional.empty();
+  }
+
+  public MetadataObject[] objects() {
+    return objects;
+  }
+
+  @Override
+  public Audit auditInfo() {
+    return auditInfo;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof TagEntity)) {
+      return false;
+    }
+
+    TagEntity that = (TagEntity) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(namespace, that.namespace)
+        && Objects.equals(comment, that.comment)
+        && Objects.equals(properties, that.properties)
+        && Objects.equals(auditInfo, that.auditInfo);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name, namespace, comment, properties, auditInfo);
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+
+    private final TagEntity tagEntity;
+
+    private Builder() {
+      this.tagEntity = new TagEntity();
+    }
+
+    public Builder withId(Long id) {
+      tagEntity.id = id;
+      return this;
+    }
+
+    public Builder withName(String name) {
+      tagEntity.name = name;
+      return this;
+    }
+
+    public Builder withNamespace(Namespace namespace) {
+      tagEntity.namespace = namespace;
+      return this;
+    }
+
+    public Builder withComment(String comment) {
+      tagEntity.comment = comment;
+      return this;
+    }
+
+    public Builder withProperties(Map<String, String> properties) {
+      tagEntity.properties = properties;
+      return this;
+    }
+
+    public Builder withMetadataObjects(MetadataObject[] objects) {
+      tagEntity.objects = objects;
+      return this;
+    }
+
+    public Builder withAuditInfo(Audit auditInfo) {
+      tagEntity.auditInfo = auditInfo;
+      return this;
+    }
+
+    public TagEntity build() {
+      tagEntity.validate();
+      return tagEntity;
+    }
+  }
+}

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/JDBCBackend.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/JDBCBackend.java
@@ -236,6 +236,7 @@ public class JDBCBackend implements RelationalBackend {
         return RoleMetaService.getInstance()
             .deleteRoleMetasByLegacyTimeline(
                 legacyTimeline, GARBAGE_COLLECTOR_SINGLE_DELETION_LIMIT);
+      case TAG:
       case COLUMN:
       case AUDIT:
         return 0;
@@ -260,6 +261,7 @@ public class JDBCBackend implements RelationalBackend {
       case GROUP:
       case AUDIT:
       case ROLE:
+      case TAG:
         // These entity types have not implemented multi-versions, so we can skip.
         return 0;
 

--- a/core/src/main/java/com/datastrato/gravitino/storage/relational/service/RoleMetaService.java
+++ b/core/src/main/java/com/datastrato/gravitino/storage/relational/service/RoleMetaService.java
@@ -6,6 +6,7 @@ package com.datastrato.gravitino.storage.relational.service;
 
 import com.datastrato.gravitino.Entity;
 import com.datastrato.gravitino.MetadataObject;
+import com.datastrato.gravitino.MetadataObjects;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.authorization.AuthorizationUtils;
 import com.datastrato.gravitino.authorization.SecurableObject;
@@ -92,8 +93,7 @@ public class RoleMetaService {
             POConverters.initializeSecurablePOBuilderWithVersion(
                 roleEntity.id(), object, getEntityType(object));
         objectBuilder.withEntityId(
-            MetadataObjectUtils.getSecurableObjectEntityId(
-                metalakeId, object.fullName(), object.type()));
+            MetadataObjectUtils.getMetadataObjectId(metalakeId, object.fullName(), object.type()));
         securableObjectPOs.add(objectBuilder.build());
       }
 
@@ -139,7 +139,7 @@ public class RoleMetaService {
 
     for (SecurableObjectPO securableObjectPO : securableObjectPOs) {
       String fullName =
-          MetadataObjectUtils.getSecurableObjectFullName(
+          MetadataObjectUtils.getMetadataObjectFullName(
               securableObjectPO.getType(), securableObjectPO.getEntityId());
       if (fullName != null) {
         securableObjects.add(
@@ -230,7 +230,7 @@ public class RoleMetaService {
 
   private String getEntityType(SecurableObject securableObject) {
     if (securableObject.type() == MetadataObject.Type.METALAKE
-        && securableObject.name().equals(Entity.SECURABLE_ENTITY_RESERVED_NAME)) {
+        && securableObject.name().equals(MetadataObjects.METADATA_OBJECT_RESERVED_NAME)) {
       return Entity.ALL_METALAKES_ENTITY_TYPE;
     }
     return securableObject.type().name();

--- a/core/src/main/java/com/datastrato/gravitino/tag/TagManager.java
+++ b/core/src/main/java/com/datastrato/gravitino/tag/TagManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Datastrato Pvt Ltd.
+ * Copyright 2024 Datastrato Pvt Ltd.
  * This software is licensed under the Apache License version 2.
  */
 package com.datastrato.gravitino.tag;

--- a/core/src/main/java/com/datastrato/gravitino/tag/TagManager.java
+++ b/core/src/main/java/com/datastrato/gravitino/tag/TagManager.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 Datastrato Pvt Ltd.
+ * This software is licensed under the Apache License version 2.
+ */
+package com.datastrato.gravitino.tag;
+
+import com.datastrato.gravitino.Entity;
+import com.datastrato.gravitino.EntityStore;
+import com.datastrato.gravitino.MetadataObject;
+import com.datastrato.gravitino.NameIdentifier;
+import com.datastrato.gravitino.Namespace;
+import com.datastrato.gravitino.exceptions.NoSuchMetalakeException;
+import com.datastrato.gravitino.exceptions.NoSuchTagException;
+import com.datastrato.gravitino.exceptions.TagAlreadyExistsException;
+import com.datastrato.gravitino.storage.IdGenerator;
+import java.io.IOException;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TagManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TagManager.class);
+
+  public TagManager(IdGenerator idGenerator, EntityStore entityStore) {}
+
+  public String[] listTags(String metalake) {
+    throw new UnsupportedOperationException("Not implemented yet");
+  }
+
+  public Tag[] listTagsInfo(String metalake, boolean extended) {
+    throw new UnsupportedOperationException("Not implemented yet");
+  }
+
+  public Tag createTag(String metalake, String name, String comment, Map<String, String> properties)
+      throws TagAlreadyExistsException {
+    throw new UnsupportedOperationException("Not implemented yet");
+  }
+
+  public Tag getTag(String metalake, String name) throws NoSuchTagException {
+    throw new UnsupportedOperationException("Not implemented yet");
+  }
+
+  public Tag alterTag(String metalake, String name, TagChange... changes)
+      throws NoSuchTagException, IllegalArgumentException {
+    throw new UnsupportedOperationException("Not implemented yet");
+  }
+
+  public boolean deleteTag(String metalake, String name) {
+    throw new UnsupportedOperationException("Not implemented yet");
+  }
+
+  public String[] listTagsForMetadataObject(String metalake, MetadataObject metadataObject) {
+    throw new UnsupportedOperationException("Not implemented yet");
+  }
+
+  public Tag[] listTagsInfoForMetadataObject(String metalake, MetadataObject metadataObject) {
+    throw new UnsupportedOperationException("Not implemented yet");
+  }
+
+  public Tag getTagForMetadataObject(String metalake, MetadataObject metadataObject, String name)
+      throws NoSuchTagException {
+    throw new UnsupportedOperationException("Not implemented yet");
+  }
+
+  public String[] associateTagsForMetadataObject(
+      String metalake, MetadataObject metadataObject, String[] tagsToAdd, String[] tagsToRemove) {
+    throw new UnsupportedOperationException("Not implemented yet");
+  }
+
+  private static void checkMetalakeExists(String metalake, EntityStore entityStore) {
+    try {
+      NameIdentifier metalakeIdent = NameIdentifier.of(metalake);
+      if (!entityStore.exists(metalakeIdent, Entity.EntityType.METALAKE)) {
+        LOG.warn("Metalake {} does not exist", metalakeIdent);
+        throw new NoSuchMetalakeException("Metalake %s does not exist", metalakeIdent);
+      }
+    } catch (IOException ioe) {
+      LOG.error("Failed to check if metalake exists", ioe);
+      throw new RuntimeException(ioe);
+    }
+  }
+
+  private static Namespace ofTagNamespace(String metalake) {
+    return Namespace.of(metalake, Entity.SYSTEM_CATALOG_RESERVED_NAME, Entity.TAG_SCHEMA_NAME);
+  }
+}

--- a/core/src/test/java/com/datastrato/gravitino/catalog/TestCatalogNormalizeDispatcher.java
+++ b/core/src/test/java/com/datastrato/gravitino/catalog/TestCatalogNormalizeDispatcher.java
@@ -5,12 +5,12 @@
 package com.datastrato.gravitino.catalog;
 
 import static com.datastrato.gravitino.Catalog.Type.RELATIONAL;
-import static com.datastrato.gravitino.Entity.SECURABLE_ENTITY_RESERVED_NAME;
 
 import com.datastrato.gravitino.Catalog;
 import com.datastrato.gravitino.Config;
 import com.datastrato.gravitino.Configs;
 import com.datastrato.gravitino.EntityStore;
+import com.datastrato.gravitino.MetadataObjects;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.meta.AuditInfo;
 import com.datastrato.gravitino.meta.BaseMetalake;
@@ -92,7 +92,8 @@ public class TestCatalogNormalizeDispatcher {
     }
 
     // Test for illegal and reserved names
-    NameIdentifier catalogIdent1 = NameIdentifier.of(metalake, SECURABLE_ENTITY_RESERVED_NAME);
+    NameIdentifier catalogIdent1 =
+        NameIdentifier.of(metalake, MetadataObjects.METADATA_OBJECT_RESERVED_NAME);
     Exception exception =
         Assertions.assertThrows(
             IllegalArgumentException.class,

--- a/core/src/test/java/com/datastrato/gravitino/catalog/TestFilesetNormalizeDispatcher.java
+++ b/core/src/test/java/com/datastrato/gravitino/catalog/TestFilesetNormalizeDispatcher.java
@@ -4,8 +4,7 @@
  */
 package com.datastrato.gravitino.catalog;
 
-import static com.datastrato.gravitino.Entity.SECURABLE_ENTITY_RESERVED_NAME;
-
+import com.datastrato.gravitino.MetadataObjects;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.exceptions.FilesetAlreadyExistsException;
@@ -83,7 +82,8 @@ public class TestFilesetNormalizeDispatcher extends TestOperationDispatcher {
     Map<String, String> props = ImmutableMap.of("k1", "v1", "k2", "v2");
     schemaNormalizeDispatcher.createSchema(NameIdentifier.of(filesetNs.levels()), "comment", props);
 
-    NameIdentifier filesetIdent = NameIdentifier.of(filesetNs, SECURABLE_ENTITY_RESERVED_NAME);
+    NameIdentifier filesetIdent =
+        NameIdentifier.of(filesetNs, MetadataObjects.METADATA_OBJECT_RESERVED_NAME);
     Exception exception =
         Assertions.assertThrows(
             IllegalArgumentException.class,

--- a/core/src/test/java/com/datastrato/gravitino/catalog/TestSchemaNormalizeDispatcher.java
+++ b/core/src/test/java/com/datastrato/gravitino/catalog/TestSchemaNormalizeDispatcher.java
@@ -4,8 +4,7 @@
  */
 package com.datastrato.gravitino.catalog;
 
-import static com.datastrato.gravitino.Entity.SECURABLE_ENTITY_RESERVED_NAME;
-
+import com.datastrato.gravitino.MetadataObjects;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.Schema;
@@ -61,7 +60,7 @@ public class TestSchemaNormalizeDispatcher extends TestOperationDispatcher {
   @Test
   public void testNameSpec() {
     NameIdentifier schemaIdent1 =
-        NameIdentifier.of(metalake, catalog, SECURABLE_ENTITY_RESERVED_NAME);
+        NameIdentifier.of(metalake, catalog, MetadataObjects.METADATA_OBJECT_RESERVED_NAME);
     Exception exception =
         Assertions.assertThrows(
             IllegalArgumentException.class,

--- a/core/src/test/java/com/datastrato/gravitino/catalog/TestTableNormalizeDispatcher.java
+++ b/core/src/test/java/com/datastrato/gravitino/catalog/TestTableNormalizeDispatcher.java
@@ -4,8 +4,7 @@
  */
 package com.datastrato.gravitino.catalog;
 
-import static com.datastrato.gravitino.Entity.SECURABLE_ENTITY_RESERVED_NAME;
-
+import com.datastrato.gravitino.MetadataObjects;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.TestColumn;
@@ -122,7 +121,8 @@ public class TestTableNormalizeDispatcher extends TestOperationDispatcher {
     Map<String, String> props = ImmutableMap.of("k1", "v1", "k2", "v2");
     schemaNormalizeDispatcher.createSchema(NameIdentifier.of(tableNs.levels()), "comment", props);
 
-    NameIdentifier tableIdent1 = NameIdentifier.of(tableNs, SECURABLE_ENTITY_RESERVED_NAME);
+    NameIdentifier tableIdent1 =
+        NameIdentifier.of(tableNs, MetadataObjects.METADATA_OBJECT_RESERVED_NAME);
     Column[] columns =
         new Column[] {
           TestColumn.builder().withName("colNAME1").withType(Types.StringType.get()).build(),
@@ -147,7 +147,7 @@ public class TestTableNormalizeDispatcher extends TestOperationDispatcher {
     Column[] columns1 =
         new Column[] {
           TestColumn.builder()
-              .withName(SECURABLE_ENTITY_RESERVED_NAME)
+              .withName(MetadataObjects.METADATA_OBJECT_RESERVED_NAME)
               .withType(Types.StringType.get())
               .build()
         };

--- a/core/src/test/java/com/datastrato/gravitino/catalog/TestTopicNormalizeDispatcher.java
+++ b/core/src/test/java/com/datastrato/gravitino/catalog/TestTopicNormalizeDispatcher.java
@@ -4,8 +4,7 @@
  */
 package com.datastrato.gravitino.catalog;
 
-import static com.datastrato.gravitino.Entity.SECURABLE_ENTITY_RESERVED_NAME;
-
+import com.datastrato.gravitino.MetadataObjects;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.Namespace;
 import com.datastrato.gravitino.messaging.Topic;
@@ -69,7 +68,8 @@ public class TestTopicNormalizeDispatcher extends TestOperationDispatcher {
     Map<String, String> props = ImmutableMap.of("k1", "v1", "k2", "v2");
     schemaNormalizeDispatcher.createSchema(NameIdentifier.of(topicNs.levels()), "comment", props);
 
-    NameIdentifier topicIdent = NameIdentifier.of(topicNs, SECURABLE_ENTITY_RESERVED_NAME);
+    NameIdentifier topicIdent =
+        NameIdentifier.of(topicNs, MetadataObjects.METADATA_OBJECT_RESERVED_NAME);
     Exception exception =
         Assertions.assertThrows(
             IllegalArgumentException.class,

--- a/core/src/test/java/com/datastrato/gravitino/connector/capability/TestCapability.java
+++ b/core/src/test/java/com/datastrato/gravitino/connector/capability/TestCapability.java
@@ -4,8 +4,7 @@
  */
 package com.datastrato.gravitino.connector.capability;
 
-import static com.datastrato.gravitino.Entity.SECURABLE_ENTITY_RESERVED_NAME;
-
+import com.datastrato.gravitino.MetadataObjects;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -25,7 +24,9 @@ public class TestCapability {
       Assertions.assertTrue(result.supported());
 
       // test for reserved name
-      result = Capability.DEFAULT.specificationOnName(scope, SECURABLE_ENTITY_RESERVED_NAME);
+      result =
+          Capability.DEFAULT.specificationOnName(
+              scope, MetadataObjects.METADATA_OBJECT_RESERVED_NAME);
       Assertions.assertFalse(result.supported());
       Assertions.assertTrue(result.unsupportedMessage().contains("is reserved"));
 

--- a/core/src/test/java/com/datastrato/gravitino/meta/TestEntity.java
+++ b/core/src/test/java/com/datastrato/gravitino/meta/TestEntity.java
@@ -6,6 +6,8 @@ package com.datastrato.gravitino.meta;
 
 import com.datastrato.gravitino.Catalog;
 import com.datastrato.gravitino.Field;
+import com.datastrato.gravitino.MetadataObject;
+import com.datastrato.gravitino.MetadataObjects;
 import com.datastrato.gravitino.authorization.Privileges;
 import com.datastrato.gravitino.authorization.SecurableObjects;
 import com.datastrato.gravitino.file.Fileset;
@@ -295,5 +297,47 @@ public class TestEntity {
                         catalogName, Lists.newArrayList(Privileges.UseCatalog.allow()))))
             .build();
     Assertions.assertNull(roleWithoutFields.properties());
+  }
+
+  @Test
+  public void testTag() {
+    Map<String, String> prop = ImmutableMap.of("k1", "v1", "k2", "v2");
+
+    TagEntity tag1 =
+        TagEntity.builder()
+            .withId(1L)
+            .withName("tag1")
+            .withComment("comment")
+            .withProperties(prop)
+            .withAuditInfo(auditInfo)
+            .build();
+    Assertions.assertEquals(1L, tag1.id());
+    Assertions.assertEquals("tag1", tag1.name());
+    Assertions.assertEquals("comment", tag1.comment());
+    Assertions.assertEquals(prop, tag1.properties());
+    Assertions.assertEquals(auditInfo, tag1.auditInfo());
+
+    TagEntity tag2 =
+        TagEntity.builder().withId(1L).withName("tag2").withAuditInfo(auditInfo).build();
+    Assertions.assertNull(tag2.comment());
+    Assertions.assertNull(tag2.properties());
+
+    MetadataObject[] metadataObjects =
+        new MetadataObject[] {
+          MetadataObjects.parse("test1", MetadataObject.Type.METALAKE),
+          MetadataObjects.parse("test2", MetadataObject.Type.CATALOG),
+          MetadataObjects.parse("a.b", MetadataObject.Type.SCHEMA),
+          MetadataObjects.parse("a.b.c", MetadataObject.Type.TABLE),
+          MetadataObjects.parse("a.b.c.d", MetadataObject.Type.COLUMN)
+        };
+
+    TagEntity tag3 =
+        TagEntity.builder()
+            .withId(1L)
+            .withName("tag3")
+            .withAuditInfo(auditInfo)
+            .withMetadataObjects(metadataObjects)
+            .build();
+    Assertions.assertEquals(metadataObjects, tag3.objects());
   }
 }

--- a/server/src/main/java/com/datastrato/gravitino/server/web/rest/RoleOperations.java
+++ b/server/src/main/java/com/datastrato/gravitino/server/web/rest/RoleOperations.java
@@ -6,9 +6,9 @@ package com.datastrato.gravitino.server.web.rest;
 
 import com.codahale.metrics.annotation.ResponseMetered;
 import com.codahale.metrics.annotation.Timed;
-import com.datastrato.gravitino.Entity;
 import com.datastrato.gravitino.GravitinoEnv;
 import com.datastrato.gravitino.MetadataObject;
+import com.datastrato.gravitino.MetadataObjects;
 import com.datastrato.gravitino.NameIdentifier;
 import com.datastrato.gravitino.authorization.AccessControlManager;
 import com.datastrato.gravitino.authorization.Privilege;
@@ -149,7 +149,7 @@ public class RoleOperations {
     // Securable object ignores the metalake namespace, so we should add it back.
     if (object.type() == MetadataObject.Type.METALAKE) {
       // All metalakes don't need to check the securable object whether exists.
-      if (object.name().equals(Entity.SECURABLE_ENTITY_RESERVED_NAME)) {
+      if (object.name().equals(MetadataObjects.METADATA_OBJECT_RESERVED_NAME)) {
         return;
       }
       identifier = NameIdentifier.parse(object.fullName());


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add a basic `TagManager` framework. The current framework is not ready to work since it misses the core logic. 

### Why are the changes needed?

This subtask adds a basic tag framework without actual logic. The reason of adding this is to control the PR size to avoid a big PR, since there're many changes in RDBMS support. If we want to make it complete, the PR will be very big.

Fix: #3895 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The current PR is not ready to work, so tests will be added later on.
