### PR TITLE
[Minor] Frontend integration test failed in headless environment

### DIFF
--- a/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/ChromeWebDriverProvider.java
+++ b/integration-test/src/test/java/com/datastrato/gravitino/integration/test/web/ui/utils/ChromeWebDriverProvider.java
@@ -91,6 +91,7 @@ public class ChromeWebDriverProvider implements WebDriverProvider {
     // Display the web interface during testing
     if (Strings.isEmpty(System.getenv("DISPLAY_WEBPAGE_IN_TESTING"))) {
       chromeOptions.addArguments("--headless");
+      chromeOptions.addArguments("--no-sandbox");
     }
 
     if (SystemUtils.IS_OS_MAC_OSX) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Frontend integration test failed in certain headless environment, like the ec2 in aws.

### Why are the changes needed?

 Frontend integration test failed due to the following error:
```
 MetalakePageTest > initializationError FAILED
    org.openqa.selenium.WebDriverException: unknown error: Chrome failed to start: exited abnormally.
      (chrome not reachable)
      (The process started from chrome location /actions-runner/_work/gravitino-test/gravitino-test/gravitino/integration-test/build/chrome/chrome-linux/chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
    Build info: version: '3.141.59', revision: 'e82be7d358', time: '2018-11-14T08:17:03'
    System info: host: 'ip-172-31-5-251', ip: '172.31.5.251', os.name: 'Linux', os.arch: 'amd64', os.version: '6.5.0-1020-aws', java.version: '1.8.0_412'
    Driver info: driver.version: ChromeDriver
    remote stacktrace: #0 0x561b8bc79869 <unknown>
    #1 0x561b8bc14383 <unknown>
    #2 0x561b8b9f6ca3 <unknown>
    #3 0x561b8ba1a286 <unknown>
    #4 0x561b8ba157cd <unknown>
    #5 0x561b8ba4f11d <unknown>
    #6 0x561b8ba49963 <unknown>
    #7 0x561b8ba1fe36 <unknown>
    #8 0x561b8ba20fd5 <unknown>
    #9 0x561b8bc41f90 <unknown>
    #10 0x561b8bc53d80 <unknown>
```

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

<img width="1492" alt="image" src="https://github.com/datastrato/gravitino/assets/154112360/3e16870e-ad51-4677-aec5-8e8be0c68f9b">