### PR TITLE
[MINOR] fix(common): Override `toString` method of `topicDTO`

### DIFF
--- a/common/src/main/java/com/datastrato/gravitino/dto/messaging/TopicDTO.java
+++ b/common/src/main/java/com/datastrato/gravitino/dto/messaging/TopicDTO.java
@@ -90,6 +90,22 @@ public class TopicDTO implements Topic {
     return Objects.hash(name, comment, properties, audit);
   }
 
+  @Override
+  public String toString() {
+    return "TopicDTO{"
+        + "name='"
+        + name
+        + '\''
+        + ", comment='"
+        + comment
+        + '\''
+        + ", properties="
+        + properties
+        + ", audit="
+        + audit
+        + '}';
+  }
+
   /** A builder for constructing a Topic DTO. */
   public static class Builder {
     private String name;


### PR DESCRIPTION
### What changes were proposed in this pull request?

Override `toString` method of `topicDTO`

### Why are the changes needed?

In order to locate the inconsistent properties when an assert fails.

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

tests passed
