### PR TITLE
[#3936] ci(web): update sleep millis of web ci

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/AbstractWebIT.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/AbstractWebIT.java
@@ -34,8 +34,8 @@ public class AbstractWebIT extends AbstractIT {
   // https://www.selenium.dev/documentation/webdriver/waits/#implicit-waits
   protected static final long MAX_IMPLICIT_WAIT = 30;
   protected static final long MAX_TIMEOUT = 20;
-  protected static final long EACH_TEST_SLEEP_MILLIS = 1_000;
-  protected static final long ACTION_SLEEP_MILLIS = 1_000;
+  protected static final long EACH_TEST_SLEEP_MILLIS = 2_000;
+  protected static final long ACTION_SLEEP_MILLIS = 2_000;
 
   protected boolean waitShowText(final String text, final Object locator) {
     try {


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?
update sleep millis of web ci

### Why are the changes needed?
api data inconsistencies with test cast by the instability response

Fix: #3936

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
manual test