### PR TITLE
[#3944] fix(pyClient): Python client loss depends library in the requirements-dev

### DIFF
--- a/clients/client-python/requirements-dev.txt
+++ b/clients/client-python/requirements-dev.txt
@@ -10,3 +10,5 @@ pandas==2.0.3
 pyarrow==15.0.2
 llama-index==0.10.40
 tenacity==8.3.0
+cachetools==5.3.3
+readerwriterlock==1.0.9

--- a/clients/client-python/requirements.txt
+++ b/clients/client-python/requirements.txt
@@ -2,9 +2,9 @@
 # This software is licensed under the Apache License version 2.
 
 # the tools to publish the python client to Pypi
-requests
-dataclasses-json
+requests==2.32.2
+dataclasses-json==0.6.6
 readerwriterlock==1.0.9
 fsspec==2024.3.1
-pyarrow
+pyarrow==15.0.2
 cachetools==5.3.3


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add lose Python depends on library into `requirements-dev.txt`
```
cachetools==5.3.3
readerwriterlock==1.0.9
```

### Why are the changes needed?

Fix: #3944

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

CI Passed.
