### PR TITLE
[#3952] fix(client-python): fix version.ini not found issue when installing the package

### DIFF
--- a/clients/client-python/.gitignore
+++ b/clients/client-python/.gitignore
@@ -12,7 +12,7 @@ venv
 dist
 build
 README.md
-version.ini
+gravitino/version.ini
 docs
 
 # Unit test / coverage reports

--- a/clients/client-python/MANIFEST.in
+++ b/clients/client-python/MANIFEST.in
@@ -4,4 +4,4 @@
 include requirements.txt
 include requirements-dev.txt
 include README.md
-include version.ini
+include gravitino/version.ini

--- a/clients/client-python/build.gradle.kts
+++ b/clients/client-python/build.gradle.kts
@@ -243,7 +243,7 @@ tasks {
     delete("build")
     delete("dist")
     delete("docs")
-    delete("version.ini")
+    delete("gravitino/version.ini")
     delete("gravitino.egg-info")
     delete("tests/unittests/htmlcov")
     delete("tests/unittests/.coverage")

--- a/clients/client-python/gravitino/constants/root.py
+++ b/clients/client-python/gravitino/constants/root.py
@@ -7,4 +7,4 @@ from pathlib import Path
 
 MODULE_NAME = "gravitino"
 PROJECT_HOME = Path(__file__).parent.parent.parent
-GRAVITNO_DIR = PROJECT_HOME / MODULE_NAME
+GRAVITINO_DIR = PROJECT_HOME / MODULE_NAME

--- a/clients/client-python/gravitino/constants/version.py
+++ b/clients/client-python/gravitino/constants/version.py
@@ -6,8 +6,9 @@ This software is licensed under the Apache License version 2.
 from enum import Enum
 
 from gravitino.constants.root import PROJECT_HOME
+from gravitino.constants.root import MODULE_NAME
 
-VERSION_INI = PROJECT_HOME / "version.ini"
+VERSION_INI = PROJECT_HOME / MODULE_NAME / "version.ini"
 SETUP_FILE = PROJECT_HOME / "setup.py"
 
 

--- a/clients/client-python/scripts/generate_doc.py
+++ b/clients/client-python/scripts/generate_doc.py
@@ -8,7 +8,7 @@ import os
 import shutil
 
 from gravitino.constants.doc import DOC_DIR
-from gravitino.constants.root import GRAVITNO_DIR, MODULE_NAME
+from gravitino.constants.root import GRAVITINO_DIR, MODULE_NAME
 
 if __name__ == "__main__":
 
@@ -25,4 +25,4 @@ if __name__ == "__main__":
     pydoc.writedoc(MODULE_NAME)
 
     # Write doc for submodules
-    pydoc.writedocs(GRAVITNO_DIR.as_posix(), MODULE_NAME + ".")
+    pydoc.writedocs(GRAVITINO_DIR.as_posix(), MODULE_NAME + ".")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the issue of version.ini not found issue when installing python gravitino package using pip and run.

### Why are the changes needed?

Previously, the `version.ini` file is under the project path, which will not be included after installing the package using pip, so now module to `graviitino` folder.

Fix: #3952

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Exisiting tests.
