### PR TITLE
[#3935] test: fix test_rm_file() in test_gvfs_with_local.py on MacOS

### DIFF
--- a/clients/client-python/tests/unittests/test_gvfs_with_local.py
+++ b/clients/client-python/tests/unittests/test_gvfs_with_local.py
@@ -362,7 +362,7 @@ class TestLocalFilesystem(unittest.TestCase):
         # test delete dir
         dir_virtual_path = fileset_virtual_location + "/sub_dir"
         self.assertTrue(fs.exists(dir_virtual_path))
-        with self.assertRaises(IsADirectoryError):
+        with self.assertRaises((IsADirectoryError, PermissionError)):
             fs.rm_file(dir_virtual_path)
 
     @patch(


### PR DESCRIPTION
<!--
1. Title: [#<issue>] <type>(<scope>): <subject>
   Examples:
     - "[#123] feat(operator): support xxx"
     - "[#233] fix: check null before access result in xxx"
     - "[MINOR] refactor: fix typo in variable name"
     - "[MINOR] docs: fix typo in README"
     - "[#255] test: fix flaky test NameOfTheTest"
   Reference: https://www.conventionalcommits.org/en/v1.0.0/
2. If the PR is unfinished, please mark this PR as draft.
-->

### What changes were proposed in this pull request?

* Add `PermissionError` to assert in function `test_rm_file()`

### Why are the changes needed?

Fix: #3935 

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

`./gradlew clients:client-python:unittest` on MacOS